### PR TITLE
fix(subscriber): fix busy loop in aggregator task

### DIFF
--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -15,6 +15,7 @@ console-api = { path = "../console-api", features = ["transport"]}
 tracing-core = "0.1.18"
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.2.17", default-features = false, features = ["fmt", "registry"] }
+futures = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 


### PR DESCRIPTION
currently, there's an issue where the `console-subscriber` background
aggregator task busy-loops, using 100% CPU time. this is because it's
currently awaiting a `recv` call on the events channel on every
iteration of the aggregate loop...and events are generated when a task
is exited. this includes the aggregator task! so, when the aggregator
task has finished a poll, the subscriber sends an exit message...which
wakes the aggregator task back up.

this branch fixes the issue by changing the aggregator task to *not*
include new messages on the events channel in the `select!` that will
wake up the aggregator. instead, it allows messages to be buffered, and
drains all events in the channel whenever it's woken by something else.
to avoid losing events due to a full buffer, i've also added a "high
water line" where the `TasksLayer` will notify the aggregator task after
a send, *if* the channel is approaching its maximum capacity (with some
wiggle room). now, the aggregator is woken in the following cases:

* the data flush interval has elapsed
* a new client has subscribed
* the event buffer is nearing capacity

and the buffer is drained before going back to sleep in all these cases.
this should avoid the busy loop and prevent the aggregator from
monopolizing CPU time.

we can probably also shrink the event buffer a bit now that we're always
woken when nearing capacity...

confirming that this does fix the busy loop, here's CPU usage in 
the example app:

on `main`:

![Screenshot_20210506_105249](https://user-images.githubusercontent.com/2796466/117344210-0048e900-ae5a-11eb-926d-f236ec24179f.png)

...and on this branch:

![Screenshot_20210506_105353](https://user-images.githubusercontent.com/2796466/117344280-0fc83200-ae5a-11eb-910a-c352c1a3227b.png)

note the "CPU%" column :) :) :)
