### PR TITLE
subscriber: add ability to record events to a file

### DIFF
--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -17,6 +17,8 @@ tracing = "0.1.26"
 tracing-subscriber = { version = "0.2.17", default-features = false, features = ["fmt", "registry", "env-filter"] }
 futures = { version = "0.3", default-features = false }
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 

--- a/console-subscriber/src/init.rs
+++ b/console-subscriber/src/init.rs
@@ -27,6 +27,7 @@ type ConsoleSubscriberLayer = Layered<TasksLayer, Layered<EnvFilter, Registry>>;
 /// | `TOKIO_CONSOLE_RETENTION_SECS`      | The number of seconds to accumulate completed tracing data                | 3600s (1h)        |
 /// | `TOKIO_CONSOLE_BIND`                | A HOST:PORT description, such as `localhost:1234`                         | `127.0.0.1:6669`  |
 /// | `TOKIO_CONSOLE_PUBLISH_INTERVAL_MS` | The number of milliseconds to wait between sending updates to the console | 1000ms (1s)       |
+/// | `TOKIO_CONSOLE_RECORD_PATH`         | The file path to save a recording                                         | None              |
 /// | `RUST_LOG`                          | Configure the tracing filter. See [`EnvFilter`] for further information   | `tokio=trace`     |
 ///
 /// ## Further customization

