### PR TITLE
console: add TUI app, simple top-style view

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -13,3 +13,5 @@ tokio = { version = "1", features = ["full", "rt-multi-thread"]}
 futures = "0.3"
 tui = { version = "0.15.0", features = ["crossterm"] }
 chrono = "0.4"
+tracing = "0.1"
+prost-types = "0.7"

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "console"
 version = "0.1.0"
-authors = ["Eliza Weisman <eliza@buoyant.io>"]
+authors = ["Eliza Weisman <eliza@buoyant.io>", "David Barsky <me@davidbarsky.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tonic = { version = "0.4", features = ["transport"] }
+console-api = { path = "../console-api", features = ["transport"]}
+tokio = { version = "1", features = ["full", "rt-multi-thread"]}
+futures = "0.3"
+tui = { version = "0.15.0", features = ["crossterm"] }
+chrono = "0.4"

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -1,3 +1,78 @@
-fn main() {
-    println!("Hello, world!");
+use chrono::Local;
+use console_api::tasks::{tasks_client::TasksClient, TasksRequest};
+use futures::stream::StreamExt;
+use std::io;
+use tokio::select;
+
+use tui::{
+    backend::TermionBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Span, Spans},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+    Terminal,
+};
+
+use tui::backend::CrosstermBackend;
+use tui::style::*;
+use tui::text::*;
+use tui::widgets::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args();
+    args.next(); // drop the first arg (the name of the binary)
+    let target = args.next().unwrap_or_else(|| {
+        eprintln!("using default address (http://127.0.0.1:6669)");
+        String::from("http://127.0.0.1:6669")
+    });
+
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+
+    let mut client = TasksClient::connect(target).await?;
+    let request = tonic::Request::new(TasksRequest {});
+    let mut stream = client.watch_tasks(request).await?.into_inner();
+
+    while let Some(update) = stream.next().await {
+        match update {
+            Ok(update) => {
+                eprintln!("UPDATE {:?}", update);
+            }
+            Err(e) => {
+                eprintln!("update stream error: {}", e);
+                return Err(e.into());
+            }
+        }
+    }
+
+    loop {
+        terminal.draw(|f| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .margin(0)
+                .constraints([Constraint::Length(10), Constraint::Percentage(95)].as_ref())
+                .split(f.size());
+
+            let header_block = Block::default()
+                .title(vec![Span::styled(
+                    "desolation",
+                    Style::default().add_modifier(Modifier::BOLD),
+                )])
+                .borders(Borders::ALL);
+
+            let text = vec![Spans::from(vec![
+                Span::styled("controls: ", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw("up/down = scroll, q = quit"),
+            ])];
+            let header = Paragraph::new(text)
+                .block(header_block)
+                .wrap(Wrap { trim: true });
+
+            f.render_widget(header, chunks[0]);
+        })?;
+    }
+
+    Ok(())
 }

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -1,0 +1,153 @@
+use console_api as proto;
+use std::collections::HashMap;
+use std::time::Duration;
+use tui::{
+    layout,
+    style::{self, Style},
+    widgets::{Block, Cell, Row, Table, TableState},
+};
+
+#[derive(Default, Debug)]
+pub(crate) struct State {
+    tasks: HashMap<u64, Task>,
+    table_state: TableState,
+}
+
+#[derive(Default, Debug)]
+struct Task {
+    id_hex: String,
+    fields: String,
+    kind: &'static str,
+    stats: Stats,
+}
+
+#[derive(Default, Debug)]
+struct Stats {
+    polls: u64,
+    busy: Duration,
+    idle: Duration,
+    total: Duration,
+}
+impl State {
+    pub(crate) fn len(&self) -> usize {
+        self.tasks.len()
+    }
+    pub(crate) fn update(&mut self, update: proto::tasks::TaskUpdate) {
+        let new_tasks = update.new_tasks.into_iter().filter_map(|task| {
+            if task.id.is_none() {
+                tracing::warn!(?task, "skipping task with no id");
+            }
+            let kind = match task.kind() {
+                proto::tasks::task::Kind::Spawn => "T",
+                proto::tasks::task::Kind::Blocking => "B",
+            };
+
+            let id = task.id?.id;
+            let task = Task {
+                id_hex: format!("{:x}", id),
+                fields: task.string_fields,
+                kind,
+                stats: Default::default(),
+            };
+            Some((id, task))
+        });
+        self.tasks.extend(new_tasks);
+
+        for (id, stats) in update.stats_update {
+            if let Some(task) = self.tasks.get_mut(&id) {
+                task.stats = stats.into();
+            }
+        }
+
+        for proto::SpanId { id } in update.completed {
+            if self.tasks.remove(&id).is_none() {
+                tracing::warn!(?id, "tried to complete a task that didn't exist");
+            }
+        }
+    }
+
+    pub(crate) fn render<B: tui::backend::Backend>(
+        &mut self,
+        frame: &mut tui::terminal::Frame<B>,
+        area: layout::Rect,
+    ) {
+        const HEADER: &[&str] = &["TID", "KIND", "TOTAL", "BUSY", "IDLE", "POLLS", "FIELDS"];
+        const DUR_LEN: usize = 10;
+        // This data is only updated every second, so it doesn't make a ton of
+        // sense to have a lot of precision in timestamps (and this makes sure
+        // there's room for the unit!)
+        const DUR_PRECISION: usize = 4;
+        const POLLS_LEN: usize = 5;
+        let rows = self.tasks.values().map(|task| {
+            let row = Row::new(vec![
+                Cell::from(task.id_hex.as_str()),
+                // TODO(eliza): is there a way to write a `fmt::Debug` impl
+                // directly to tui without doing an allocation?
+                Cell::from(task.kind),
+                Cell::from(format!(
+                    "{:>width$.prec$?}",
+                    task.stats.total,
+                    width = DUR_LEN,
+                    prec = DUR_PRECISION,
+                )),
+                Cell::from(format!(
+                    "{:>width$.prec$?}",
+                    task.stats.busy,
+                    width = DUR_LEN,
+                    prec = DUR_PRECISION,
+                )),
+                Cell::from(format!(
+                    "{:>width$.prec$?}",
+                    task.stats.idle,
+                    width = DUR_LEN,
+                    prec = DUR_PRECISION,
+                )),
+                Cell::from(format!("{:>width$}", task.stats.polls, width = POLLS_LEN)),
+                Cell::from(task.fields.as_str()),
+            ]);
+            row
+        });
+        let t = Table::new(rows)
+            .header(
+                Row::new(HEADER.iter().map(|&v| Cell::from(v)))
+                    .height(1)
+                    .style(Style::default().add_modifier(style::Modifier::REVERSED)),
+            )
+            .block(Block::default())
+            .widths(&[
+                layout::Constraint::Min(20),
+                layout::Constraint::Length(4),
+                layout::Constraint::Min(DUR_LEN as u16),
+                layout::Constraint::Min(DUR_LEN as u16),
+                layout::Constraint::Min(DUR_LEN as u16),
+                layout::Constraint::Min(POLLS_LEN as u16),
+                layout::Constraint::Min(10),
+            ]);
+
+        frame.render_widget(t, area)
+    }
+}
+
+impl From<proto::tasks::Stats> for Stats {
+    fn from(pb: proto::tasks::Stats) -> Self {
+        fn pb_duration(dur: prost_types::Duration) -> Duration {
+            use std::convert::TryFrom;
+
+            let secs =
+                u64::try_from(dur.seconds).expect("a task should not have a negative duration!");
+            let nanos =
+                u64::try_from(dur.nanos).expect("a task should not have a negative duration!");
+            Duration::from_secs(secs) + Duration::from_nanos(nanos)
+        }
+
+        let total = pb.total_time.map(pb_duration).unwrap_or_default();
+        let busy = pb.busy_time.map(pb_duration).unwrap_or_default();
+        let idle = total - busy;
+        Self {
+            total,
+            idle,
+            busy,
+            polls: pb.polls,
+        }
+    }
+}


### PR DESCRIPTION
This branch adds an initial `tui` app skeleton for the `console` CLI,
including a fairly basic `top(1)`-inspired task list view. There's a lot
more work to do here, but it works pretty nicely for a quick first pass.

Co-authored-by: David Barsky <me@davidbarsky.com>

![Screenshot_20210504_110732](https://user-images.githubusercontent.com/2796466/117050047-c3e68300-acc9-11eb-85ee-4aba2827d002.png)
