### PR TITLE
fix(console): disable tui's default features

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -11,7 +11,7 @@ tonic = { version = "0.4", features = ["transport"] }
 console-api = { path = "../console-api", features = ["transport"]}
 tokio = { version = "1", features = ["full", "rt-multi-thread"]}
 futures = "0.3"
-tui = { version = "0.15.0", features = ["crossterm"] }
+tui = { version = "0.15.0", default-features = false, features = ["crossterm"] }
 chrono = "0.4"
 tracing = "0.1"
 prost-types = "0.7"


### PR DESCRIPTION
otherwise, `cargo check` fails on windows with errors like the following:
```
error[E0433]: failed to resolve: maybe a missing crate `sys`?
  --> termion-1.5.6\src\lib.rs:27:9
   |
24 | pub use sys::size::terminal_size;
   |         ^^^ maybe a missing crate `sys`?
