### PR TITLE
console: add interactive sorting

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -15,3 +15,5 @@ tui = { version = "0.15.0", features = ["crossterm"] }
 chrono = "0.4"
 tracing = "0.1"
 prost-types = "0.7"
+crossterm = { version = "0.19", features = ["event-stream"] }
+color-eyre = "0.5"

--- a/console/src/input.rs
+++ b/console/src/input.rs
@@ -1,0 +1,23 @@
+// TODO(eliza): support TUI backends other than crossterm?
+// This would probably involve using `spawn_blocking` to drive their blocking
+// input-handling mechanisms in the background...
+pub use crossterm::event::*;
+
+pub fn should_quit(input: &Event) -> bool {
+    use Event::*;
+    use KeyCode::*;
+    match input {
+        Key(KeyEvent {
+            code: Char('q'), ..
+        }) => true,
+        Key(KeyEvent {
+            code: Char('c'),
+            modifiers,
+        })
+        | Key(KeyEvent {
+            code: Char('d'),
+            modifiers,
+        }) if modifiers.contains(KeyModifiers::CONTROL) => true,
+        _ => false,
+    }
+}

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -64,6 +64,10 @@ impl State {
     }
 
     pub(crate) fn update_input(&mut self, event: input::Event) {
+        // Clippy likes to remind us that we could use an `if let` here, since
+        // the match only has one arm...but this is a `match` because I
+        // anticipate adding more cases later...
+        #[allow(clippy::single_match)]
         match event {
             input::Event::Key(event) => self.key_input(event),
             _ => {

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -82,13 +82,13 @@ impl State {
         match code {
             Left => {
                 if self.selected_column == 0 {
-                    self.selected_column = Self::HEADER.len();
+                    self.selected_column = Self::HEADER.len() - 1;
                 } else {
                     self.selected_column -= 1;
                 }
             }
             Right => {
-                if self.selected_column == Self::HEADER.len() {
+                if self.selected_column == Self::HEADER.len() - 1 {
                     self.selected_column = 0;
                 } else {
                     self.selected_column += 1;

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -1,20 +1,41 @@
+use crate::input;
 use console_api as proto;
-use std::collections::HashMap;
-use std::time::Duration;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    convert::TryFrom,
+    rc::{Rc, Weak},
+    time::{Duration, SystemTime},
+};
 use tui::{
     layout,
     style::{self, Style},
+    text,
     widgets::{Block, Cell, Row, Table, TableState},
 };
-
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub(crate) struct State {
-    tasks: HashMap<u64, Task>,
+    tasks: HashMap<u64, Rc<RefCell<Task>>>,
+    sorted_tasks: Vec<Weak<RefCell<Task>>>,
+    sort_by: SortBy,
     table_state: TableState,
+    selected_column: usize,
+    sort_descending: bool,
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
+#[repr(usize)]
+enum SortBy {
+    Tid = 0,
+    Total = 2,
+    Busy = 3,
+    Idle = 4,
+    Polls = 5,
+}
+
+#[derive(Debug)]
 struct Task {
+    id: u64,
     id_hex: String,
     fields: String,
     kind: &'static str,
@@ -22,9 +43,10 @@ struct Task {
     completed_for: usize,
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 struct Stats {
     polls: u64,
+    created_at: SystemTime,
     busy: Duration,
     idle: Duration,
     total: Duration,
@@ -34,11 +56,51 @@ impl State {
     // How many updates to retain completed tasks for
     const RETAIN_COMPLETED_FOR: usize = 6;
 
+    const HEADER: &'static [&'static str] =
+        &["TID", "KIND", "TOTAL", "BUSY", "IDLE", "POLLS", "FIELDS"];
+
     pub(crate) fn len(&self) -> usize {
         self.tasks.len()
     }
 
-    pub(crate) fn update(&mut self, update: proto::tasks::TaskUpdate) {
+    pub(crate) fn update_input(&mut self, event: input::Event) {
+        match event {
+            input::Event::Key(event) => self.key_input(event),
+            _ => {
+                // do nothing for now
+                // TODO(eliza): mouse input would be cool...
+            }
+        }
+    }
+
+    fn key_input(&mut self, input::KeyEvent { code, .. }: input::KeyEvent) {
+        use input::KeyCode::*;
+        match code {
+            Left => {
+                if self.selected_column == 0 {
+                    self.selected_column = Self::HEADER.len();
+                } else {
+                    self.selected_column -= 1;
+                }
+            }
+            Right => {
+                if self.selected_column == Self::HEADER.len() {
+                    self.selected_column = 0;
+                } else {
+                    self.selected_column += 1;
+                }
+            }
+            Char('i') => self.sort_descending = !self.sort_descending,
+            _ => {} // do nothing for now...
+        }
+        if let Ok(sort_by) = SortBy::try_from(self.selected_column) {
+            self.sort_by = sort_by;
+        }
+    }
+
+    pub(crate) fn update_tasks(&mut self, update: proto::tasks::TaskUpdate) {
+        let mut stats_update = update.stats_update;
+        let sorted = &mut self.sorted_tasks;
         let new_tasks = update.new_tasks.into_iter().filter_map(|task| {
             if task.id.is_none() {
                 tracing::warn!(?task, "skipping task with no id");
@@ -49,25 +111,30 @@ impl State {
             };
 
             let id = task.id?.id;
+            let stats = stats_update.remove(&id)?.into();
             let task = Task {
+                id,
                 id_hex: format!("{:x}", id),
                 fields: task.string_fields,
                 kind,
-                stats: Default::default(),
+                stats,
                 completed_for: 0,
             };
+            let task = Rc::new(RefCell::new(task));
+            sorted.push(Rc::downgrade(&task));
             Some((id, task))
         });
         self.tasks.extend(new_tasks);
 
-        for (id, stats) in update.stats_update {
+        for (id, stats) in stats_update {
             if let Some(task) = self.tasks.get_mut(&id) {
-                task.stats = stats.into();
+                task.borrow_mut().stats = stats.into();
             }
         }
 
         for proto::SpanId { id } in update.completed {
             if let Some(task) = self.tasks.get_mut(&id) {
+                let mut task = task.borrow_mut();
                 task.kind = "!";
                 task.completed_for = 1;
             } else {
@@ -81,16 +148,19 @@ impl State {
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
     ) {
-        const HEADER: &[&str] = &["TID", "KIND", "TOTAL", "BUSY", "IDLE", "POLLS", "FIELDS"];
         const DUR_LEN: usize = 10;
         // This data is only updated every second, so it doesn't make a ton of
         // sense to have a lot of precision in timestamps (and this makes sure
         // there's room for the unit!)
         const DUR_PRECISION: usize = 4;
         const POLLS_LEN: usize = 5;
-        let rows = self.tasks.values().map(|task| {
+        self.sort_by.sort(&mut self.sorted_tasks);
+
+        let rows = self.sorted_tasks.iter().filter_map(|task| {
+            let task = task.upgrade()?;
+            let task = task.borrow();
             let mut row = Row::new(vec![
-                Cell::from(task.id_hex.as_str()),
+                Cell::from(task.id_hex.to_string()),
                 // TODO(eliza): is there a way to write a `fmt::Debug` impl
                 // directly to tui without doing an allocation?
                 Cell::from(task.kind),
@@ -113,35 +183,55 @@ impl State {
                     prec = DUR_PRECISION,
                 )),
                 Cell::from(format!("{:>width$}", task.stats.polls, width = POLLS_LEN)),
-                Cell::from(task.fields.as_str()),
+                Cell::from(task.fields.to_string()),
             ]);
             if task.completed_for > 0 {
                 row = row.style(Style::default().add_modifier(style::Modifier::DIM));
             }
-            row
+            Some(row)
         });
-        let t = Table::new(rows)
-            .header(
-                Row::new(HEADER.iter().map(|&v| Cell::from(v)))
-                    .height(1)
-                    .style(Style::default().add_modifier(style::Modifier::REVERSED)),
-            )
-            .block(Block::default())
-            .widths(&[
-                layout::Constraint::Min(20),
-                layout::Constraint::Length(4),
-                layout::Constraint::Min(DUR_LEN as u16),
-                layout::Constraint::Min(DUR_LEN as u16),
-                layout::Constraint::Min(DUR_LEN as u16),
-                layout::Constraint::Min(POLLS_LEN as u16),
-                layout::Constraint::Min(10),
-            ]);
 
-        frame.render_widget(t, area)
+        let block = Block::default().title(vec![
+            text::Span::styled(
+                "controls: ",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
+            text::Span::raw("\u{2190}/\u{2192} = select column (sort), i = invert sort (highest/lowest), q = quit"),
+        ]);
+
+        let header = Row::new(Self::HEADER.iter().enumerate().map(|(idx, &value)| {
+            let cell = Cell::from(value);
+            if idx == self.selected_column {
+                cell.style(Style::default().remove_modifier(style::Modifier::REVERSED))
+            } else {
+                cell
+            }
+        }))
+        .height(1)
+        .style(Style::default().add_modifier(style::Modifier::REVERSED));
+
+        let t = if self.sort_descending {
+            Table::new(rows)
+        } else {
+            Table::new(rows.rev())
+        };
+        let t = t.header(header).block(block).widths(&[
+            layout::Constraint::Min(20),
+            layout::Constraint::Length(4),
+            layout::Constraint::Min(DUR_LEN as u16),
+            layout::Constraint::Min(DUR_LEN as u16),
+            layout::Constraint::Min(DUR_LEN as u16),
+            layout::Constraint::Min(POLLS_LEN as u16),
+            layout::Constraint::Min(10),
+        ]);
+
+        frame.render_widget(t, area);
+        self.sorted_tasks.retain(|t| t.upgrade().is_some());
     }
 
     pub(crate) fn retain_active(&mut self) {
         self.tasks.retain(|_, task| {
+            let mut task = task.borrow_mut();
             if task.completed_for == 0 {
                 return true;
             }
@@ -151,11 +241,22 @@ impl State {
     }
 }
 
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            tasks: Default::default(),
+            sorted_tasks: Default::default(),
+            sort_by: Default::default(),
+            selected_column: SortBy::default() as usize,
+            table_state: Default::default(),
+            sort_descending: false,
+        }
+    }
+}
+
 impl From<proto::tasks::Stats> for Stats {
     fn from(pb: proto::tasks::Stats) -> Self {
         fn pb_duration(dur: prost_types::Duration) -> Duration {
-            use std::convert::TryFrom;
-
             let secs =
                 u64::try_from(dur.seconds).expect("a task should not have a negative duration!");
             let nanos =
@@ -171,6 +272,48 @@ impl From<proto::tasks::Stats> for Stats {
             idle,
             busy,
             polls: pb.polls,
+            created_at: pb.created_at.expect("task span was never created").into(),
+        }
+    }
+}
+
+impl Default for SortBy {
+    fn default() -> Self {
+        Self::Total
+    }
+}
+
+impl SortBy {
+    fn sort(&self, tasks: &mut Vec<Weak<RefCell<Task>>>) {
+        // tasks.retain(|t| t.upgrade().is_some());
+        match self {
+            Self::Tid => tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().id)),
+            Self::Total => {
+                tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().stats.total))
+            }
+            Self::Idle => {
+                tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().stats.idle))
+            }
+            Self::Busy => {
+                tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().stats.busy))
+            }
+            Self::Polls => {
+                tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().stats.polls))
+            }
+        }
+    }
+}
+
+impl TryFrom<usize> for SortBy {
+    type Error = ();
+    fn try_from(idx: usize) -> Result<Self, Self::Error> {
+        match idx {
+            idx if idx == Self::Tid as usize => Ok(Self::Tid),
+            idx if idx == Self::Total as usize => Ok(Self::Total),
+            idx if idx == Self::Busy as usize => Ok(Self::Busy),
+            idx if idx == Self::Idle as usize => Ok(Self::Idle),
+            idx if idx == Self::Polls as usize => Ok(Self::Polls),
+            _ => Err(()),
         }
     }
 }

--- a/console/src/term.rs
+++ b/console/src/term.rs
@@ -1,0 +1,47 @@
+pub use color_eyre::eyre::WrapErr;
+use std::io;
+pub use tui::{backend::CrosstermBackend, Terminal};
+
+pub fn init_crossterm() -> color_eyre::Result<(Terminal<CrosstermBackend<io::Stdout>>, OnShutdown)>
+{
+    use crossterm::{
+        event::{DisableMouseCapture, EnableMouseCapture},
+        terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
+    };
+    terminal::enable_raw_mode().wrap_err("Failed to enable crossterm raw mode")?;
+
+    let mut stdout = std::io::stdout();
+    crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture)
+        .wrap_err("Failed to enable crossterm alternate screen and mouse capture")?;
+    let backend = CrosstermBackend::new(io::stdout());
+    let term = Terminal::new(backend).wrap_err("Failed to create crossterm terminal")?;
+
+    let cleanup = OnShutdown::new(|| {
+        // Be a good terminal citizen...
+        let mut stdout = std::io::stdout();
+        crossterm::execute!(stdout, LeaveAlternateScreen, DisableMouseCapture)
+            .wrap_err("Failed to disable crossterm alternate screen and mouse capture")?;
+        terminal::disable_raw_mode().wrap_err("Failed to enable crossterm raw mode")?;
+        Ok(())
+    });
+
+    Ok((term, cleanup))
+}
+
+pub struct OnShutdown {
+    action: fn() -> color_eyre::Result<()>,
+}
+
+impl OnShutdown {
+    fn new(action: fn() -> color_eyre::Result<()>) -> Self {
+        Self { action }
+    }
+}
+
+impl Drop for OnShutdown {
+    fn drop(&mut self) {
+        if let Err(error) = (self.action)() {
+            tracing::error!(%error, "error running terminal cleanup");
+        }
+    }
+}


### PR DESCRIPTION
this branch adds support for sorting tasks in the top tasks view. tasks can
be sorted by their task ID, total runtime, busy time, idle time, and
number of polls, and the sorted column can be selected using the left
and right arrow keys (similar to `top(1)`). the sort direction
(ascending/descending) can be inverted using the `i` key.

in order to add sorting, it was necessary to add rudimentary plumbing
for interactivity by setting up `crossterm`'s input-handling utilities
and handling keypress events. we can add mouse support later.

here's a quick demo of sorting tasks:

[![asciicast](https://asciinema.org/a/X0xi6hzpEPVUaVVVgP26xdATG.svg)][1]

[1]: https://asciinema.org/a/X0xi6hzpEPVUaVVVgP26xdATG

closes: #4 