### PR TITLE
api: populate field names

### DIFF
--- a/console-api/src/common.rs
+++ b/console-api/src/common.rs
@@ -39,13 +39,15 @@ impl<'a> From<&'a tracing_core::Metadata<'a>> for Metadata {
             column: None, // tracing doesn't support columns yet
         };
 
+        let field_names = meta.fields().iter().map(|f| f.name().to_string()).collect();
+
         Metadata {
             name: meta.name().to_string(),
             target: meta.target().to_string(),
             location: Some(location),
             kind: kind as i32,
             level: metadata::Level::from(*meta.level()) as i32,
-            field_names: Vec::new(),
+            field_names,
             ..Default::default()
         }
     }


### PR DESCRIPTION
In #26 `field_names` field was introduced in the Metadata
message but was never populated. This PR populates it
with the names of the fields

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>