### PR TITLE
fix: detect completed tasks even if console connects after

### DIFF
--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -148,16 +148,6 @@ impl State {
                 t.updated();
             }
         }
-
-        for proto::SpanId { id } in update.completed {
-            if let Some(task) = self.tasks.get_mut(&id) {
-                let mut task = task.borrow_mut();
-                task.kind = "!";
-                task.completed_for = 1;
-            } else {
-                tracing::warn!(?id, "tried to complete a task that didn't exist");
-            }
-        }
     }
 
     pub(crate) fn render<B: tui::backend::Backend>(

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -134,7 +134,7 @@ impl State {
                 stats,
                 completed_for: 0,
             };
-            task.updated();
+            task.update();
             let task = Rc::new(RefCell::new(task));
             sorted.push(Rc::downgrade(&task));
             Some((id, task))
@@ -145,7 +145,7 @@ impl State {
             if let Some(task) = self.tasks.get_mut(&id) {
                 let mut t = task.borrow_mut();
                 t.stats = stats.into();
-                t.updated();
+                t.update();
             }
         }
     }
@@ -356,7 +356,7 @@ impl Task {
             .unwrap_or_else(|| self.total(since) - self.busy())
     }
 
-    fn updated(&mut self) {
+    fn update(&mut self) {
         let completed = self.stats.total.is_some() && self.completed_for == 0;
         if completed {
             self.kind = "!";

--- a/proto/tasks.proto
+++ b/proto/tasks.proto
@@ -37,22 +37,11 @@ message TaskUpdate {
     // *is* included in this map, the corresponding value represents a complete
     // snapshot of that task's stats at in the current time window.
     map<uint64, Stats> stats_update = 3;
-    // The IDs of any tasks which have *completed* since the last update.
-    //
-    // If a task's ID is present in this list, that task has terminated. The
-    // client is free to delete any data it has stored for that task if it is no
-    // longer relevant. Task IDs *may* be reused when new tasks are spawned; if
-    // a new task is spawned for the same ID, it will appear in the `new_tasks`
-    // list in a future `TaskUpdate`.
-    //
-    // When a task ID is present in this list, the `stats_update` field of this
-    // `TaskUpdate` will contain the final statistics recorded for that task.
-    repeated common.SpanId completed = 4;
     // The system time when this update was recorded.
     //
     // This is the timestamp any durations in the included `Stats` were
     // calculated relative to.
-    google.protobuf.Timestamp now = 5;
+    google.protobuf.Timestamp now = 4;
 }
 
 // Data recorded when a new task is spawned.


### PR DESCRIPTION
The "completion" of a task would result in that being sent to all watchers in a task update. However, after a flush, that status wasn't stored in a way that new watchers could detect. This changes it so that a task is determined "completed" when it includes a "total" duration, instead of being in a separate part of the `TasksUpdate` proto message.