### PR TITLE
Add pause and resume

### DIFF
--- a/console/src/input.rs
+++ b/console/src/input.rs
@@ -21,3 +21,13 @@ pub fn should_quit(input: &Event) -> bool {
         _ => false,
     }
 }
+
+pub(crate) fn is_space(input: &Event) -> bool {
+    matches!(
+        input,
+        Event::Key(KeyEvent {
+            code: KeyCode::Char(' '),
+            ..
+        })
+    )
+}

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -7,6 +7,8 @@ use futures::stream::StreamExt;
 use tokio::sync::{mpsc, watch};
 use tui::{
     layout::{Constraint, Direction, Layout},
+    style::Color,
+    text::Span,
     widgets::{Paragraph, Wrap},
 };
 
@@ -52,6 +54,17 @@ async fn main() -> color_eyre::Result<()> {
                 if input::should_quit(&input) {
                     return Ok(());
                 }
+
+                if input::is_space(&input) {
+                    if tasks.is_paused() {
+                        conn.resume().await;
+                        tasks.resume();
+                    } else {
+                        conn.pause().await;
+                        tasks.pause();
+                    }
+                }
+
                 let update_kind = view.update_input(input, &tasks);
                 // Using the result of update_input to manage the details watcher task
                 let _ = update_tx.send(update_kind);
@@ -84,7 +97,13 @@ async fn main() -> color_eyre::Result<()> {
                 .constraints([Constraint::Length(1), Constraint::Percentage(95)].as_ref())
                 .split(f.size());
 
-            let header = Paragraph::new(conn.render(&view.styles)).wrap(Wrap { trim: true });
+            let mut header_text = conn.render(&view.styles);
+            if tasks.is_paused() {
+                header_text
+                    .0
+                    .push(Span::styled(" PAUSED", view.styles.fg(Color::Red)));
+            }
+            let header = Paragraph::new(header_text).wrap(Wrap { trim: true });
             f.render_widget(header, chunks[0]);
             view.render(f, chunks[1], &mut tasks);
         })?;

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -23,6 +23,13 @@ pub(crate) struct State {
     last_updated_at: Option<SystemTime>,
     new_tasks: Vec<TaskRef>,
     current_task_details: DetailsRef,
+    temporality: Temporality,
+}
+
+#[derive(Debug)]
+enum Temporality {
+    Live,
+    Paused,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -238,6 +245,20 @@ impl State {
             task.completed_for <= Self::RETAIN_COMPLETED_FOR
         })
     }
+
+    // temporality methods
+
+    pub(crate) fn pause(&mut self) {
+        self.temporality = Temporality::Paused;
+    }
+
+    pub(crate) fn resume(&mut self) {
+        self.temporality = Temporality::Live;
+    }
+
+    pub(crate) fn is_paused(&self) -> bool {
+        matches!(self.temporality, Temporality::Paused)
+    }
 }
 
 impl Task {
@@ -410,6 +431,12 @@ impl From<proto::field::Value> for FieldValue {
             proto::field::Value::U64Val(v) => Self::U64(v),
             proto::field::Value::DebugVal(v) => Self::Debug(v),
         }
+    }
+}
+
+impl Default for Temporality {
+    fn default() -> Self {
+        Self::Live
     }
 }
 

--- a/proto/tasks.proto
+++ b/proto/tasks.proto
@@ -9,6 +9,8 @@ import "common.proto";
 service Tasks {
     rpc WatchTasks(TasksRequest) returns (stream TaskUpdate) {}
     rpc WatchTaskDetails(DetailsRequest) returns (stream TaskDetails) {}
+    rpc Pause(PauseRequest) returns (PauseResponse) {}
+    rpc Resume(ResumeRequest) returns (ResumeResponse) {}
 }
 
 message TaskId {
@@ -20,6 +22,12 @@ message TasksRequest {
 
 message DetailsRequest {
     TaskId id = 1;
+}
+
+message PauseRequest {
+}
+
+message ResumeRequest {
 }
 
 // A task state update.
@@ -62,6 +70,12 @@ message TaskDetails {
 
     // HdrHistogram.rs `Histogram` serialized to binary in the V2 format
     optional bytes poll_times_histogram = 3;
+}
+
+message PauseResponse {
+}
+
+message ResumeResponse {
 }
 
 // Data recorded when a new task is spawned.


### PR DESCRIPTION
A first step to address #70. You can now press the spacebar to "pause" the console. The subscriber will continue to process events, but as along as the client is "paused", it won't send any task updates. Resuming will bring the client back to "live", getting all updates again.

![paused](https://user-images.githubusercontent.com/51479/127583646-0cb879c9-0fb7-4025-90c8-4edee8c3e08d.PNG)

I've tried a few different UI things, from making the whole background of the top red, to just making the word red... It's fine if others feel there's a better or prettier way to show this, but to keep moving forward, I just picked something that seemed good enough.

Closes #85 