### PR TITLE
feat(console): add waker stats to task view

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,12 @@ members = [
     "console-api"
 ]
 resolver = "2"
+
+# Patch the dependency on tokio to get waker instrumentation while developing.
+# This can be un-patched when the following commits are released:
+# - https://github.com/tokio-rs/tokio/commit/e7d74b3119178b9b86f7b547774b6b121de2239a
+# - https://github.com/tokio-rs/tokio/commit/f55b77aaddaed8e48a8c0d81c66da82f12433087
+[patch.crates-io.tokio]
+git = "https://github.com/tokio-rs/tokio"
+rev = "f55b77aaddaed8e48a8c0d81c66da82f12433087"
+features = ["full", "rt-multi-thread"]

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -1,5 +1,10 @@
 use crate::input;
-use tui::layout;
+use std::borrow::Cow;
+use tui::{
+    layout,
+    style::{self, Style},
+    text::Span,
+};
 
 mod task;
 
@@ -79,4 +84,8 @@ impl Default for View {
     fn default() -> Self {
         View::TasksList
     }
+}
+
+pub(crate) fn bold<'a>(text: impl Into<Cow<'a, str>>) -> Span<'a> {
+    Span::styled(text, Style::default().add_modifier(style::Modifier::BOLD))
 }

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -1,8 +1,7 @@
-use crate::{input, tasks::Task};
+use crate::{input, tasks::Task, view::bold};
 use std::{cell::RefCell, rc::Rc, time::SystemTime};
 use tui::{
     layout::{self, Layout},
-    style::{self, Style},
     text::{Span, Spans, Text},
     widgets::{Block, Borders, Paragraph},
 };
