### PR TITLE
subscriber: correctly reflect busy and idle times

### DIFF
--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -7,6 +7,7 @@ use std::{
     convert::TryFrom,
     fmt,
     io::Cursor,
+    ops::Add,
     rc::{Rc, Weak},
     sync::Arc,
     time::{Duration, SystemTime},
@@ -64,6 +65,8 @@ struct Stats {
     polls: u64,
     created_at: SystemTime,
     busy: Duration,
+    last_poll_started: Option<SystemTime>,
+    last_poll_ended: Option<SystemTime>,
     idle: Option<Duration>,
     total: Option<Duration>,
 
@@ -258,14 +261,21 @@ impl Task {
             .unwrap_or_else(|| since.duration_since(self.stats.created_at).unwrap())
     }
 
-    pub(crate) fn busy(&self) -> Duration {
+    pub(crate) fn busy(&self, since: SystemTime) -> Duration {
+        if let (Some(last_poll_started), None) =
+            (self.stats.last_poll_started, self.stats.last_poll_ended)
+        {
+            // in this case the task is being polled at the moment
+            let current_time_in_poll = since.duration_since(last_poll_started).unwrap();
+            return self.stats.busy.add(current_time_in_poll);
+        }
         self.stats.busy
     }
 
     pub(crate) fn idle(&self, since: SystemTime) -> Duration {
         self.stats
             .idle
-            .unwrap_or_else(|| self.total(since) - self.busy())
+            .unwrap_or_else(|| self.total(since) - self.busy(since))
     }
 
     /// Returns the total number of times the task has been polled.
@@ -348,6 +358,8 @@ impl From<proto::tasks::Stats> for Stats {
             total,
             idle,
             busy,
+            last_poll_started: pb.last_poll_started.map(Into::into),
+            last_poll_ended: pb.last_poll_ended.map(Into::into),
             polls: pb.polls,
             created_at: pb.created_at.expect("task span was never created").into(),
             wakes: pb.wakes,
@@ -396,7 +408,7 @@ impl SortBy {
                 tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().idle(now)))
             }
             Self::Busy => {
-                tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().busy()))
+                tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().busy(now)))
             }
             Self::Polls => {
                 tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().stats.polls))

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -7,7 +7,6 @@ use std::{
     convert::TryFrom,
     fmt,
     io::Cursor,
-    ops::Add,
     rc::{Rc, Weak},
     sync::Arc,
     time::{Duration, SystemTime},
@@ -267,7 +266,7 @@ impl Task {
         {
             // in this case the task is being polled at the moment
             let current_time_in_poll = since.duration_since(last_poll_started).unwrap();
-            return self.stats.busy.add(current_time_in_poll);
+            return self.stats.busy + current_time_in_poll;
         }
         self.stats.busy
     }

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -117,7 +117,7 @@ impl TaskView {
 
         let busy = Spans::from(vec![
             bold("Busy: "),
-            Span::from(format!("{:.prec$?}", task.busy(), prec = DUR_PRECISION,)),
+            Span::from(format!("{:.prec$?}", task.busy(now), prec = DUR_PRECISION,)),
         ]);
         let idle = Spans::from(vec![
             bold("Idle: "),

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -104,7 +104,7 @@ impl List {
                 )),
                 Cell::from(format!(
                     "{:>width$.prec$?}",
-                    task.busy(),
+                    task.busy(now),
                     width = DUR_LEN,
                     prec = DUR_PRECISION,
                 )),

--- a/proto/tasks.proto
+++ b/proto/tasks.proto
@@ -115,32 +115,39 @@ message Stats {
     // Subtracting this timestamp from `created_at` can be used to calculate the
     // time to first poll for this task, a measurement of executor latency.
     optional google.protobuf.Timestamp first_poll = 3;
-    // The timestamp of the most recent time this task was polled.
+    // The timestamp of the most recent time this task's poll method was invoked.
     //
     // If this is `None`, the task has not yet been polled.
     //
     // If the task has only been polled a single time, then this value may be
     // equal to the `first_poll` timestamp.
     //
-    // If the task has completed, then this is the time the final poll occurred.
-    optional google.protobuf.Timestamp last_poll = 4;
+    optional google.protobuf.Timestamp last_poll_started = 4;
+    // The timestamp of the most recent time this task's poll method finished execution.
+    //
+    // If this is `None`, the task has not yet been polled or is currently being polled.
+    //
+    // If the task has completed, then this is the time the final invocation of its poll
+    // method has completed.
+    optional google.protobuf.Timestamp last_poll_ended = 5;
     // The total duration this task was being *actively polled*, summed across
-    // all polls.
-    google.protobuf.Duration busy_time = 5;
+    // all polls. Note that this includes only polls that have completed and is
+    // not reflecting any inprogress polls.
+    google.protobuf.Duration busy_time = 6;
     // The amount of time this task has *existed*, regardless of whether or not
     // it was being polled.
     //
     // Subtracting `busy_time` from `total_time` calculates the task's idle
     // time, the amount of time it has spent *waiting* to be polled.
-    google.protobuf.Duration total_time = 6;
+    google.protobuf.Duration total_time = 7;
     // The total number of times this task's waker has been woken.
-    uint64 wakes = 7;
+    uint64 wakes = 8;
     // The total number of times this task's waker has been cloned.
-    uint64 waker_clones = 8;
+    uint64 waker_clones = 9;
     // The total number of times this task's waker has been dropped.
-    uint64 waker_drops = 9;
+    uint64 waker_drops = 10;
     // The timestamp of the most recent time this task has been woken.
     //
     // If this is `None`, the task has not yet been woken.
-    optional google.protobuf.Timestamp last_wake = 10;
+    optional google.protobuf.Timestamp last_wake = 11;
 }


### PR DESCRIPTION
This PR enables us to track `last_poll_started` and `last_poll_ended` times
in order to be able to correctly calculate the busy time of a task. Namely,
the busy time is the sum across all the time spent executing `poll` plus
the time we have spent so for in a poll method that has been invoked
but has not returned: 

![Screenshot 2021-07-09 at 15 09 20](https://user-images.githubusercontent.com/4391506/125077235-8affcb80-e0c9-11eb-89ab-3b269c1a9bbc.png)

Note that task 1 has been polled only ones, its polled method has not
returned and as a result of that its idle time is very low while its busy
time is close to its total time. You can test this change with the example program
provided in the issue.

fix #59

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>