### PR TITLE
console: handle disconnection more gracefully

### DIFF
--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -20,20 +20,6 @@ enum ConnectionState {
     Disconnected,
 }
 
-async fn connect(
-    target: String,
-    should_delay: bool,
-) -> Result<tonic::Streaming<TaskUpdate>, Box<dyn std::error::Error>> {
-    if should_delay {
-        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-    }
-
-    let mut client = TasksClient::connect(target).await?;
-    let request = tonic::Request::new(TasksRequest {});
-    let rsp = client.watch_tasks(request).await?;
-    Ok(rsp.into_inner())
-}
-
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
@@ -135,4 +121,18 @@ async fn main() -> color_eyre::Result<()> {
             view.render(f, chunks[1], &mut tasks);
         })?;
     }
+}
+
+async fn connect(
+    target: String,
+    is_reconnect: bool,
+) -> Result<tonic::Streaming<TaskUpdate>, Box<dyn std::error::Error>> {
+    if is_reconnect {
+        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+    }
+
+    let mut client = TasksClient::connect(target).await?;
+    let request = tonic::Request::new(TasksRequest {});
+    let rsp = client.watch_tasks(request).await?;
+    Ok(rsp.into_inner())
 }

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -105,10 +105,8 @@ async fn main() -> color_eyre::Result<()> {
                 .constraints([Constraint::Length(2), Constraint::Percentage(95)].as_ref())
                 .split(f.size());
 
-            let target = target.clone();
-
             let header_block = Block::default().title(vec![
-                Span::raw(format!("connection: {} ", target.clone())),
+                Span::raw(format!("connection: {} ", target)),
                 match connection_state {
                     Some(ConnectionState::Connected) => Span::styled(
                         "(CONNECTED)",

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -11,12 +11,20 @@ use std::{
 };
 use tui::text::Span;
 
+#[derive(Debug)]
+pub(crate) enum ConnectionState {
+    Pending,
+    Connected(String),
+    Disconnected,
+}
+
 #[derive(Default, Debug)]
 pub(crate) struct State {
     tasks: HashMap<u64, Rc<RefCell<Task>>>,
     metas: HashMap<u64, Metadata>,
     last_updated_at: Option<SystemTime>,
     new_tasks: Vec<TaskRef>,
+    connection_state: ConnectionState,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -98,6 +106,14 @@ impl State {
     /// Returns any new tasks that were added since the last task update.
     pub(crate) fn take_new_tasks(&mut self) -> impl Iterator<Item = TaskRef> + '_ {
         self.new_tasks.drain(..)
+    }
+
+    pub(crate) fn set_connection_state(&mut self, conn_state: ConnectionState) {
+        self.connection_state = conn_state;
+    }
+
+    pub(crate) fn connection_state(&self) -> &ConnectionState {
+        &self.connection_state
     }
 
     pub(crate) fn update_tasks(&mut self, update: proto::tasks::TaskUpdate) {
@@ -381,5 +397,11 @@ impl fmt::Display for FieldValue {
         }
 
         Ok(())
+    }
+}
+
+impl Default for ConnectionState {
+    fn default() -> ConnectionState {
+        ConnectionState::Pending
     }
 }

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -11,20 +11,12 @@ use std::{
 };
 use tui::text::Span;
 
-#[derive(Debug)]
-pub(crate) enum ConnectionState {
-    Pending,
-    Connected(String),
-    Disconnected,
-}
-
 #[derive(Default, Debug)]
 pub(crate) struct State {
     tasks: HashMap<u64, Rc<RefCell<Task>>>,
     metas: HashMap<u64, Metadata>,
     last_updated_at: Option<SystemTime>,
     new_tasks: Vec<TaskRef>,
-    connection_state: ConnectionState,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -106,14 +98,6 @@ impl State {
     /// Returns any new tasks that were added since the last task update.
     pub(crate) fn take_new_tasks(&mut self) -> impl Iterator<Item = TaskRef> + '_ {
         self.new_tasks.drain(..)
-    }
-
-    pub(crate) fn set_connection_state(&mut self, conn_state: ConnectionState) {
-        self.connection_state = conn_state;
-    }
-
-    pub(crate) fn connection_state(&self) -> &ConnectionState {
-        &self.connection_state
     }
 
     pub(crate) fn update_tasks(&mut self, update: proto::tasks::TaskUpdate) {
@@ -397,11 +381,5 @@ impl fmt::Display for FieldValue {
         }
 
         Ok(())
-    }
-}
-
-impl Default for ConnectionState {
-    fn default() -> ConnectionState {
-        ConnectionState::Pending
     }
 }


### PR DESCRIPTION
This PR aims to make it so we do not panic on disconnects.
Instead of panicking the connection state indicator changes
and browsing the last state is still possible.


<img width="354" alt="Screenshot 2021-06-29 at 12 15 14" src="https://user-images.githubusercontent.com/4391506/123771443-b4537700-d8d3-11eb-9740-95799ecc253b.png">
<img width="343" alt="Screenshot 2021-06-29 at 12 15 20" src="https://user-images.githubusercontent.com/4391506/123771470-bb7a8500-d8d3-11eb-876c-8d56f1d1cea6.png">


Related: #30

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>