--- a/console-subscriber/src/record.rs
+++ b/console-subscriber/src/record.rs
@@ -1,0 +1,224 @@
+use serde::{
+    ser::{SerializeSeq, SerializeStruct},
+    Serialize,
+};
+use std::{
+    fs::File,
+    io,
+    path::Path,
+    sync::{Arc, Mutex},
+    time::SystemTime,
+};
+
+use console_api as proto;
+
+/// This marks the currently understood version of the recording format. This
+/// should be increased whenever the format has a breaking change that we
+/// cannot parse. Though, even better, we should probably support parsing
+/// older versions.
+///
+/// But while this is in rapid development, we can move fast and break things.
+const DATA_FORMAT_VERSION: u8 = 1;
+
+pub(crate) struct Recorder {
+    buf: Arc<Mutex<RecordBuf>>,
+
+    worker: std::thread::JoinHandle<()>,
+}
+
+struct Io {
+    buf: Arc<Mutex<RecordBuf>>,
+    file: File,
+}
+
+struct RecordBuf {
+    /// The current buffer to serialize events into.
+    bytes: Vec<u8>,
+    /// The "next" buffer that should be used when the IO thread takes the
+    /// current buffer. After flushing, the IO thread will put the buffer
+    /// back in this slot, so the allocation can be reused.
+    next: Vec<u8>,
+}
+
+#[derive(Serialize)]
+struct Header {
+    v: u8,
+}
+
+#[derive(Serialize)]
+enum Event<'a> {
+    Spawn {
+        id: u64,
+        at: SystemTime,
+        fields: SerializeFields<'a>,
+    },
+    Enter {
+        id: u64,
+        at: SystemTime,
+    },
+    Exit {
+        id: u64,
+        at: SystemTime,
+    },
+    Close {
+        id: u64,
+        at: SystemTime,
+    },
+    Waker {
+        id: u64,
+        op: super::WakeOp,
+        at: SystemTime,
+    },
+}
+
+struct SerializeFields<'a>(&'a [proto::Field]);
+
+struct SerializeField<'a>(&'a proto::Field);
+
+impl Recorder {
+    pub(crate) fn new(path: &Path) -> io::Result<Self> {
+        let buf = Arc::new(Mutex::new(RecordBuf::new()));
+        let buf2 = buf.clone();
+        let file = std::fs::File::create(path)?;
+
+        let worker = std::thread::Builder::new()
+            .name("console/subscriber/recorder/io".into())
+            .spawn(move || {
+                record_io(Io { buf: buf2, file });
+            })?;
+
+        let recorder = Recorder { buf, worker };
+
+        recorder.write(&Header {
+            v: DATA_FORMAT_VERSION,
+        });
+
+        Ok(recorder)
+    }
+
+    pub(crate) fn record(&self, event: &crate::Event) {
+        let event = match event {
+            crate::Event::Spawn { id, at, fields, .. } => Event::Spawn {
+                id: id.into_u64(),
+                at: *at,
+                fields: SerializeFields(fields),
+            },
+            crate::Event::Enter { id, at } => Event::Enter {
+                id: id.into_u64(),
+                at: *at,
+            },
+            crate::Event::Exit { id, at } => Event::Exit {
+                id: id.into_u64(),
+                at: *at,
+            },
+            crate::Event::Close { id, at } => Event::Close {
+                id: id.into_u64(),
+                at: *at,
+            },
+            crate::Event::Waker { id, op, at } => Event::Waker {
+                id: id.into_u64(),
+                at: *at,
+                op: *op,
+            },
+            _ => return,
+        };
+
+        self.write(&event);
+    }
+
+    fn write<T: Serialize>(&self, val: &T) {
+        let mut buf = self.buf.lock().unwrap();
+        serde_json::to_writer(&mut buf.bytes, val).expect("json");
+        buf.bytes.push(b'\n');
+        drop(buf);
+        self.worker.thread().unpark();
+    }
+}
+
+impl RecordBuf {
+    fn new() -> Self {
+        Self {
+            bytes: Vec::new(),
+            next: Vec::new(),
+        }
+    }
+
+    /// Takes the existing bytes to be written, and resets self so that
+    /// it may continue to buffer events.
+    fn take(&mut self) -> Vec<u8> {
+        let next = std::mem::take(&mut self.next);
+        std::mem::replace(&mut self.bytes, next)
+    }
+
+    fn put(&mut self, mut next: Vec<u8>) {
+        debug_assert_eq!(self.next.capacity(), 0);
+        next.clear();
+        self.next = next;
+    }
+}
+
+fn record_io(mut dst: Io) {
+    use std::io::Write;
+
+    loop {
+        std::thread::park();
+
+        // Only lock the mutex to take the bytes out. The file write could
+        // take a relatively long time, and we don't want to be blocking
+        // the serialization end holding this lock.
+        let bytes = dst.buf.lock().unwrap().take();
+        match dst.file.write_all(&bytes) {
+            Ok(()) => {
+                dst.buf.lock().unwrap().put(bytes);
+            }
+            Err(_e) => {
+                // TODO: what to do if file error?
+            }
+        }
+    }
+}
+
+impl serde::Serialize for SerializeFields<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for element in self.0 {
+            seq.serialize_element(&SerializeField(element))?;
+        }
+        seq.end()
+    }
+}
+
+impl serde::Serialize for SerializeField<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut ser = serializer.serialize_struct("Field", 2)?;
+        ser.serialize_field(
+            "name",
+            match self.0.name.as_ref().expect("name") {
+                proto::field::Name::StrName(ref n) => n,
+                proto::field::Name::NameIdx(_idx) => todo!("metadata idx"),
+            },
+        )?;
+
+        match self.0.value.as_ref().expect("field value") {
+            proto::field::Value::DebugVal(v) | proto::field::Value::StrVal(v) => {
+                ser.serialize_field("value", v)?;
+            }
+            proto::field::Value::U64Val(v) => {
+                ser.serialize_field("value", v)?;
+            }
+            proto::field::Value::I64Val(v) => {
+                ser.serialize_field("value", v)?;
+            }
+            proto::field::Value::BoolVal(v) => {
+                ser.serialize_field("value", v)?;
+            }
+        }
+        ser.end()
+    }
+}


### PR DESCRIPTION
This adds an option (default is off for now) to record all relevant events to a file, as described in #70, with the goal of being able to share the file and/or replay the run in the Console after the fact.

- To try to prevent blocking file system writes from interfering, the events are serialized to a group of buffers, and a worker thread is spawned that juggles them and tries to write them to disk.
- The data format of JSON was somewhat arbitrarily chosen. We could chose a different format if we wanted to try to reduce the size on the disk.

Closes #84 