### PR TITLE
feat(console): truncate paths for libs from cargo

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -19,3 +19,5 @@ crossterm = { version = "0.20", features = ["event-stream"] }
 color-eyre = "0.5"
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
 h2 = "0.3"
+regex = "1.5"
+once_cell = "1.8"


### PR DESCRIPTION
This branch updates the console to truncate fields named
`spawn.location` when formatting fields on task spans, if the field's
value is a path in the Cargo registry.

Paths in the Cargo registry tend to look like this:
```
/home/eliza/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.9.0/src/runtime/basic_scheduler.rs:157:24
```
We perform the truncation using a regular expression matching strings
beginning with a `/` and accepting up to the string
`/.cargo/registry/src`, followed by one additional path
segment for the `github.com-<SHA>` part. The first match found in the
string is replaced with the string `<cargo>`, so that it's clear the
path is in the Cargo registry.

This could, alternatively, have been implemented by parsing the paths to
a `std::path::Path` and actually inspecting path segments. This might be
more *semantically* correct than using a regex. However, the issue here
is that the paths in the `spawn.location` field are generated in the
environment where the instrumented program is _compiled_, rather than in
the environment where the console application is running. This might,
for example, be on an OS with a different path separator, and
`std::path::Path` defaults to using the system's path separator. We
could work around this, theoretically, but the regex seemed much
simpler.

### Before:
![image](https://user-images.githubusercontent.com/2796466/128218221-71c7ec6c-303f-448c-8374-eef0785ab1c3.png)

### After:
![image](https://user-images.githubusercontent.com/2796466/128218996-3051d861-4c05-4df7-aa65-c7f4dfdf09a3.png)
(note the `spawn.location` fields from `hyper`).

Closes #74