### PR TITLE
fix: update uncompleted tasks total time every update

### DIFF
--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -113,7 +113,6 @@ impl State {
         if let Some(now) = update.now {
             self.last_updated_at = Some(now.into());
         }
-        
         let mut stats_update = update.stats_update;
         let sorted = &mut self.sorted_tasks;
         let new_tasks = update.new_tasks.into_iter().filter_map(|task| {

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -113,6 +113,7 @@ impl State {
         if let Some(now) = update.now {
             self.last_updated_at = Some(now.into());
         }
+        
         let mut stats_update = update.stats_update;
         let sorted = &mut self.sorted_tasks;
         let new_tasks = update.new_tasks.into_iter().filter_map(|task| {

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -64,7 +64,10 @@ impl View {
                 tasks.render(frame, area);
             }
             View::TaskInstance(view) => {
-                view.render(frame, area);
+                let now = tasks
+                    .last_updated_at()
+                    .expect("task view implies we've received an update");
+                view.render(frame, area, now);
             }
         }
 

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -1,5 +1,5 @@
 use crate::{input, tasks::Task};
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, time::SystemTime};
 use tui::{
     layout,
     style::{self, Style},
@@ -24,6 +24,7 @@ impl TaskView {
         &mut self,
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
+        now: SystemTime,
     ) {
         // Rows with the following info:
         // - Task main attributes
@@ -50,7 +51,7 @@ impl TaskView {
                 "Total Time: ",
                 Style::default().add_modifier(style::Modifier::BOLD),
             ),
-            Span::from(format!("{:.prec$?}", task.total(), prec = DUR_PRECISION,)),
+            Span::from(format!("{:.prec$?}", task.total(now), prec = DUR_PRECISION,)),
             Span::raw(", "),
             Span::styled(
                 "Busy: ",
@@ -62,7 +63,7 @@ impl TaskView {
                 "Idle: ",
                 Style::default().add_modifier(style::Modifier::BOLD),
             ),
-            Span::from(format!("{:.prec$?}", task.idle(), prec = DUR_PRECISION,)),
+            Span::from(format!("{:.prec$?}", task.idle(now), prec = DUR_PRECISION,)),
         ]);
 
         let lines = vec![attrs, metrics];


### PR DESCRIPTION
The "total" time of a task was sent from the subscriber to the console
each time there was any _other_ change for the task. However, tasks that
didn't have changes wouldn't send updates, and so their total time would
lag behind. This fixes it so all tasks in the console have an up-to-date
total time, by:

- The `total` time is now only sent in a `Task` proto when the task is
  completed.
- The subscriber's "current" time is sent in every `TaskUpdate`.
- The console uses that time to calculate "total" time if
  the task isn't completed yet.