### PR TITLE
feat(console): factor out conn mgmt, add backoffs

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -18,3 +18,4 @@ prost-types = "0.7"
 crossterm = { version = "0.19", features = ["event-stream"] }
 color-eyre = "0.5"
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
+h2 = "0.3"

--- a/console/src/conn.rs
+++ b/console/src/conn.rs
@@ -1,0 +1,147 @@
+use console_api::tasks::{
+    tasks_client::TasksClient, DetailsRequest, TaskDetails, TaskUpdate, TasksRequest,
+};
+use futures::stream::StreamExt;
+use std::{error::Error, pin::Pin, time::Duration};
+use tonic::{transport::Channel, Streaming};
+
+#[derive(Debug)]
+pub struct Connection {
+    target: String,
+    state: State,
+}
+
+#[derive(Debug)]
+enum State {
+    Connected {
+        client: TasksClient<Channel>,
+        stream: Streaming<TaskUpdate>,
+    },
+    Disconnected(Duration),
+}
+
+impl Connection {
+    const BACKOFF: Duration = Duration::from_millis(500);
+    pub fn new(target: String) -> Self {
+        Self {
+            target,
+            state: State::Disconnected(Duration::from_secs(0)),
+        }
+    }
+
+    async fn connect(&mut self) {
+        const MAX_BACKOFF: Duration = Duration::from_secs(5);
+
+        while let State::Disconnected(backoff) = self.state {
+            if backoff == Duration::from_secs(0) {
+                tracing::debug!(to = %self.target, "connecting");
+            } else {
+                tracing::debug!(reconnect_in = ?backoff, "reconnecting");
+                tokio::time::sleep(backoff).await;
+            }
+            let try_connect = async {
+                let mut client = TasksClient::connect(self.target.clone()).await?;
+                let request = tonic::Request::new(TasksRequest {});
+                let stream = client.watch_tasks(request).await?.into_inner();
+                Ok::<State, Box<dyn Error + Send + Sync>>(State::Connected { client, stream })
+            };
+            self.state = match try_connect.await {
+                Ok(connected) => {
+                    tracing::debug!("connected successfully!");
+                    connected
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "error connecting");
+                    let backoff = std::cmp::max(backoff + Self::BACKOFF, MAX_BACKOFF);
+                    State::Disconnected(backoff)
+                }
+            };
+        }
+    }
+
+    pub async fn next_update(&mut self) -> TaskUpdate {
+        loop {
+            match self.state {
+                State::Connected { ref mut stream, .. } => match Pin::new(stream).next().await {
+                    Some(Ok(update)) => return update,
+                    Some(Err(status)) => {
+                        tracing::warn!(%status, "error from stream");
+                        self.state = State::Disconnected(Self::BACKOFF);
+                    }
+                    None => {
+                        tracing::error!("stream closed by server");
+                        self.state = State::Disconnected(Self::BACKOFF);
+                    }
+                },
+                State::Disconnected(_) => self.connect().await,
+            }
+        }
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn watch_details(
+        &mut self,
+        task_id: u64,
+    ) -> Result<Streaming<TaskDetails>, tonic::Status> {
+        loop {
+            match self.state {
+                State::Connected { ref mut client, .. } => {
+                    let request = tonic::Request::new(DetailsRequest {
+                        id: Some(task_id.into()),
+                    });
+                    match client.watch_task_details(request).await {
+                        Ok(watch) => return Ok(watch.into_inner()),
+                        // If the error is a `h2::Error`, that indicates
+                        // something went wrong at the connection level, rather
+                        // than the server returning an error code. In that
+                        // case, let's try reconnecting...
+                        Err(error) if error.source().iter().any(|src| src.is::<h2::Error>()) => {
+                            tracing::warn!(
+                                id = task_id,
+                                error = %error,
+                                "error watching task details"
+                            );
+                            self.state = State::Disconnected(Self::BACKOFF);
+                        }
+                        // Otherwise, return the error.
+                        Err(e) => return Err(e),
+                    }
+                }
+                State::Disconnected(_) => self.connect().await,
+            }
+        }
+    }
+
+    pub fn render(&self) -> tui::text::Spans {
+        use tui::{
+            style::{Color, Modifier, Style},
+            text::{Span, Spans},
+        };
+        let state = match self.state {
+            State::Connected { .. } => Span::styled(
+                "(CONNECTED)",
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .fg(Color::Green),
+            ),
+            State::Disconnected(d) if d == Duration::from_secs(0) => Span::styled(
+                "(CONNECTING)",
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .fg(Color::Yellow),
+            ),
+            State::Disconnected(d) => Span::styled(
+                format!("(RECONNECTING IN {:?})", d),
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .fg(Color::Yellow),
+            ),
+        };
+        Spans::from(vec![
+            Span::raw("connection: "),
+            Span::raw(self.target.clone()),
+            Span::raw(" "),
+            state,
+        ])
+    }
+}

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -1,30 +1,23 @@
 use color_eyre::{eyre::eyre, Help, SectionExt};
