### PR TITLE
Setup Task Details view

### DIFF
--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -301,7 +301,7 @@ impl State {
                 let selected = if self.sort_descending {
                     i
                 } else {
-                    self.sorted_tasks.len() - i
+                    self.sorted_tasks.len() - i - 1
                 };
                 self.sorted_tasks[selected].clone()
             })
@@ -325,6 +325,10 @@ impl Default for State {
 impl Task {
     pub(crate) fn id_hex(&self) -> &str {
         &self.id_hex
+    }
+
+    pub(crate) fn fields(&self) -> &str {
+        &self.fields
     }
 
     pub(crate) fn total(&self) -> Duration {

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -34,7 +34,7 @@ enum SortBy {
 }
 
 #[derive(Debug)]
-struct Task {
+pub(crate) struct Task {
     id: u64,
     id_hex: String,
     fields: String,
@@ -209,6 +209,11 @@ impl State {
                 Style::default().add_modifier(style::Modifier::BOLD),
             ),
             text::Span::raw(" = scroll, "),
+            text::Span::styled(
+                "enter",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
+            text::Span::raw(" = task details, "),
             text::Span::styled("i", Style::default().add_modifier(style::Modifier::BOLD)),
             text::Span::raw(" = invert sort (highest/lowest), "),
             text::Span::styled("q", Style::default().add_modifier(style::Modifier::BOLD)),
@@ -288,6 +293,20 @@ impl State {
         };
         self.table_state.select(Some(i));
     }
+
+    pub(crate) fn selected_task(&self) -> Weak<RefCell<Task>> {
+        self.table_state
+            .selected()
+            .map(|i| {
+                let selected = if self.sort_descending {
+                    i
+                } else {
+                    self.sorted_tasks.len() - i
+                };
+                self.sorted_tasks[selected].clone()
+            })
+            .unwrap_or_default()
+    }
 }
 
 impl Default for State {
@@ -300,6 +319,24 @@ impl Default for State {
             table_state: Default::default(),
             sort_descending: false,
         }
+    }
+}
+
+impl Task {
+    pub(crate) fn id_hex(&self) -> &str {
+        &self.id_hex
+    }
+
+    pub(crate) fn total(&self) -> Duration {
+        self.stats.total
+    }
+
+    pub(crate) fn busy(&self) -> Duration {
+        self.stats.busy
+    }
+
+    pub(crate) fn idle(&self) -> Duration {
+        self.stats.idle
     }
 }
 

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -1,0 +1,61 @@
+use crate::input;
+use tui::layout;
+
+mod task;
+
+pub(crate) enum View {
+    /// The table list of all tasks.
+    TasksList,
+    /// Inspecting a single task instance.
+    TaskInstance(self::task::TaskView),
+}
+
+impl View {
+    pub(crate) fn update_input(&mut self, event: input::Event, tasks: &mut crate::tasks::State) {
+        match self {
+            View::TasksList => {
+                // The enter key changes views, so handle here since we can
+                // mutate the currently selected view.
+                match event {
+                    input::Event::Key(input::KeyEvent {
+                        code: input::KeyCode::Enter,
+                        ..
+                    }) => {
+                        if let Some(task) = tasks.selected_task().upgrade() {
+                            *self = View::TaskInstance(self::task::TaskView::new(task));
+                        }
+                    }
+                    _ => {
+                        // otherwise pass on to view
+                        tasks.update_input(event);
+                    }
+                }
+            }
+            View::TaskInstance(view) => view.update_input(event),
+        }
+    }
+
+    pub(crate) fn render<B: tui::backend::Backend>(
+        &mut self,
+        frame: &mut tui::terminal::Frame<B>,
+        area: layout::Rect,
+        tasks: &mut crate::tasks::State,
+    ) {
+        match self {
+            View::TasksList => {
+                tasks.render(frame, area);
+                tasks.retain_active();
+            }
+            View::TaskInstance(view) => {
+                view.render(frame, area);
+                // retain_active()? should that always be done?
+            }
+        }
+    }
+}
+
+impl Default for View {
+    fn default() -> Self {
+        View::TasksList
+    }
+}

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -2,6 +2,7 @@ use crate::{input, tasks::Task};
 use std::{cell::RefCell, rc::Rc};
 use tui::{
     layout,
+    style::{self, Style},
     text::{Span, Spans},
     widgets::{Block, Borders, Paragraph},
 };
@@ -33,16 +34,34 @@ impl TaskView {
         let task = &*self.task.borrow();
         const DUR_PRECISION: usize = 4;
 
-        let attrs = Spans::from(vec![Span::raw("ID: "), Span::raw(task.id_hex())]);
+        let attrs = Spans::from(vec![
+            Span::styled("ID: ", Style::default().add_modifier(style::Modifier::BOLD)),
+            Span::raw(task.id_hex()),
+            Span::raw(", "),
+            Span::styled(
+                "Fields: ",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
+            Span::raw(task.fields()),
+        ]);
 
         let metrics = Spans::from(vec![
-            Span::raw("Total Time: "),
+            Span::styled(
+                "Total Time: ",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
             Span::from(format!("{:.prec$?}", task.total(), prec = DUR_PRECISION,)),
             Span::raw(", "),
-            Span::raw("Busy: "),
+            Span::styled(
+                "Busy: ",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
             Span::from(format!("{:.prec$?}", task.busy(), prec = DUR_PRECISION,)),
             Span::raw(", "),
-            Span::raw("Idle: "),
+            Span::styled(
+                "Idle: ",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
             Span::from(format!("{:.prec$?}", task.idle(), prec = DUR_PRECISION,)),
         ]);
 

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -1,0 +1,54 @@
+use crate::{input, tasks::Task};
+use std::{cell::RefCell, rc::Rc};
+use tui::{
+    layout,
+    text::{Span, Spans},
+    widgets::{Block, Borders, Paragraph},
+};
+
+pub(crate) struct TaskView {
+    task: Rc<RefCell<Task>>,
+}
+
+impl TaskView {
+    pub(super) fn new(task: Rc<RefCell<Task>>) -> Self {
+        TaskView { task }
+    }
+
+    pub(crate) fn update_input(&mut self, _event: input::Event) {
+        // TODO :D
+    }
+
+    pub(crate) fn render<B: tui::backend::Backend>(
+        &mut self,
+        frame: &mut tui::terminal::Frame<B>,
+        area: layout::Rect,
+    ) {
+        // Rows with the following info:
+        // - Task main attributes
+        // - task metadata
+        // - metrics
+        // - logs?
+
+        let task = &*self.task.borrow();
+        const DUR_PRECISION: usize = 4;
+
+        let attrs = Spans::from(vec![Span::raw("ID: "), Span::raw(task.id_hex())]);
+
+        let metrics = Spans::from(vec![
+            Span::raw("Total Time: "),
+            Span::from(format!("{:.prec$?}", task.total(), prec = DUR_PRECISION,)),
+            Span::raw(", "),
+            Span::raw("Busy: "),
+            Span::from(format!("{:.prec$?}", task.busy(), prec = DUR_PRECISION,)),
+            Span::raw(", "),
+            Span::raw("Idle: "),
+            Span::from(format!("{:.prec$?}", task.idle(), prec = DUR_PRECISION,)),
+        ]);
+
+        let lines = vec![attrs, metrics];
+        let block = Block::default().borders(Borders::ALL).title("Task");
+        let paragraph = Paragraph::new(lines).block(block);
+        frame.render_widget(paragraph, area);
+    }
+}

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -1,0 +1,1 @@
+// TODO: move view-like stuff from tasks::State into here


### PR DESCRIPTION
This starts adding the concept of there being multiple possible "views" of the console. To add a second view, this includes a basic "task details" view. If you hit "enter" when scrolling through the task list, it will go to the details view. It's pretty bare-bones for now, just showing the same info you would see in the task list view, but with a different layout. The point of opening this now is to simply start the process of having multiple views.

Some things we _could_ show are listed in [this doc](https://hackmd.io/a4P75rj0RP6qettxAVzv8w?view#Task-instance). I'm thinking about another PR soon that would include a list of logs (tracing events) scoped to the task to show on the details page, so you can see the logs of just a single task easily.