### PR TITLE
chore(deps): un-patch tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,3 @@ members = [
     "console-api"
 ]
 resolver = "2"
-
-# Patch the dependency on tokio to get waker instrumentation while developing.
-# This can be un-patched when the following commits are released:
-# - https://github.com/tokio-rs/tokio/commit/e7d74b3119178b9b86f7b547774b6b121de2239a
-# - https://github.com/tokio-rs/tokio/commit/f55b77aaddaed8e48a8c0d81c66da82f12433087
-[patch.crates-io.tokio]
-git = "https://github.com/tokio-rs/tokio"
-rev = "f55b77aaddaed8e48a8c0d81c66da82f12433087"
-features = ["full", "rt-multi-thread"]

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 
-tokio = { version = "^1.6.2", features = ["sync", "time", "macros", "tracing"]}
+tokio = { version = "^1.7", features = ["sync", "time", "macros", "tracing"]}
 tokio-stream = "0.1"
 tonic = { version = "0.4", features = ["transport"] }
 console-api = { path = "../console-api", features = ["transport"]}
@@ -19,8 +19,7 @@ futures = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 
-tokio = { version = "^1.6.2", features = ["full", "rt-multi-thread"]}
+tokio = { version = "^1.7", features = ["full", "rt-multi-thread"]}
 futures = "0.3"
 
 tracing-subscriber = { version = "0.2.17", features = ["fmt", "registry", "env-filter"] }
-

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 
-tokio = { version = "^1.5", features = ["sync", "time", "macros", "tracing"]}
+tokio = { version = "^1.6.2", features = ["sync", "time", "macros", "tracing"]}
 tokio-stream = "0.1"
 tonic = { version = "0.4", features = ["transport"] }
 console-api = { path = "../console-api", features = ["transport"]}
@@ -19,7 +19,7 @@ futures = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 
-tokio = { version = "^1.5", features = ["full", "rt-multi-thread"]}
+tokio = { version = "^1.6.2", features = ["full", "rt-multi-thread"]}
 futures = "0.3"
 
 tracing-subscriber = { version = "0.2.17", features = ["fmt", "registry", "env-filter"] }


### PR DESCRIPTION
now that 1.6.2 has been published we can remove the patch.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>