@@ -59,61 +58,36 @@ impl TaskView {
 
         let fields_area = chunks[1];
 
-        let attrs = Spans::from(vec![
-            Span::styled("ID: ", Style::default().add_modifier(style::Modifier::BOLD)),
-            Span::raw(task.id_hex()),
-        ]);
+        let attrs = Spans::from(vec![bold("ID: "), Span::raw(task.id_hex())]);
 
         let metrics = Spans::from(vec![
-            Span::styled(
-                "Total Time: ",
-                Style::default().add_modifier(style::Modifier::BOLD),
-            ),
+            bold("Total Time: "),
             Span::from(format!("{:.prec$?}", task.total(now), prec = DUR_PRECISION,)),
             Span::raw(", "),
-            Span::styled(
-                "Busy: ",
-                Style::default().add_modifier(style::Modifier::BOLD),
-            ),
+            bold("Busy: "),
             Span::from(format!("{:.prec$?}", task.busy(), prec = DUR_PRECISION,)),
             Span::raw(", "),
-            Span::styled(
-                "Idle: ",
-                Style::default().add_modifier(style::Modifier::BOLD),
-            ),
+            bold("Idle: "),
             Span::from(format!("{:.prec$?}", task.idle(now), prec = DUR_PRECISION,)),
         ]);
 
         let wakers = Spans::from(vec![
-            Span::styled(
-                "Current wakers: ",
-                Style::default().add_modifier(style::Modifier::BOLD),
-            ),
+            bold("Current wakers: "),
             Span::from(format!("{} (", task.waker_count())),
-            Span::styled(
-                "clones: ",
-                Style::default().add_modifier(style::Modifier::BOLD),
-            ),
+            bold("clones: "),
             Span::from(format!("{}, ", task.waker_clones())),
-            Span::styled(
-                "drops: ",
-                Style::default().add_modifier(style::Modifier::BOLD),
-            ),
-            Span::from(format!("{})", task.waker_drops())),
+            bold("drops: "),
         ]);
 
         let mut wakeups = vec![
-            Span::styled(
-                "Woken: ",
-                Style::default().add_modifier(style::Modifier::BOLD),
-            ),
+            bold("Woken: "),
             Span::from(format!("{} times", task.wakes())),
         ];
 
         // If the task has been woken, add the time since wake to its stats as well.
         if let Some(since) = task.since_wake(now) {
             wakeups.push(Span::raw(", "));
-            wakeups.push(Span::styled("last woken:", bold()));
+            wakeups.push(bold("last woken:"));
             wakeups.push(Span::from(format!(" {:?} ago", since)));
         }
 
@@ -121,10 +95,6 @@ impl TaskView {
 
         fn block_for(title: &str) -> Block {
             Block::default().borders(Borders::ALL).title(title)
-        }
-
-        fn bold() -> Style {
-            Style::default().add_modifier(style::Modifier::BOLD)
         }
 
         let mut fields = Text::default();

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -1,9 +1,9 @@
 use crate::{input, tasks::Task};
 use std::{cell::RefCell, rc::Rc, time::SystemTime};
 use tui::{
-    layout,
+    layout::{self, Layout},
     style::{self, Style},
-    text::{Span, Spans},
+    text::{Span, Spans, Text},
     widgets::{Block, Borders, Paragraph},
 };
 
@@ -35,18 +35,34 @@ impl TaskView {
         let task = &*self.task.borrow();
         const DUR_PRECISION: usize = 4;
 
-        let mut attrs = vec![
+        let chunks = Layout::default()
+            .direction(layout::Direction::Vertical)
+            .constraints(
+                [
+                    layout::Constraint::Length(5),
+                    layout::Constraint::Percentage(60),
+                ]
+                .as_ref(),
+            )
+            .split(area);
+
+        let stats_area = Layout::default()
+            .direction(layout::Direction::Horizontal)
+            .constraints(
+                [
+                    layout::Constraint::Percentage(50),
+                    layout::Constraint::Percentage(50),
+                ]
+                .as_ref(),
+            )
+            .split(chunks[0]);
+
+        let fields_area = chunks[1];
+
+        let attrs = Spans::from(vec![
             Span::styled("ID: ", Style::default().add_modifier(style::Modifier::BOLD)),
             Span::raw(task.id_hex()),
-            Span::raw(", "),
-            Span::styled(
-                "Fields: ",
-                Style::default().add_modifier(style::Modifier::BOLD),
-            ),
-        ];
-
-        attrs.extend(task.formatted_fields().clone());
-        let atributes = Spans::from(attrs);
+        ]);
 
         let metrics = Spans::from(vec![
             Span::styled(
@@ -68,9 +84,58 @@ impl TaskView {
             Span::from(format!("{:.prec$?}", task.idle(now), prec = DUR_PRECISION,)),
         ]);
 
-        let lines = vec![atributes, metrics];
-        let block = Block::default().borders(Borders::ALL).title("Task");
-        let paragraph = Paragraph::new(lines).block(block);
-        frame.render_widget(paragraph, area);
+        let wakers = Spans::from(vec![
+            Span::styled(
+                "Current wakers: ",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
+            Span::from(format!("{} (", task.waker_count())),
+            Span::styled(
+                "clones: ",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
+            Span::from(format!("{}, ", task.waker_clones())),
+            Span::styled(
+                "drops: ",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
+            Span::from(format!("{})", task.waker_drops())),
+        ]);
+
+        let mut wakeups = vec![
+            Span::styled(
+                "Woken: ",
+                Style::default().add_modifier(style::Modifier::BOLD),
+            ),
+            Span::from(format!("{} times", task.wakes())),
+        ];
+
+        // If the task has been woken, add the time since wake to its stats as well.
+        if let Some(since) = task.since_wake(now) {
+            wakeups.push(Span::raw(", "));
+            wakeups.push(Span::styled("last woken:", bold()));
+            wakeups.push(Span::from(format!(" {:?} ago", since)));
+        }
+
+        let wakeups = Spans::from(wakeups);
+
+        fn block_for(title: &str) -> Block {
+            Block::default().borders(Borders::ALL).title(title)
+        }
+
+        fn bold() -> Style {
+            Style::default().add_modifier(style::Modifier::BOLD)
+        }
+
+        let mut fields = Text::default();
+        fields.extend(task.formatted_fields().iter().cloned().map(Spans::from));
+
+        let task_widget = Paragraph::new(vec![attrs, metrics]).block(block_for("Task"));
+        let wakers_widget = Paragraph::new(vec![wakers, wakeups]).block(block_for("Waker"));
+        let fields_widget = Paragraph::new(fields).block(block_for("Fields"));
+
+        frame.render_widget(task_widget, stats_area[0]);
+        frame.render_widget(wakers_widget, stats_area[1]);
+        frame.render_widget(fields_widget, fields_area);
     }
 }


### PR DESCRIPTION
this branch builds on #44 and adds waker stats to the console's task
view.

i also rearranged the task view a bit to make it a little more readable.
now, stats are grouped into boxes, and the fields are drawn on multiple
lines (which will be nice if we start recording user fields...).

for example:
![image](https://user-images.githubusercontent.com/2796466/121950547-a0721780-cd0e-11eb-89e3-f19e82391b2e.png)

also, i refactored a few things.