### PR TITLE
minor task details view improvement

### DIFF
--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -429,6 +429,10 @@ impl Task {
         &self.formatted_fields
     }
 
+    pub(crate) fn is_completed(&self) -> bool {
+        self.stats.total.is_some()
+    }
+
     pub(crate) fn total(&self, since: SystemTime) -> Duration {
         self.stats
             .total

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -99,6 +99,7 @@ impl TaskView {
             bold("clones: "),
             Span::from(format!("{}, ", task.waker_clones())),
             bold("drops: "),
+            Span::from(format!("{})", task.waker_drops())),
         ]);
 
         let mut wakeups = vec![

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -38,13 +38,15 @@ impl TaskView {
             .direction(layout::Direction::Vertical)
             .constraints(
                 [
-                    layout::Constraint::Length(5),
+                    layout::Constraint::Length(1),
+                    layout::Constraint::Length(6),
                     layout::Constraint::Percentage(60),
                 ]
                 .as_ref(),
             )
             .split(area);
 
+        let controls_area = chunks[0];
         let stats_area = Layout::default()
             .direction(layout::Direction::Horizontal)
             .constraints(
@@ -54,22 +56,42 @@ impl TaskView {
                 ]
                 .as_ref(),
             )
-            .split(chunks[0]);
+            .split(chunks[1]);
 
-        let fields_area = chunks[1];
+        let fields_area = chunks[2];
+
+        let controls = Spans::from(vec![
+            Span::raw("controls: "),
+            bold("esc"),
+            Span::raw(" = return to task list, "),
+            bold("q"),
+            Span::raw(" = quit"),
+        ]);
 
         let attrs = Spans::from(vec![bold("ID: "), Span::raw(task.id_hex())]);
 
-        let metrics = Spans::from(vec![
+        let mut total = vec![
             bold("Total Time: "),
             Span::from(format!("{:.prec$?}", task.total(now), prec = DUR_PRECISION,)),
-            Span::raw(", "),
+        ];
+
+        // TODO(eliza): maybe surface how long the task has been completed, as well?
+        if task.is_completed() {
+            total.push(Span::raw(" (completed)"));
+        };
+
+        let total = Spans::from(total);
+
+        let busy = Spans::from(vec![
             bold("Busy: "),
             Span::from(format!("{:.prec$?}", task.busy(), prec = DUR_PRECISION,)),
-            Span::raw(", "),
+        ]);
+        let idle = Spans::from(vec![
             bold("Idle: "),
             Span::from(format!("{:.prec$?}", task.idle(now), prec = DUR_PRECISION,)),
         ]);
+
+        let metrics = vec![attrs, total, busy, idle];
 
         let wakers = Spans::from(vec![
             bold("Current wakers: "),
@@ -100,10 +122,11 @@ impl TaskView {
         let mut fields = Text::default();
         fields.extend(task.formatted_fields().iter().cloned().map(Spans::from));
 
-        let task_widget = Paragraph::new(vec![attrs, metrics]).block(block_for("Task"));
+        let task_widget = Paragraph::new(metrics).block(block_for("Task"));
         let wakers_widget = Paragraph::new(vec![wakers, wakeups]).block(block_for("Waker"));
         let fields_widget = Paragraph::new(fields).block(block_for("Fields"));
 
+        frame.render_widget(Block::default().title(controls), controls_area);
         frame.render_widget(task_widget, stats_area[0]);
         frame.render_widget(wakers_widget, stats_area[1]);
         frame.render_widget(fields_widget, fields_area);


### PR DESCRIPTION
this branch:
 - adds whether or not the task is completed to the task details view
 - rearranges the task metrics so they are less likely to get line 
   wrapped on small terminals
 - adds the keyboard controls to the task details view, similar to the
   task list view
 - puts back the waker drops stat in the task details view (it had
   disappeared somehow, probably due to a bad rebase?)