### PR TITLE
console: bold field names

### DIFF
--- a/console-api/src/common.rs
+++ b/console-api/src/common.rs
@@ -64,6 +64,31 @@ impl<'a> From<&'a std::panic::Location<'a>> for Location {
     }
 }
 
+impl fmt::Display for field::Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            field::Value::BoolVal(v) => fmt::Display::fmt(v, f)?,
+            field::Value::StrVal(v) => fmt::Display::fmt(v, f)?,
+            field::Value::U64Val(v) => fmt::Display::fmt(v, f)?,
+            field::Value::DebugVal(v) => fmt::Display::fmt(v, f)?,
+            field::Value::I64Val(v) => fmt::Display::fmt(v, f)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for Field {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name_val = (self.name.as_ref(), self.value.as_ref());
+        if let (Some(field::Name::StrName(name)), Some(val)) = name_val {
+            write!(f, "{}={}", name, val)?;
+        }
+
+        Ok(())
+    }
+}
+
 impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (self.module_path.as_ref(), self.file.as_ref()) {

--- a/console-api/src/common.rs
+++ b/console-api/src/common.rs
@@ -62,31 +62,6 @@ impl<'a> From<&'a std::panic::Location<'a>> for Location {
     }
 }
 
-impl fmt::Display for field::Value {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            field::Value::BoolVal(v) => fmt::Display::fmt(v, f)?,
-            field::Value::StrVal(v) => fmt::Display::fmt(v, f)?,
-            field::Value::U64Val(v) => fmt::Display::fmt(v, f)?,
-            field::Value::DebugVal(v) => fmt::Display::fmt(v, f)?,
-            field::Value::I64Val(v) => fmt::Display::fmt(v, f)?,
-        }
-
-        Ok(())
-    }
-}
-
-impl fmt::Display for Field {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name_val = (self.name.as_ref(), self.value.as_ref());
-        if let (Some(field::Name::StrName(name)), Some(val)) = name_val {
-            write!(f, "{}={}", name, val)?;
-        }
-
-        Ok(())
-    }
-}
-
 impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (self.module_path.as_ref(), self.file.as_ref()) {

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -140,10 +140,10 @@ impl State {
         }
 
         if let Some(new_metadata) = update.new_metadata {
-            let metas = new_metadata.metadata.into_iter().map(|meta| {
-                let id = meta.id.expect("no id").id;
-                let metadata = meta.metadata.expect("no metadata");
-                (id, metadata.into())
+            let metas = new_metadata.metadata.into_iter().filter_map(|meta| {
+                let id = meta.id?.id;
+                let metadata = meta.metadata?;
+                Some((id, metadata.into()))
             });
             self.metas.extend(metas);
         }
@@ -164,11 +164,11 @@ impl State {
                 .fields
                 .drain(..)
                 .filter_map(|f| {
-                    let field_name = f.name.as_ref().expect("no name");
+                    let field_name = f.name.as_ref()?;
                     let name: Option<Arc<str>> = match field_name {
                         proto::field::Name::StrName(n) => Some(n.clone().into()),
                         proto::field::Name::NameIdx(idx) => {
-                            let meta_id = f.metadata_id.as_ref().expect("no id");
+                            let meta_id = f.metadata_id.as_ref()?;
                             metas
                                 .get(&meta_id.id)
                                 .and_then(|meta| meta.field_names.get(*idx as usize))

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -1,5 +1,5 @@
 use crate::{input, tasks::Task};
-use std::{cell::RefCell, fmt::Write, rc::Rc, time::SystemTime};
+use std::{cell::RefCell, rc::Rc, time::SystemTime};
 use tui::{
     layout,
     style::{self, Style},
@@ -35,17 +35,7 @@ impl TaskView {
         let task = &*self.task.borrow();
         const DUR_PRECISION: usize = 4;
 
-        let fields: String = task
-            .fields()
-            .iter()
-            .fold(String::new(), |mut res, f| {
-                write!(&mut res, "{}={} ", f.name, f.value).unwrap();
-                res
-            })
-            .trim_end()
-            .into();
-
-        let attrs = Spans::from(vec![
+        let mut attrs = vec![
             Span::styled("ID: ", Style::default().add_modifier(style::Modifier::BOLD)),
             Span::raw(task.id_hex()),
             Span::raw(", "),
@@ -53,8 +43,10 @@ impl TaskView {
                 "Fields: ",
                 Style::default().add_modifier(style::Modifier::BOLD),
             ),
-            Span::raw(fields),
-        ]);
+        ];
+
+        attrs.extend(task.formatted_fields().clone());
+        let atributes = Spans::from(attrs);
 
         let metrics = Spans::from(vec![
             Span::styled(
@@ -76,7 +68,7 @@ impl TaskView {
             Span::from(format!("{:.prec$?}", task.idle(now), prec = DUR_PRECISION,)),
         ]);
 
-        let lines = vec![attrs, metrics];
+        let lines = vec![atributes, metrics];
         let block = Block::default().borders(Borders::ALL).title("Task");
         let paragraph = Paragraph::new(lines).block(block);
         frame.render_widget(paragraph, area);

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -1,5 +1,5 @@
 use crate::{input, tasks::Task};
-use std::{cell::RefCell, rc::Rc, time::SystemTime};
+use std::{cell::RefCell, fmt::Write, rc::Rc, time::SystemTime};
 use tui::{
     layout,
     style::{self, Style},
@@ -35,6 +35,16 @@ impl TaskView {
         let task = &*self.task.borrow();
         const DUR_PRECISION: usize = 4;
 
+        let fields: String = task
+            .fields()
+            .iter()
+            .fold(String::new(), |mut res, f| {
+                write!(&mut res, "{}={} ", f.name, f.value).unwrap();
+                res
+            })
+            .trim_end()
+            .into();
+
         let attrs = Spans::from(vec![
             Span::styled("ID: ", Style::default().add_modifier(style::Modifier::BOLD)),
             Span::raw(task.id_hex()),
@@ -43,7 +53,7 @@ impl TaskView {
                 "Fields: ",
                 Style::default().add_modifier(style::Modifier::BOLD),
             ),
-            Span::raw(task.fields()),
+            Span::raw(fields),
         ]);
 
         let metrics = Spans::from(vec![


### PR DESCRIPTION
This PR delays the formatting of the fields and instead
stores them on the `Task` struct. This allows for nicer formatting
options. Currently we just bold the field names in the task tables view.

fix #33

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>