### PR TITLE
chore: add macOS and windows to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,12 @@ jobs:
           command: check
 
   test:
-    name: Tests
-    runs-on: ubuntu-latest
+    name: Tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
follow-up for https://github.com/tokio-rs/console/pull/16#pullrequestreview-653701605

this adds macOS and windows to the tests job on CI to ensure that everything builds on more platforms. `fail-fast` is disabled for the tests job matrix to help understand when platform specific failures occur.