### PR TITLE
feat(subscriber): Record and send poll times with HdrHistogram

### DIFF
--- a/console-api/src/common.rs
+++ b/console-api/src/common.rs
@@ -129,6 +129,12 @@ impl From<tracing_core::span::Id> for SpanId {
     }
 }
 
+impl From<SpanId> for tracing_core::span::Id {
+    fn from(span_id: SpanId) -> Self {
+        tracing_core::span::Id::from_u64(span_id.id)
+    }
+}
+
 impl From<&'static tracing_core::Metadata<'static>> for register_metadata::NewMetadata {
     fn from(meta: &'static tracing_core::Metadata) -> Self {
         register_metadata::NewMetadata {

--- a/console-api/src/common.rs
+++ b/console-api/src/common.rs
@@ -135,6 +135,12 @@ impl From<SpanId> for tracing_core::span::Id {
     }
 }
 
+impl From<u64> for SpanId {
+    fn from(id: u64) -> Self {
+        SpanId { id }
+    }
+}
+
 impl From<&'static tracing_core::Metadata<'static>> for register_metadata::NewMetadata {
     fn from(meta: &'static tracing_core::Metadata) -> Self {
         register_metadata::NewMetadata {

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -16,6 +16,7 @@ tracing-core = "0.1.18"
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.2.17", default-features = false, features = ["fmt", "registry"] }
 futures = { version = "0.3", default-features = false }
+hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
 
 [dev-dependencies]
 

--- a/console-subscriber/src/aggregator.rs
+++ b/console-subscriber/src/aggregator.rs
@@ -110,7 +110,7 @@ impl Default for Stats {
             waker_clones: 0,
             waker_drops: 0,
             last_wake: None,
-            poll_times_histogram: Histogram::<u64>::new(1).unwrap(),
+            poll_times_histogram: Histogram::<u64>::new(2).unwrap(),
         }
     }
 }

--- a/console-subscriber/src/aggregator.rs
+++ b/console-subscriber/src/aggregator.rs
@@ -207,7 +207,7 @@ impl Aggregator {
                                     }
 
                                 }
-                                // If task is not found, drop the subscription
+                                // If task is not found, drop the subscription which should close the stream
                             },
                         };
 

