### PR TITLE
feat(console): programmatically determine column widths

### DIFF
--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -1,5 +1,5 @@
 use crate::{input, tasks::State};
-use std::borrow::Cow;
+use std::{borrow::Cow, cmp};
 use tui::{
     layout,
     style::{self, Style},
@@ -21,6 +21,7 @@ pub struct View {
     list: tasks::List,
     state: ViewState,
 }
+
 enum ViewState {
     /// The table list of all tasks.
     TasksList,
@@ -37,6 +38,11 @@ pub(crate) enum UpdateKind {
     ExitTaskView,
     /// No significant change
     Other,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Width {
+    curr: u16,
 }
 
 macro_rules! key {
@@ -139,4 +145,20 @@ pub(crate) fn color_time_units<'a>(text: impl Into<Cow<'a, str>>) -> Span<'a> {
 
 fn fg_style(color: style::Color) -> Style {
     Style::default().fg(color)
+}
+
+impl Width {
+    pub(crate) fn new(curr: u16) -> Self {
+        Self { curr }
+    }
+
+    pub(crate) fn update_str<S: AsRef<str>>(&mut self, s: S) -> S {
+        let len = s.as_ref().len();
+        self.curr = cmp::max(self.curr, len as u16);
+        s
+    }
+
+    pub(crate) fn constraint(&self) -> layout::Constraint {
+        layout::Constraint::Length(self.curr)
+    }
 }


### PR DESCRIPTION
Currently, we use hard-coded fixed character widths for all columns in the
console's task list view. This works fine for time values, which are
displayed as decimals with fixed maximum precision. However, for other
stuff (such as targets and task IDs), the length can vary widely, and
space is often wasted when all values are shorter than the hard-coded
max width.

This branch updates the console to compute the maximum number of
characters needed to display the longest entry in a column every time it
draws the table, and use exactly that many characters. Therefore, we
waste significantly fewer chars on making the table columns long enough
to display "any reasonable value".

I was a bit concerned that resizing these columns would potentially be
visually disruptive and make the table harder to read. Testing it out in
the demo app, the resizing isn't really noticeable...or at least, it
didn't bother *me*. If anyone else wants to try this branch out and let
me know if they find it really disruptive, I'd appreciate that. It would
be fine to not move forward with this change if it hurts the readability
of the table.