-use console_api::tasks::{
-    tasks_client::TasksClient, DetailsRequest, TaskDetails, TaskUpdate, TasksRequest,
-};
-use futures::stream::StreamExt;
+use console_api::tasks::TaskDetails;
 use tasks::State;
 
+use futures::stream::StreamExt;
 use tokio::sync::{mpsc, watch};
-use tonic::transport::Channel;
 use tui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Span, Spans},
     widgets::{Block, Paragraph, Wrap},
 };
 
 use crate::view::UpdateKind;
 
+mod conn;
 mod input;
 mod tasks;
 mod term;
 mod view;
-
-enum ConnectionState {
-    Connected,
-    Disconnected,
-}
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
@@ -39,9 +32,7 @@ async fn main() -> color_eyre::Result<()> {
 
     let (mut terminal, _cleanup) = term::init_crossterm()?;
     terminal.clear()?;
-    let mut stream: Option<tonic::Streaming<TaskUpdate>> = None;
-    let mut client: Option<TasksClient<Channel>> = None;
-    let mut connection_state: Option<ConnectionState> = None;
+    let mut conn = conn::Connection::new(target);
     // A channel to send the outcome of `View::update_input` to the watch_details_stream task.
     let (update_tx, update_rx) = watch::channel(UpdateKind::Other);
     // A channel to send the task details update stream (no need to keep outdated details in the memory)
@@ -65,49 +56,20 @@ async fn main() -> color_eyre::Result<()> {
                 let _ = update_tx.send(update_kind);
                 match update_kind {
                     UpdateKind::SelectTask(task_id) => {
-                        tokio::spawn(watch_details_stream(task_id, client.clone(), update_rx.clone(), details_tx.clone()));
-                    }
+                        match conn.watch_details(task_id).await {
+                            Ok(stream) => {
+                                tokio::spawn(watch_details_stream(task_id, stream, update_rx.clone(), details_tx.clone()));
+                            },
+                            Err(error) => {tracing::warn!(%error, "error watching task details"); tasks.unset_task_details();}
+                        }
+                    },
                     UpdateKind::ExitTaskView => {
                         tasks.unset_task_details();
                     }
                     _ => {}
                 }
             },