--- a/console-subscriber/src/aggregator.rs
+++ b/console-subscriber/src/aggregator.rs
@@ -163,7 +163,7 @@ impl Aggregator {
                 subscription = self.rpcs.recv() => {
                     if let Some(subscription) = subscription {
                         match subscription {
-                            WatchKind::TaskUpdate(subscription) => {
+                            WatchKind::Task(subscription) => {
                                 tracing::debug!("new tasks subscription");
                                 let new_tasks = self.tasks.all().map(|(id, task)| {
                                     task.to_proto(id.clone())
@@ -185,7 +185,7 @@ impl Aggregator {
                                     self.watchers.push(subscription)
                                 }
                             },
-                            WatchKind::TaskDetailUpdate(task_id, subscription) => {
+                            WatchKind::TaskDetail(task_id, subscription) => {
                                 tracing::debug!(id = ?task_id, "new task details subscription");
                                 let task_id: span::Id = task_id.into();
                                 if let Some(stats) = self.stats.find(&task_id) {

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -388,9 +388,6 @@ impl proto::tasks::tasks_server::Tasks for Server {
             .map_err(|_| tonic::Status::not_found("task not found"))?;
 
         tracing::debug!(id = ?task_id, "task details watch started");
-        // At this point we don't know if the task with the given ID exists or not.
-        // But the only Watch sender will be dropped if the task doesn't exist
-        // so that should close the stream.
         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
         Ok(tonic::Response::new(stream))
     }

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -383,12 +383,10 @@ impl proto::tasks::tasks_server::Tasks for Server {
             buffer: self.client_buffer,
         }));
         // If the aggregator drops the sender, the task doesn't exist.
-        let rx = stream_recv
-            .await
-            .map_err(|_| {
-                tracing::warn!(id = ?task_id, "requested task not found");
-                tonic::Status::not_found("task not found")
-            })?;
+        let rx = stream_recv.await.map_err(|_| {
+            tracing::warn!(id = ?task_id, "requested task not found");
+            tonic::Status::not_found("task not found")
+        })?;
 
         tracing::debug!(id = ?task_id, "task details watch started");
         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -371,6 +371,9 @@ impl proto::tasks::tasks_server::Tasks for Server {
         let (tx, rx) = mpsc::channel(self.client_buffer);
         permit.send(WatchKind::TaskDetailUpdate(task_id, Watch(tx)));
         tracing::debug!("task details watch started");
+        // At this point we don't know if the task with the given ID exists or not.
+        // But the only Watch sender will be dropped if the task doesn't exist
+        // so that should close the stream.
         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
         Ok(tonic::Response::new(stream))
     }

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -17,3 +17,4 @@ tracing = "0.1"
 prost-types = "0.7"
 crossterm = { version = "0.19", features = ["event-stream"] }
 color-eyre = "0.5"
+hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -146,10 +146,8 @@ async fn watch_details_stream(
                             UpdateKind::ExitTaskView => {
                                 break;
                             },
-                            UpdateKind::SelectTask(new_id) => {
-                                if new_id != task_id {
-                                    break;
-                                }
+                            UpdateKind::SelectTask(new_id) if new_id != task_id => {
+                                break;
                             },
                             _ => {}
                         }

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -38,8 +38,8 @@ async fn main() -> color_eyre::Result<()> {
 
     // A channel to send the outcome of `View::update_input` to the watch_details_stream task.
     let (update_tx, update_rx) = watch::channel(UpdateKind::Other);
-    // A channel to send the task details update stream
-    let (details_tx, mut details_rx) = mpsc::channel::<TaskDetails>(8);
+    // A channel to send the task details update stream (no need to keep outdated details in the memory)
+    let (details_tx, mut details_rx) = mpsc::channel::<TaskDetails>(2);
 
     let mut tasks = tasks::State::default();
     let mut input = input::EventStream::new();
@@ -160,6 +160,6 @@ async fn watch_details_stream(
             }
         }
     } else {
-        // TODO: handle connection error, print details?
+        // TODO: handle connection error, print details somewhere? Related to Issue #30
     }
 }

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -203,14 +203,11 @@ impl State {
         if let Some(id) = update.task_id {
             let details = Details {
                 task_id: id.id,
-                poll_times_histogram: update
-                    .details
-                    .and_then(|details| details.poll_times_histogram)
-                    .and_then(|data| {
-                        hdrhistogram::serialization::Deserializer::new()
-                            .deserialize(&mut Cursor::new(&data))
-                            .ok()
-                    }),
+                poll_times_histogram: update.poll_times_histogram.and_then(|data| {
+                    hdrhistogram::serialization::Deserializer::new()
+                        .deserialize(&mut Cursor::new(&data))
+                        .ok()
+                }),
                 last_updated_at: update.now.map(|now| now.into()),
             };
 

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -195,7 +195,7 @@ impl State {
         }
     }
 
-    pub(crate) fn get_task_details_ref(&self) -> DetailsRef {
+    pub(crate) fn details_ref(&self) -> DetailsRef {
         self.current_task_details.clone()
     }
 

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -332,10 +332,6 @@ impl Details {
     pub(crate) fn poll_times_histogram(&self) -> Option<&Histogram<u64>> {
         self.poll_times_histogram.as_ref()
     }
-
-    pub(crate) fn last_updated_at(&self) -> Option<SystemTime> {
-        self.last_updated_at
-    }
 }
 
 impl From<proto::tasks::Stats> for Stats {

--- a/console/src/view/mini_histogram.rs
+++ b/console/src/view/mini_histogram.rs
@@ -105,9 +105,6 @@ impl<'a> Widget for MiniHistogram<'a> {
 }
 
 impl<'a> MiniHistogram<'a> {
-    // fn bars_area_width() -> u64 {
-    //     max_qty_label.len() as u16;
-    // }
 
     fn render_legend(
         &mut self,

--- a/console/src/view/mini_histogram.rs
+++ b/console/src/view/mini_histogram.rs
@@ -1,0 +1,242 @@
+use std::time::Duration;
+
+use tui::{
+    layout::Rect,
+    style::Style,
+    symbols,
+    widgets::{Block, Widget},
+};
+
+/// This is a tui-rs widget to visualize a latency histogram in a small area.
+/// It is based on the [`Sparkline`] widget, so it draws a mini bar chart with
+/// some labels for clarity. Unlike Sparkline, it does not omit very small values.
+pub(crate) struct MiniHistogram<'a> {
+    /// A block to wrap the widget in
+    block: Option<Block<'a>>,
+    /// Widget style
+    style: Style,
+    /// Values for the buckets of the histogram
+    data: &'a [u64],
+    /// Metadata about the histogram
+    metadata: HistogramMetadata,
+    /// The maximum value to take to compute the maximum bar height (if nothing is specified, the
+    /// widget uses the max of the dataset)
+    max: Option<u64>,
+    /// A set of bar symbols used to represent the give data
+    bar_set: symbols::bar::Set,
+    /// Duration precision for the labels
+    duration_precision: usize,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct HistogramMetadata {
+    /// The max recorded value in the histogram. This is the label for the bottom-right in the chart
+    pub(crate) max_value: u64,
+    /// The min recorded value in the histogram.
+    pub(crate) min_value: u64,
+    /// The value of the bucket with the greatest quantity
+    pub(crate) max_bucket: u64,
+    /// The value of the bucket with the smallest quantity
+    pub(crate) min_bucket: u64,
+}
+
+impl<'a> Default for MiniHistogram<'a> {
+    fn default() -> Self {
+        MiniHistogram {
+            block: None,
+            style: Default::default(),
+            data: &[],
+            metadata: Default::default(),
+            max: None,
+            bar_set: symbols::bar::NINE_LEVELS,
+            duration_precision: 4,
+        }
+    }
+}
+
+impl<'a> Widget for MiniHistogram<'a> {
+    fn render(mut self, area: tui::layout::Rect, buf: &mut tui::buffer::Buffer) {
+        let inner_area = match self.block.take() {
+            Some(b) => {
+                let inner_area = b.inner(area);
+                b.render(area, buf);
+                inner_area
+            }
+            None => area,
+        };
+
+        if inner_area.height < 1 {
+            return;
+        }
+
+        let max_qty_label = self.metadata.max_bucket.to_string();
+        let min_qty_label = self.metadata.min_bucket.to_string();
+        let max_record_label = format!(
+            "{:.prec$?}",
+            Duration::from_nanos(self.metadata.max_value),
+            prec = self.duration_precision,
+        );
+        let min_record_label = format!(
+            "{:.prec$?}",
+            Duration::from_nanos(self.metadata.min_value),
+            prec = self.duration_precision,
+        );
+        let y_axis_label_width = max_qty_label.len() as u16;
+
+        self.render_legend(
+            inner_area,
+            buf,
+            max_record_label,
+            min_record_label,
+            max_qty_label,
+            min_qty_label,
+        );
+
+        // Shrink the bars area by 1 row from the bottom
+        // and `y_axis_label_width` columns from the left.
+        let bars_area = Rect {
+            x: inner_area.x + y_axis_label_width,
+            y: inner_area.y,
+            width: inner_area.width - y_axis_label_width,
+            height: inner_area.height - 1,
+        };
+        self.render_bars(bars_area, buf);
+    }
+}
+
+impl<'a> MiniHistogram<'a> {
+    // fn bars_area_width() -> u64 {
+    //     max_qty_label.len() as u16;
+    // }
+
+    fn render_legend(
+        &mut self,
+        area: tui::layout::Rect,
+        buf: &mut tui::buffer::Buffer,
+        max_record_label: String,
+        min_record_label: String,
+        max_qty_label: String,
+        min_qty_label: String,
+    ) {
+        // top left: max quantity
+        buf.set_string(area.left(), area.top(), &max_qty_label, Style::default());
+        // bottom left: 0 aligned to right
+        let zero_label = format!("{:>width$}", &min_qty_label, width = max_qty_label.len());
+        buf.set_string(
+            area.left(),
+            area.bottom() - 2,
+            &zero_label,
+            Style::default(),
+        );
+        // bottom left below the chart: min time
+        buf.set_string(
+            area.left() + max_qty_label.len() as u16,
+            area.bottom() - 1,
+            &min_record_label,
+            Style::default(),
+        );
+        // bottom right: max time
+        buf.set_string(
+            area.right() - max_record_label.len() as u16,
+            area.bottom() - 1,
+            &max_record_label,
+            Style::default(),
+        );
+    }
+
+    fn render_bars(&mut self, area: tui::layout::Rect, buf: &mut tui::buffer::Buffer) {
+        let max = match self.max {
+            Some(v) => v,
+            None => *self.data.iter().max().unwrap_or(&1u64),
+        };
+        let max_index = std::cmp::min(area.width as usize, self.data.len());
+        let mut data = self
+            .data
+            .iter()
+            .take(max_index)
+            .map(|e| {
+                if max != 0 {
+                    let r = e * u64::from(area.height) * 8 / max;
+                    // This is the only difference in the bar rendering logic
+                    // between MiniHistogram and Sparkline. At least render a
+                    // ONE_EIGHT, if the value is greater than 0, even if it's
+                    // relatively very small.
+                    if *e > 0 && r == 0 {
+                        1
+                    } else {
+                        r
+                    }
+                } else {
+                    0
+                }
+            })
+            .collect::<Vec<u64>>();
+        for j in (0..area.height).rev() {
+            for (i, d) in data.iter_mut().enumerate() {
+                let symbol = match *d {
+                    0 => self.bar_set.empty,
+                    1 => self.bar_set.one_eighth,
+                    2 => self.bar_set.one_quarter,
+                    3 => self.bar_set.three_eighths,
+                    4 => self.bar_set.half,
+                    5 => self.bar_set.five_eighths,
+                    6 => self.bar_set.three_quarters,
+                    7 => self.bar_set.seven_eighths,
+                    _ => self.bar_set.full,
+                };
+                buf.get_mut(area.left() + i as u16, area.top() + j)
+                    .set_symbol(symbol)
+                    .set_style(self.style);
+
+                if *d > 8 {
+                    *d -= 8;
+                } else {
+                    *d = 0;
+                }
+            }
+        }
+    }
+
+    pub fn duration_precision(mut self, precision: usize) -> MiniHistogram<'a> {
+        self.duration_precision = precision;
+        self
+    }
+
+    // The same Sparkline setter methods below
+
+    #[allow(dead_code)]
+    pub fn block(mut self, block: Block<'a>) -> MiniHistogram<'a> {
+        self.block = Some(block);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn style(mut self, style: Style) -> MiniHistogram<'a> {
+        self.style = style;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn data(mut self, data: &'a [u64]) -> MiniHistogram<'a> {
+        self.data = data;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn metadata(mut self, metadata: HistogramMetadata) -> MiniHistogram<'a> {
+        self.metadata = metadata;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn max(mut self, max: u64) -> MiniHistogram<'a> {
+        self.max = Some(max);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn bar_set(mut self, bar_set: symbols::bar::Set) -> MiniHistogram<'a> {
+        self.bar_set = bar_set;
+        self
+    }
+}

--- a/console/src/view/mini_histogram.rs
+++ b/console/src/view/mini_histogram.rs
@@ -105,7 +105,6 @@ impl<'a> Widget for MiniHistogram<'a> {
 }
 
 impl<'a> MiniHistogram<'a> {
-
     fn render_legend(
         &mut self,
         area: tui::layout::Rect,

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -6,9 +6,9 @@ use tui::{
     text::Span,
 };
 
+mod mini_histogram;
 mod task;
 mod tasks;
-mod mini_histogram;
 
 pub struct View {
     /// The tasks list is stored separately from the currently selected state,

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -27,10 +27,14 @@ enum ViewState {
     TaskInstance(self::task::TaskView),
 }
 
-/// The outcome of the
+/// The outcome of the update_input method
+#[derive(Debug, Copy, Clone)]
 pub(crate) enum UpdateKind {
-    SelectTask(crate::tasks::TaskRef),
+    /// A new task is selected
+    SelectTask(u64),
+    /// The TaskView is exited
     ExitTaskView,
+    /// No significant change
     Other,
 }
 
@@ -54,7 +58,7 @@ impl View {
                 match event {
                     key!(Enter) => {
                         if let Some(task) = self.list.selected_task().upgrade() {
-                            update_kind = UpdateKind::SelectTask(self.list.selected_task());
+                            update_kind = UpdateKind::SelectTask(task.borrow().id());
                             self.state = TaskInstance(self::task::TaskView::new(
                                 task,
                                 tasks.get_task_details_ref(),

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -60,10 +60,8 @@ impl View {
                     key!(Enter) => {
                         if let Some(task) = self.list.selected_task().upgrade() {
                             update_kind = UpdateKind::SelectTask(task.borrow().id());
-                            self.state = TaskInstance(self::task::TaskView::new(
-                                task,
-                                tasks.get_task_details_ref(),
-                            ));
+                            self.state =
+                                TaskInstance(self::task::TaskView::new(task, tasks.details_ref()));
                         }
                     }
                     _ => {

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -8,6 +8,7 @@ use tui::{
 
 mod task;
 mod tasks;
+mod mini_histogram;
 
 pub struct View {
     /// The tasks list is stored separately from the currently selected state,

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -257,24 +257,23 @@ fn make_percentiles_widgets(details: DetailsRef, task_id: u64) -> (Text<'static>
         .and_then(|details| filter_same_task(task_id, details))
         .and_then(|details| details.poll_times_histogram())
         .map(|histogram| {
-            vec![
-                (5, histogram.value_at_percentile(5.0)),
-                (10, histogram.value_at_percentile(10.0)),
-                (25, histogram.value_at_percentile(25.0)),
-                (50, histogram.value_at_percentile(50.0)),
-                (75, histogram.value_at_percentile(75.0)),
-                (90, histogram.value_at_percentile(90.0)),
-                (95, histogram.value_at_percentile(95.0)),
-                (99, histogram.value_at_percentile(99.0)),
-            ]
+            [10f64, 25f64, 50f64, 75f64, 90f64, 95f64, 99f64].iter().map(|i| {
+                (*i, histogram.value_at_percentile(*i))
+            }).collect::<Vec<(f64, u64)>>()
         })
         .map(|pairs| {
             pairs.into_iter().map(|pair| {
-                format!(
-                    "p{}: {:.prec$?}",
-                    pair.0,
-                    Duration::from_nanos(pair.1),
-                    prec = DUR_PRECISION,
+                Spans::from(
+                    vec![
+                        bold(format!("p{:>2}: ", pair.0)),
+                        Span::from(
+                            format!(
+                                "{:.prec$?}",
+                                Duration::from_nanos(pair.1),
+                                prec = DUR_PRECISION,
+                            )
+                        )
+                    ],
                 )
             })
         });
@@ -282,7 +281,7 @@ fn make_percentiles_widgets(details: DetailsRef, task_id: u64) -> (Text<'static>
     let mut percentiles_1 = Text::default();
     let mut percentiles_2 = Text::default();
     if let Some(mut percentiles_iter) = percentiles_iter {
-        percentiles_1.extend(percentiles_iter.by_ref().take(4).map(Spans::from));
+        percentiles_1.extend(percentiles_iter.by_ref().take(5).map(Spans::from));
         percentiles_2.extend(percentiles_iter.map(Spans::from));
     }
     (percentiles_1, percentiles_2)

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -257,24 +257,21 @@ fn make_percentiles_widgets(details: DetailsRef, task_id: u64) -> (Text<'static>
         .and_then(|details| filter_same_task(task_id, details))
         .and_then(|details| details.poll_times_histogram())
         .map(|histogram| {
-            [10f64, 25f64, 50f64, 75f64, 90f64, 95f64, 99f64].iter().map(|i| {
-                (*i, histogram.value_at_percentile(*i))
-            }).collect::<Vec<(f64, u64)>>()
+            [10f64, 25f64, 50f64, 75f64, 90f64, 95f64, 99f64]
+                .iter()
+                .map(|i| (*i, histogram.value_at_percentile(*i)))
+                .collect::<Vec<(f64, u64)>>()
         })
         .map(|pairs| {
             pairs.into_iter().map(|pair| {
-                Spans::from(
-                    vec![
-                        bold(format!("p{:>2}: ", pair.0)),
-                        Span::from(
-                            format!(
-                                "{:.prec$?}",
-                                Duration::from_nanos(pair.1),
-                                prec = DUR_PRECISION,
-                            )
-                        )
-                    ],
-                )
+                Spans::from(vec![
+                    bold(format!("p{:>2}: ", pair.0)),
+                    Span::from(format!(
+                        "{:.prec$?}",
+                        Duration::from_nanos(pair.1),
+                        prec = DUR_PRECISION,
+                    )),
+                ])
             })
         });
 

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -3,7 +3,11 @@ use crate::{
     tasks::{Details, DetailsRef, Task},
     view::bold,
 };
-use std::{cell::RefCell, rc::Rc, time::SystemTime};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    time::{Duration, SystemTime},
+};
 use tui::{
     layout::{self, Layout},
     text::{Span, Spans, Text},
@@ -14,6 +18,8 @@ pub(crate) struct TaskView {
     task: Rc<RefCell<Task>>,
     details: DetailsRef,
 }
+
+const DUR_PRECISION: usize = 4;
 
 impl TaskView {
     pub(super) fn new(task: Rc<RefCell<Task>>, details: DetailsRef) -> Self {
@@ -37,7 +43,6 @@ impl TaskView {
         // - logs?
 
         let task = &*self.task.borrow();
-        const DUR_PRECISION: usize = 4;
 
         let chunks = Layout::default()
             .direction(layout::Direction::Vertical)
@@ -221,9 +226,14 @@ fn make_percentiles_widgets(details: DetailsRef, task_id: u64) -> (Text<'static>
             ]
         })
         .map(|pairs| {
-            pairs
-                .into_iter()
-                .map(|pair| format!("p{}: {}ms", pair.0, (pair.1 as f64 / 1000f64)))
+            pairs.into_iter().map(|pair| {
+                format!(
+                    "p{}: {:.prec$?}",
+                    pair.0,
+                    Duration::from_nanos(pair.1),
+                    prec = DUR_PRECISION,
+                )
+            })
         });
 
     let mut percentiles_1 = Text::default();

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -1,6 +1,6 @@
 use crate::{
     input,
-    tasks::{DetailsRef, Task},
+    tasks::{Details, DetailsRef, Task},
     view::bold,
 };
 use std::{cell::RefCell, rc::Rc, time::SystemTime};
@@ -45,7 +45,7 @@ impl TaskView {
                 [
                     layout::Constraint::Length(1),
                     layout::Constraint::Length(6),
-                    layout::Constraint::Length(9),
+                    layout::Constraint::Length(6),
                     layout::Constraint::Percentage(60),
                 ]
                 .as_ref(),
@@ -75,8 +75,21 @@ impl TaskView {
             )
             .split(chunks[2]);
 
+        let percentiles_columns = Layout::default()
+            .direction(layout::Direction::Horizontal)
+            .constraints(
+                [
+                    layout::Constraint::Percentage(50),
+                    layout::Constraint::Percentage(50),
+                ]
+                .as_ref(),
+            )
+            .split(histogram_area[0].inner(&layout::Margin {
+                horizontal: 1,
+                vertical: 1,
+            }));
+
         let fields_area = chunks[3];
-        let percentiles_area = histogram_area[0];
         let sparkline_area = histogram_area[1];
 
         let controls = Spans::from(vec![
@@ -142,58 +155,7 @@ impl TaskView {
         let mut fields = Text::default();
         fields.extend(task.formatted_fields().iter().cloned().map(Spans::from));
 
-        let percentiles_iter = self
-            .details
-            .borrow()
-            .as_ref()
-            .and_then(|details| details.poll_times_histogram())
-            .map(|histogram| {
-                vec![
-                    (10, histogram.value_at_percentile(10.0)),
-                    (25, histogram.value_at_percentile(25.0)),
-                    (50, histogram.value_at_percentile(50.0)),
-                    (75, histogram.value_at_percentile(75.0)),
-                    (90, histogram.value_at_percentile(90.0)),
-                    (95, histogram.value_at_percentile(95.0)),
-                    (99, histogram.value_at_percentile(99.0)),
-                ]
-            })
-            .map(|pairs| {
-                pairs
-                    .into_iter()
-                    .map(|pair| format!("p{}: {}ms", pair.0, (pair.1 as f64 / 1000f64)))
-            });
-
-        let mut percentiles = Text::default();
-        if let Some(percentiles_iter) = percentiles_iter {
-            percentiles.extend(percentiles_iter.map(Spans::from));
-        }
-
-        let buckets = frame.size().width / 2;
-
-        let chart_data = self
-            .details
-            .borrow()
-            .as_ref()
-            .and_then(|details| details.poll_times_histogram())
-            .map(|histogram| {
-                // This is probably very buggy
-                let steps =
-                    ((histogram.max() - histogram.min()) as f64 / buckets as f64).ceil() as u64;
-                if steps > 0 {
-                    let data: Vec<u64> = histogram
-                        .iter_linear(steps)
-                        .map(|it| {
-                            // format!("{}", (it.value_iterated_to() / 1000)),
-                            it.count_since_last_iteration()
-                        })
-                        .collect();
-                    data
-                } else {
-                    Vec::new()
-                }
-            })
-            .unwrap_or_default();
+        let chart_data = make_chart_data(self.details.clone(), task.id(), sparkline_area.width - 2);
         let histogram_sparkline = Sparkline::default()
             .block(Block::default().title("Poll Times").borders(Borders::ALL))
             .data(&chart_data);
@@ -201,13 +163,82 @@ impl TaskView {
         let task_widget = Paragraph::new(metrics).block(block_for("Task"));
         let wakers_widget = Paragraph::new(vec![wakers, wakeups]).block(block_for("Waker"));
         let fields_widget = Paragraph::new(fields).block(block_for("Fields"));
-        let percentiles_widget = Paragraph::new(percentiles).block(block_for("Poll Times Stats"));
+
+        let percentiles_widget = block_for("Poll Times Stats");
+        let (percentiles_1, percentiles_2) =
+            make_percentiles_widgets(self.details.clone(), task.id());
+        let percentiles_widget_1 = Paragraph::new(percentiles_1);
+        let percentiles_widget_2 = Paragraph::new(percentiles_2);
 
         frame.render_widget(Block::default().title(controls), controls_area);
         frame.render_widget(task_widget, stats_area[0]);
         frame.render_widget(wakers_widget, stats_area[1]);
         frame.render_widget(fields_widget, fields_area);
-        frame.render_widget(percentiles_widget, percentiles_area);
+        frame.render_widget(percentiles_widget, histogram_area[0]);
+        frame.render_widget(percentiles_widget_1, percentiles_columns[0]);
+        frame.render_widget(percentiles_widget_2, percentiles_columns[1]);
         frame.render_widget(histogram_sparkline, sparkline_area);
+    }
+}
+
+fn make_chart_data(details: DetailsRef, task_id: u64, width: u16) -> Vec<u64> {
+    details
+        .borrow()
+        .as_ref()
+        .and_then(|details| filter_same_task(task_id, details))
+        .and_then(|details| details.poll_times_histogram())
+        .map(|histogram| {
+            // This is probably very buggy
+            let steps = ((histogram.max() - histogram.min()) as f64 / width as f64).ceil() as u64;
+            if steps > 0 {
+                let data: Vec<u64> = histogram
+                    .iter_linear(steps)
+                    .map(|it| it.count_since_last_iteration())
+                    .collect();
+                data
+            } else {
+                Vec::new()
+            }
+        })
+        .unwrap_or_default()
+}
+
+fn make_percentiles_widgets(details: DetailsRef, task_id: u64) -> (Text<'static>, Text<'static>) {
+    let percentiles_iter = details
+        .borrow()
+        .as_ref()
+        .and_then(|details| filter_same_task(task_id, details))
+        .and_then(|details| details.poll_times_histogram())
+        .map(|histogram| {
+            vec![
+                (10, histogram.value_at_percentile(10.0)),
+                (25, histogram.value_at_percentile(25.0)),
+                (50, histogram.value_at_percentile(50.0)),
+                (75, histogram.value_at_percentile(75.0)),
+                (90, histogram.value_at_percentile(90.0)),
+                (95, histogram.value_at_percentile(95.0)),
+                (99, histogram.value_at_percentile(99.0)),
+            ]
+        })
+        .map(|pairs| {
+            pairs
+                .into_iter()
+                .map(|pair| format!("p{}: {}ms", pair.0, (pair.1 as f64 / 1000f64)))
+        });
+
+    let mut percentiles_1 = Text::default();
+    let mut percentiles_2 = Text::default();
+    if let Some(mut percentiles_iter) = percentiles_iter {
+        percentiles_1.extend(percentiles_iter.by_ref().take(4).map(Spans::from));
+        percentiles_2.extend(percentiles_iter.map(Spans::from));
+    }
+    (percentiles_1, percentiles_2)
+}
+
+fn filter_same_task(task_id: u64, details: &Details) -> Option<&Details> {
+    if details.task_id() == task_id {
+        Some(details)
+    } else {
+        None
     }
 }

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -213,6 +213,7 @@ fn make_chart_data(details: DetailsRef, task_id: u64, width: u16) -> (Vec<u64>, 
         .map(|histogram| {
             let step_size =
                 ((histogram.max() - histogram.min()) as f64 / width as f64).ceil() as u64 + 1;
+            // `iter_linear` panics if step_size is 0
             let data = if step_size > 0 {
                 let mut found_first_nonzero = false;
                 let data: Vec<u64> = histogram

--- a/proto/tasks.proto
+++ b/proto/tasks.proto
@@ -127,4 +127,7 @@ message Stats {
     //
     // If this is `None`, the task has not yet been woken.
     optional google.protobuf.Timestamp last_wake = 10;
+
+    // HdrHistogram.rs `Histogram` serialized to binary in the V2 + DEFLATE format
+    optional bytes poll_times_histogram = 11;
 }

--- a/proto/tasks.proto
+++ b/proto/tasks.proto
@@ -56,7 +56,8 @@ message TaskDetails {
 
     google.protobuf.Timestamp now = 2;
 
-    Details details = 3;
+    // HdrHistogram.rs `Histogram` serialized to binary in the V2 format
+    optional bytes poll_times_histogram = 3;
 }
 
 // Data recorded when a new task is spawned.
@@ -142,9 +143,4 @@ message Stats {
     //
     // If this is `None`, the task has not yet been woken.
     optional google.protobuf.Timestamp last_wake = 10;
-}
-
-message Details {
-    // HdrHistogram.rs `Histogram` serialized to binary in the V2 format
-    optional bytes poll_times_histogram = 1;
 }

--- a/proto/tasks.proto
+++ b/proto/tasks.proto
@@ -8,9 +8,14 @@ import "common.proto";
 
 service Tasks {
     rpc WatchTasks(TasksRequest) returns (stream TaskUpdate) {}
+    rpc WatchTaskDetails(DetailsRequest) returns (stream TaskDetails) {}
 }
 
 message TasksRequest {
+}
+
+message DetailsRequest {
+    common.SpanId id = 1;
 }
 
 // A task state update.
@@ -42,6 +47,16 @@ message TaskUpdate {
     // This is the timestamp any durations in the included `Stats` were
     // calculated relative to.
     google.protobuf.Timestamp now = 4;
+}
+
+// A task details update
+message TaskDetails {
+    // The task's ID which the details belong to.
+    common.SpanId task_id = 1;
+
+    google.protobuf.Timestamp now = 2;
+
+    Details details = 3;
 }
 
 // Data recorded when a new task is spawned.
@@ -127,7 +142,9 @@ message Stats {
     //
     // If this is `None`, the task has not yet been woken.
     optional google.protobuf.Timestamp last_wake = 10;
+}
 
-    // HdrHistogram.rs `Histogram` serialized to binary in the V2 + DEFLATE format
-    optional bytes poll_times_histogram = 11;
+message Details {
+    // HdrHistogram.rs `Histogram` serialized to binary in the V2 format
+    optional bytes poll_times_histogram = 1;
 }


### PR DESCRIPTION
Closes #36 

As suggested in the issue, this PR uses `HdrHistogram` to record task poll times as nanoseconds. The histogram is serialized into bytes using the `V2Serializer`. 

The subscriber now offers a second RPC stream called TaskDetails for a given task ID. 

The console app starts a details stream when you view the details of a task and stops the stream when you leave it.

To demonstrate that it works, I also added some stats and a small chart to the task view using the histogram data.
But I won't insist on merging this part, since you may have other plans for the task details view. 

![Screenshot from 2021-06-22 21-20-43](https://user-images.githubusercontent.com/1333721/123020096-bf704980-d39f-11eb-9cdb-5c92becaf90f.png)


I've got one TODO left and I would appreciate your suggestions on it.
