### PR TITLE
fix(console): stop truncating task fields column

### DIFF
--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -161,4 +161,8 @@ impl Width {
     pub(crate) fn constraint(&self) -> layout::Constraint {
         layout::Constraint::Length(self.curr)
     }
+
+    pub(crate) fn chars(&self) -> u16 {
+        self.curr
+    }
 }

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -84,6 +84,7 @@ impl List {
         // there's room for the unit!)
         const DUR_PRECISION: usize = 4;
         const POLLS_LEN: usize = 5;
+        const KIND_LEN: u16 = 4;
 
         self.sorted_tasks.extend(state.take_new_tasks());
         self.sort_by.sort(now, &mut self.sorted_tasks);
@@ -162,15 +163,29 @@ impl List {
         } else {
             Table::new(rows.rev())
         };
+
+        // How many characters wide are the fixed-length non-field columns?
+        let fixed_col_width = id_width.chars()
+            + KIND_LEN
+            + DUR_LEN as u16
+            + DUR_LEN as u16
+            + DUR_LEN as u16
+            + POLLS_LEN as u16
+            + target_width.chars();
+        // Fill all remaining characters in the frame with the task's fields.
+        // TODO(eliza): there's gotta be a nicer way to do this in `tui`...what
+        // we want is really just a constraint that says "always use all the
+        // characters remaining".
+        let fields_width = frame.size().width - fixed_col_width;
         let widths = &[
             id_width.constraint(),
-            layout::Constraint::Length(4),
-            layout::Constraint::Min(DUR_LEN as u16),
-            layout::Constraint::Min(DUR_LEN as u16),
-            layout::Constraint::Min(DUR_LEN as u16),
-            layout::Constraint::Min(POLLS_LEN as u16),
+            layout::Constraint::Length(KIND_LEN),
+            layout::Constraint::Length(DUR_LEN as u16),
+            layout::Constraint::Length(DUR_LEN as u16),
+            layout::Constraint::Length(DUR_LEN as u16),
+            layout::Constraint::Length(POLLS_LEN as u16),
             target_width.constraint(),
-            layout::Constraint::Min(10),
+            layout::Constraint::Min(fields_width),
         ];
         let t = t
             .header(header)


### PR DESCRIPTION
Currently, there's a bug where the console's task list view truncates
the fields column to the first ten characters, even when there are
characters remaining in the window to display more of the fields column.
This is due to `tui`'s layout constraints system apparently choosing to
give that column only the minimum number of characters specified,
instead of giving it all the remaining characters not used by other
columns.

I couldn't figure out how to get `tui` to actually do what we want
(there doesn't seem to be a `Constrait` for saying "use any remaining
characters not needed for satisfying previous layout constraints"), so I
just kind of hacked around it by adding up all the other columns,
subtracting their widths from the total width of the window, and
specifying that as a "minimum" constraint.

This is kinda ugly, but it seems to work.

### Before:
![image](https://user-images.githubusercontent.com/2796466/128217907-81ec6ed0-2282-4c7a-98b2-6773dd4888f5.png)

### After:
![image](https://user-images.githubusercontent.com/2796466/128218221-71c7ec6c-303f-448c-8374-eef0785ab1c3.png)


Signed-off-by: Eliza Weisman <eliza@buoyant.io>