### PR TITLE
feat(console): color durations based on units 

### DIFF
--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -122,3 +122,21 @@ impl Default for View {
 pub(crate) fn bold<'a>(text: impl Into<Cow<'a, str>>) -> Span<'a> {
     Span::styled(text, Style::default().add_modifier(style::Modifier::BOLD))
 }
+
+pub(crate) fn color_time_units<'a>(text: impl Into<Cow<'a, str>>) -> Span<'a> {
+    use tui::style::Color::Indexed;
+    let text = text.into();
+    let style = match text.as_ref() {
+        s if s.ends_with("ps") => fg_style(Indexed(40)), // green 3
+        s if s.ends_with("ns") => fg_style(Indexed(41)), // spring green 3
+        s if s.ends_with("μs") || s.ends_with("us") => fg_style(Indexed(42)), // spring green 2
+        s if s.ends_with("ms") => fg_style(Indexed(43)), // cyan 3
+        s if s.ends_with('s') => fg_style(Indexed(44)),  // dark turquoise,
+        _ => Style::default(),
+    };
+    Span::styled(text, style)
+}
+
+fn fg_style(color: style::Color) -> Style {
+    Style::default().fg(color)
+}

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -129,7 +129,7 @@ pub(crate) fn color_time_units<'a>(text: impl Into<Cow<'a, str>>) -> Span<'a> {
     let style = match text.as_ref() {
         s if s.ends_with("ps") => fg_style(Indexed(40)), // green 3
         s if s.ends_with("ns") => fg_style(Indexed(41)), // spring green 3
-        s if s.ends_with("μs") || s.ends_with("us") => fg_style(Indexed(42)), // spring green 2
+        s if s.ends_with("µs") || s.ends_with("us") => fg_style(Indexed(42)), // spring green 2
         s if s.ends_with("ms") => fg_style(Indexed(43)), // cyan 3
         s if s.ends_with('s') => fg_style(Indexed(44)),  // dark turquoise,
         _ => Style::default(),

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -2,7 +2,7 @@ use crate::{
     input,
     tasks::{Details, DetailsRef, Task},
     view::{
-        bold,
+        self, bold,
         mini_histogram::{HistogramMetadata, MiniHistogram},
     },
 };
@@ -21,8 +21,6 @@ pub(crate) struct TaskView {
     task: Rc<RefCell<Task>>,
     details: DetailsRef,
 }
-
-const DUR_PRECISION: usize = 4;
 
 impl TaskView {
     pub(super) fn new(task: Rc<RefCell<Task>>, details: DetailsRef) -> Self {
@@ -104,10 +102,7 @@ impl TaskView {
         let attrs = Spans::from(vec![bold("ID: "), Span::raw(task.id_hex())]);
         let target = Spans::from(vec![bold("Target: "), Span::raw(task.target())]);
 
-        let mut total = vec![
-            bold("Total Time: "),
-            Span::from(format!("{:.prec$?}", task.total(now), prec = DUR_PRECISION,)),
-        ];
+        let mut total = vec![bold("Total Time: "), dur(task.total(now))];
 
         // TODO(eliza): maybe surface how long the task has been completed, as well?
         if task.is_completed() {
@@ -116,14 +111,8 @@ impl TaskView {
 
         let total = Spans::from(total);
 
-        let busy = Spans::from(vec![
-            bold("Busy: "),
-            Span::from(format!("{:.prec$?}", task.busy(now), prec = DUR_PRECISION,)),
-        ]);
-        let idle = Spans::from(vec![
-            bold("Idle: "),
-            Span::from(format!("{:.prec$?}", task.idle(now), prec = DUR_PRECISION,)),
-        ]);
+        let busy = Spans::from(vec![bold("Busy: "), dur(task.busy(now))]);
+        let idle = Spans::from(vec![bold("Idle: "), dur(task.idle(now))]);
 
         let metrics = vec![attrs, target, total, busy, idle];
 
@@ -253,15 +242,19 @@ impl Details {
             pairs.map(|pair| {
                 Spans::from(vec![
                     bold(format!("p{:>2}: ", pair.0)),
-                    Span::from(format!(
-                        "{:.prec$?}",
-                        Duration::from_nanos(pair.1),
-                        prec = DUR_PRECISION,
-                    )),
+                    dur(Duration::from_nanos(pair.1)),
                 ])
             })
         });
         text.extend(percentiles);
         text
     }
+}
+
+fn dur(dur: std::time::Duration) -> Span<'static> {
+    const DUR_PRECISION: usize = 4;
+    // TODO(eliza): can we not have to use `format!` to make a string here? is
+    // there a way to just give TUI a `fmt::Debug` implementation, or does it
+    // have to be given a string in order to do layout stuff?
+    view::color_time_units(format!("{:.prec$?}", dur, prec = DUR_PRECISION))
 }


### PR DESCRIPTION
This branch adds color-coding for durations based on their unit, as
described in #71. The colors are a simple gradient, from picoseconds to
whole seconds.

Currently, the unit is detected by formatting the value using the
`fmt::Debug` impl for `Duration`, and looking at the last two characters
to determine the unit. Admittedly, this is kind of janky, but it seemed
like re-implementing all of the `Duration` formatting logic would be
worse.

Right now, this assumes the terminal supports the ANSI 256-color
palette. I'm working on an additional change to detect what color
palettes the terminal supports and select colors based on that, but I
figured I'd do that in a separate PR.

Here's a little example screenshot:

![image](https://user-images.githubusercontent.com/2796466/126686509-e5fe37f7-82e7-422e-a486-c8d60e97ed6a.png)