-            connection = connect(target.clone(), connection_state.is_some()), if stream.is_none() => {
-                match connection {
-                    Ok((s, c)) => {
-                        stream = Some(s);
-                        client = Some(c);
-                        connection_state = Some(ConnectionState::Connected);
-                    },
-                    Err(err) => {
-                        tracing::error!(%err, "connection unsuccessful");
-                        stream = None;
-                        client = None;
-                    }
-                }
-            },
-            task_update = async { match stream.as_mut() {
-                Some(s) => s.next().await,
-                None => None,
-            }}, if stream.is_some() => {
-                match task_update {
-                    Some(Ok(update)) => {
-                        tasks.update_tasks(update);
-                    },
-                    Some(Err(status)) => {
-                        tracing::error!(%status, "error from stream");
-                        stream = None;
-                        connection_state = Some(ConnectionState::Disconnected);
-                    },
-                    None => {
-                        tracing::error!("stream closed by server");
-                        stream = None;
-                        connection_state = Some(ConnectionState::Disconnected);
-                    }
-
-                }
-            },
+            task_update = conn.next_update() => tasks.update_tasks(task_update),
             details_update = details_rx.recv() => {
                 if let Some(details_update) = details_update {
                     tasks.update_task_details(details_update);
@@ -121,21 +83,7 @@ async fn main() -> color_eyre::Result<()> {
                 .constraints([Constraint::Length(2), Constraint::Percentage(95)].as_ref())
                 .split(f.size());
 
-            let header_block = Block::default().title(vec![
-                Span::raw(format!("connection: {} ", target)),
-                match connection_state {
-                    Some(ConnectionState::Connected) => Span::styled(
-                        "(CONNECTED)",
-                        Style::default()
-                            .add_modifier(Modifier::BOLD)
-                            .fg(Color::Green),
-                    ),
-                    Some(ConnectionState::Disconnected) | None => Span::styled(
-                        "(DISCONNECTED)",
-                        Style::default().add_modifier(Modifier::BOLD).fg(Color::Red),
-                    ),
-                },
-            ]);
+            let header_block = Block::default().title(conn.render());
 
             let text = vec![Spans::from(vec![
                 Span::styled(
@@ -153,21 +101,7 @@ async fn main() -> color_eyre::Result<()> {
     }
 }
 
-async fn connect(
-    target: String,
-    is_reconnect: bool,
-) -> Result<(tonic::Streaming<TaskUpdate>, TasksClient<Channel>), Box<dyn std::error::Error>> {
-    if is_reconnect {
-        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-    }
-
-    let mut client = TasksClient::connect(target).await?;
-    let request = tonic::Request::new(TasksRequest {});
-    let rsp = client.watch_tasks(request).await?;
-    Ok((rsp.into_inner(), client))
-}
-
-/// Connects to the task details stream for the given task id, sends the updates
+/// Given the task details stream for the given task id, sends the updates
 /// to the `details_tx` channel until the currently-viewed task changes.
 ///
 /// This is a separate task from the main program loop mainly because there isn't
@@ -175,49 +109,39 @@ async fn connect(
 /// replace the details stream with another one.
 async fn watch_details_stream(
     task_id: u64,
-    mut client: Option<TasksClient<Channel>>,
+    mut details_stream: tonic::Streaming<TaskDetails>,
     mut watch_rx: watch::Receiver<UpdateKind>,
     details_tx: mpsc::Sender<TaskDetails>,
 ) {
-    let request = tonic::Request::new(DetailsRequest {
-        id: Some(task_id.into()),
-    });
-    if let Some(c) = client.as_mut() {
-        if let Ok(streaming) = c.watch_task_details(request).await {
-            let mut details_stream = streaming.into_inner();
-            loop {
-                tokio::select! { biased;
-                    details = details_stream.next() => {
-                        match details {
-                            Some(Ok(details)) => {
-                                if details_tx.send(details).await.is_err() {
-                                    break;
-                                }
-                            },
-                            _ => {
-                                break;
-                            }
-                        }
-                    },
-                    update = watch_rx.changed() => {
-                        if update.is_ok() {
-                            match *watch_rx.borrow() {
-                                UpdateKind::ExitTaskView => {
-                                    break;
-                                },
-                                UpdateKind::SelectTask(new_id) if new_id != task_id => {
-                                    break;
-                                },
-                                _ => {}
-                            }
-                        } else {
+    loop {
+        tokio::select! { biased;
+            details = details_stream.next() => {
+                match details {
+                    Some(Ok(details)) => {
+                        if details_tx.send(details).await.is_err() {
                             break;
                         }
                     },
+                    _ => {
+                        break;
+                    }
                 }
-            }
-        } else {
-            // TODO: handle connection error, print details somewhere? Related to Issue #30
+            },
+            update = watch_rx.changed() => {
+                if update.is_ok() {
+                    match *watch_rx.borrow() {
+                        UpdateKind::ExitTaskView => {
+                            break;
+                        },
+                        UpdateKind::SelectTask(new_id) if new_id != task_id => {
+                            break;
+                        },
+                        _ => {}
+                    }
+                } else {
+                    break;
+                }
+            },
         }
     }
 }


### PR DESCRIPTION
This branch factors out the connection state management (reconnects)
into a new module, so it's not part of `main`. Additionally, it adds a
simple backoff on connection errors.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>