### PR TITLE
console: set task poll percentile constraint to exactly 24

### DIFF
--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -81,7 +81,7 @@ impl TaskView {
             .constraints(
                 [
                     // 24 chars is long enough for the title "Poll Times Percentiles"
-                    layout::Constraint::Max(24),
+                    layout::Constraint::Length(24),
                     layout::Constraint::Min(50),
                 ]
                 .as_ref(),


### PR DESCRIPTION
With it only having a "max" of 24, if the chart needed to take up more space, it would use up all of it and the percentile window would be gone.