### PR TITLE
feat(subscriber): support multiple task callsites

### DIFF
--- a/console-subscriber/src/callsites.rs
+++ b/console-subscriber/src/callsites.rs
@@ -1,0 +1,51 @@
+use std::{
+    ptr,
+    sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
+};
+use tracing_core::Metadata;
+
+#[derive(Debug, Default)]
+pub(crate) struct Callsites {
+    // In practice each of these will have like, 1-5 callsites in it, max, so
+    // 32 is probably fine...if it ever becomes not fine, we'll fix that.
+    ptrs: [AtomicPtr<Metadata<'static>>; 32],
+    len: AtomicUsize,
+}
+
+impl Callsites {
+    #[track_caller]
+    pub(crate) fn insert(&self, callsite: &'static Metadata<'static>) {
+        // The callsite may already have been inserted, if the callsite cache
+        // was invalidated and is being rebuilt. In that case, don't insert it
+        // again.'
+        if self.contains(callsite) {
+            return;
+        }
+
+        let idx = self.len.fetch_add(1, Ordering::AcqRel);
+        assert!(
+            idx < 64,
+            "you tried to store more than 64 callsites, \
+            time to make the callsite sets bigger i guess \
+            (please open an issue for this)"
+        );
+        self.ptrs[idx]
+            .compare_exchange(
+                ptr::null_mut(),
+                callsite as *const _ as *mut _,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .expect("a callsite would have been clobbered by `insert` (this is a bug)");
+    }
+
+    pub(crate) fn contains(&self, callsite: &'static Metadata<'static>) -> bool {
+        let len = self.len.load(Ordering::Acquire);
+        for cs in &self.ptrs[..len + 1] {
+            if ptr::eq(cs.load(Ordering::Acquire), callsite) {
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -56,7 +56,7 @@ impl TaskView {
             .constraints(
                 [
                     layout::Constraint::Length(1),
-                    layout::Constraint::Length(6),
+                    layout::Constraint::Length(7),
                     layout::Constraint::Length(9),
                     layout::Constraint::Percentage(60),
                 ]
@@ -102,6 +102,7 @@ impl TaskView {
         ]);
 
         let attrs = Spans::from(vec![bold("ID: "), Span::raw(task.id_hex())]);
+        let target = Spans::from(vec![bold("Target: "), Span::raw(task.target())]);
 
         let mut total = vec![
             bold("Total Time: "),
@@ -124,7 +125,7 @@ impl TaskView {
             Span::from(format!("{:.prec$?}", task.idle(now), prec = DUR_PRECISION,)),
         ]);
 
-        let metrics = vec![attrs, total, busy, idle];
+        let metrics = vec![attrs, target, total, busy, idle];
 
         let wakers = Spans::from(vec![
             bold("Current wakers: "),

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -20,8 +20,9 @@ pub(crate) struct List {
 }
 
 impl List {
-    const HEADER: &'static [&'static str] =
-        &["TID", "KIND", "TOTAL", "BUSY", "IDLE", "POLLS", "FIELDS"];
+    const HEADER: &'static [&'static str] = &[
+        "TID", "KIND", "TOTAL", "BUSY", "IDLE", "POLLS", "TARGET", "FIELDS",
+    ];
 
     pub(crate) fn update_input(&mut self, event: input::Event) {
         // Clippy likes to remind us that we could use an `if let` here, since
@@ -83,6 +84,7 @@ impl List {
         // there's room for the unit!)
         const DUR_PRECISION: usize = 4;
         const POLLS_LEN: usize = 5;
+        const MIN_TARGET_LEN: usize = 15;
 
         self.sorted_tasks.extend(state.take_new_tasks());
         self.sort_by.sort(now, &mut self.sorted_tasks);
@@ -115,6 +117,7 @@ impl List {
                     prec = DUR_PRECISION,
                 )),
                 Cell::from(format!("{:>width$}", task.total_polls(), width = POLLS_LEN)),
+                Cell::from(task.target().to_owned()),
                 Cell::from(Spans::from(
                     task.formatted_fields()
                         .iter()
@@ -169,6 +172,7 @@ impl List {
                 layout::Constraint::Min(DUR_LEN as u16),
                 layout::Constraint::Min(DUR_LEN as u16),
                 layout::Constraint::Min(POLLS_LEN as u16),
+                layout::Constraint::Min(MIN_TARGET_LEN as u16),
                 layout::Constraint::Min(10),
             ])
             .highlight_symbol(">> ")


### PR DESCRIPTION
This branch updates the console subscriber to allow recording multiple
`tracing` span callsites as tasks, rather than only tracking the first
callsite that's found. This will allow collecting data from multiple
runtimes, and also removes the requirement that all task spans originate
from a single callsite, which will make implementing runtime
instrumentation simpler.

This is implemented by adding a new data structure for storing a set of
callsites. It's implemented as an array of `AtomicPtr`s to metadata,
plus an `AtomicUsize` tracking the next index to push to. As callsites
are registered, their addresses are stored at the push index, which is
incremented. When testing if a callsite is in the set, the subscriber
performs a linear scan over the pushed callsites.

A linear scan over an array is not *algorithmically* optimal, but in
practice, it is probably the best data structure here. Although the
algorithmic complexity of doing a linear scan is O(_n_), and using a
`HashSet` or something is O(1), there are never going to be a great deal
of items in the array --- in many programs, each callsite list will only
ever have a single entry, and in extreme cases, like when using `tokio`,
`rayon`, and `async-std` in the same program, there might be four or
five entries. So, the cost of an O(_n_) linear scan over a very small
_n_ slice is likely much lower than the constant-factor costs of using
an O(1) `HashSet` in this case. Also, the array allows us to avoid using
a lock, or introducing the additional overhead of a concurrent hash set.

The same data structure is used to track waker op callsites, so we can
now avoid doing string comparisons to detect those callsites.

In addition, I've updated the console to display the metadata targets of
tasks. This is useful because tasks may now be recorded from callsites
in different libraries, or in different modules of one library (e.g.
tokio's task, blocking task, and local task spans could now have
separate callsites). The targets can be used to distinguish between
different task span locations.

Here's a screenshot showing a demo app that uses `tokio`'s normal _and_
blocking tasks, alongside a (work in progress) version of `rayon` with
console instrumentation:
![image](https://user-images.githubusercontent.com/2796466/125658047-aabf85ea-aa1f-485a-8e55-5c8ef67168fd.png)
