### PR TITLE
stop rendering empty fields, refactor field conversion

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -19,3 +19,5 @@ crossterm = { version = "0.20", features = ["event-stream"] }
 color-eyre = "0.5"
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
 h2 = "0.3"
+regex = "1.5"
+once_cell = "1.8"

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -57,6 +57,7 @@ pub(crate) struct Details {
 pub(crate) struct Metadata {
     field_names: Vec<Arc<str>>,
     target: Arc<str>,
+    id: u64,
     //TODO: add more metadata as needed
 }
 
@@ -123,7 +124,7 @@ impl State {
             let metas = new_metadata.metadata.into_iter().filter_map(|meta| {
                 let id = meta.id?.id;
                 let metadata = meta.metadata?;
-                Some((id, metadata.into()))
+                Some((id, Metadata::from_proto(metadata, id)))
             });
             self.metas.extend(metas);
         }
@@ -156,44 +157,11 @@ impl State {
                     return None;
                 }
             };
-            let fields: Vec<Field> = task
+            let fields = task
                 .fields
                 .drain(..)
-                .filter_map(|f| {
-                    let field_name = f.name.as_ref()?;
-                    let name: Arc<str> = match field_name {
-                        proto::field::Name::StrName(n) => n.clone().into(),
-                        proto::field::Name::NameIdx(idx) => {
-                            debug_assert_eq!(
-                                f.metadata_id.map(|m| m.id),
-                                Some(meta_id),
-                                "malformed field name: metadata ID mismatch!"
-                            );
-                            let name = meta.field_names.get(*idx as usize).cloned();
-                            if name.is_none() {
-                                tracing::warn!(index = idx, "missing field name for");
-                            };
-                            name?
-                        }
-                    };
-
-                    let value = f.value;
-                    debug_assert!(
-                        value.is_some(),
-                        "missing field value for field `{:?}`",
-                        name
-                    );
-                    let mut value = FieldValue::from(value?)
-                        // if the value is an empty string, just skip it.
-                        .ensure_nonempty()?;
-
-                    if &*name == "spawn.location" {
-                        value = value.truncate_registry_path();
-                    }
-
-                    Some(Field { name, value })
-                })
-                .collect();
+                .filter_map(|pb| Field::from_proto(pb, meta))
+                .collect::<Vec<_>>();
 
             let formatted_fields = fields.iter().fold(Vec::default(), |mut acc, f| {
                 acc.push(vec![
@@ -407,11 +375,12 @@ impl From<proto::tasks::Stats> for Stats {
     }
 }
 
-impl From<proto::Metadata> for Metadata {
-    fn from(pb: proto::Metadata) -> Self {
+impl Metadata {
+    fn from_proto(pb: proto::Metadata, id: u64) -> Self {
         Self {
             field_names: pb.field_names.into_iter().map(|n| n.into()).collect(),
             target: pb.target.into(),
+            id,
         }
     }
 }
@@ -468,6 +437,81 @@ impl TryFrom<usize> for SortBy {
         }
     }
 }
+
+// === impl Field ===
+
+impl Field {
+    /// Converts a wire-format `Field` into an internal `Field` representation,
+    /// using the provided `Metadata` for the task span that the field came
+    /// from.
+    ///
+    /// If the field is invalid or it has a string value which is empty, this
+    /// returns `None`.
+    fn from_proto(
+        proto::Field {
+            name,
+            metadata_id,
+            value,
+        }: proto::Field,
+        meta: &Metadata,
+    ) -> Option<Self> {
+        use proto::field::Name;
+        let name: Arc<str> = match name? {
+            Name::StrName(n) => n.into(),
+            Name::NameIdx(idx) => {
+                let meta_id = metadata_id.map(|m| m.id);
+                if meta_id != Some(meta.id) {
+                    tracing::warn!(
+                        task.meta_id = meta.id,
+                        field.meta.id = ?meta_id,
+                        field.name_index = idx,
+                        ?meta,
+                        "skipping malformed field name (metadata id mismatch)"
+                    );
+                    debug_assert_eq!(
+                        meta_id,
+                        Some(meta.id),
+                        "malformed field name: metadata ID mismatch! (name idx={}; metadata={:#?})",
+                        idx,
+                        meta,
+                    );
+                    return None;
+                }
+                match meta.field_names.get(idx as usize).cloned() {
+                    Some(name) => name,
+                    None => {
+                        tracing::warn!(
+                            task.meta_id = meta.id,
+                            field.meta.id = ?meta_id,
+                            field.name_index = idx,
+                            ?meta,
+                            "missing field name for index"
+                        );
+                        return None;
+                    }
+                }
+            }
+        };
+
+        debug_assert!(
+            value.is_some(),
+            "missing field value for field `{:?}` (metadata={:#?})",
+            name,
+            meta,
+        );
+        let mut value = FieldValue::from(value?)
+            // if the value is an empty string, just skip it.
+            .ensure_nonempty()?;
+
+        if &*name == "spawn.location" {
+            value = value.truncate_registry_path();
+        }
+
+        Some(Self { name, value })
+    }
+}
+
+// === impl FieldValue ===
 
 impl fmt::Display for FieldValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Depends on #81 (since it touches the same code and would cause merge conflicts).

* feat(console): don't display fields with "" values

Now that Tokio supports optional user-provided task names
(in tokio-rs/tokio#3881), the task spans it generates may contain empty
fields (if the user does not provide a name for a spawned task).
However, the console always displays the `task.name` field, even when
they are empty. This wastes space, and looks kind of ugly.

This branch updates the console to skip displaying fields whose value is
the empty string.

### Before:
![image](https://user-images.githubusercontent.com/2796466/128227118-7ee3b4d7-634f-410f-a1d0-4e5afd423566.png)

### After:
![image](https://user-images.githubusercontent.com/2796466/128227203-248bd059-839a-4254-8470-2761f726c885.png)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

* refac(console): factor out field from pb conversion

This factors out the protobuf `Field` -> internal `Field` conversion
into a method, and cleans it up a bit. No functional change, except that
we now take the proto `Field` type by value, so we don't have to clone
strings out of it like we did previously (due to taking it by
reference). I also added the metadata ID to the `Metadata` type, so that
we can continue asserting that the metadata's ID matches the expected
one for the field, without having to pass that in separately.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>


