### PR TITLE
Emit and show self-wake count for a Task

### DIFF
--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -67,6 +67,8 @@ struct Stats {
 
     /// The timestamp of when the task was last woken.
     last_wake: Option<SystemTime>,
+    /// Total number of times the task has woken itself.
+    self_wakes: u64,
 }
 
 #[derive(Debug)]
@@ -273,6 +275,11 @@ impl Task {
         self.stats.wakes
     }
 
+    /// Returns the total number of times this task has woken itself.
+    pub(crate) fn self_wakes(&self) -> u64 {
+        self.stats.self_wakes
+    }
+
     fn update(&mut self) {
         let completed = self.stats.total.is_some() && self.completed_for == 0;
         if completed {
@@ -305,6 +312,7 @@ impl From<proto::tasks::Stats> for Stats {
             waker_clones: pb.waker_clones,
             waker_drops: pb.waker_drops,
             last_wake: pb.last_wake.map(Into::into),
+            self_wakes: pb.self_wakes,
         }
     }
 }

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -107,6 +107,12 @@ impl TaskView {
             Span::from(format!("{} times", task.wakes())),
         ];
 
+        if task.self_wakes() > 0 {
+            wakeups.push(Span::raw(", "));
+            wakeups.push(bold("Self Wakes: "));
+            wakeups.push(Span::from(format!("{} times", task.self_wakes())));
+        }
+
         // If the task has been woken, add the time since wake to its stats as well.
         if let Some(since) = task.since_wake(now) {
             wakeups.push(Span::raw(", "));

--- a/proto/tasks.proto
+++ b/proto/tasks.proto
@@ -127,4 +127,6 @@ message Stats {
     //
     // If this is `None`, the task has not yet been woken.
     optional google.protobuf.Timestamp last_wake = 10;
+    // The total number of times this task has woken itself.
+    uint64 self_wakes = 11;
 }


### PR DESCRIPTION
This counts all wakes of a task that happen while the task is "currently polled". This could be from `task::yield_now()`, from `tokio::coop`, or any other pattern that triggers the task to wake even though it's currently being polled.