### PR TITLE
Require tokio >= 1.5 on console-subscriber

### DIFF
--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 
-tokio = { version = "1", features = ["sync", "time", "macros", "tracing"]}
+tokio = { version = "^1.5", features = ["sync", "time", "macros", "tracing"]}
 tokio-stream = "0.1"
 tonic = { version = "0.4", features = ["transport"] }
 console-api = { path = "../console-api", features = ["transport"]}
@@ -19,7 +19,7 @@ futures = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 
-tokio = { version = "1", features = ["full", "rt-multi-thread"]}
+tokio = { version = "^1.5", features = ["full", "rt-multi-thread"]}
 futures = "0.3"
 
 tracing-subscriber = { version = "0.2.17", features = ["fmt", "registry", "env-filter"] }


### PR DESCRIPTION
This crate only compiles with Tokio >= 1.5, as it requires the capacity
function on `mpsc::Sender` here:

https://github.com/tokio-rs/console/blob/84c9928a7ec62bfa8b953a8fc029f33306d6cb69/console-subscriber/src/lib.rs#L154

This function was added on Tokio 1.5, according to the changelog:

https://github.com/tokio-rs/tokio/releases/tag/tokio-1.5.0