### PR TITLE
 refac(subscriber): make `Callsites` length const generic

### DIFF
--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -2,6 +2,7 @@ use console_api as proto;
 use tokio::sync::{mpsc, oneshot};
 
 use std::{
+    fmt,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
     time::{Duration, SystemTime},
@@ -310,6 +311,19 @@ where
             at: SystemTime::now(),
             id,
         });
+    }
+}
+
+impl fmt::Debug for TasksLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TasksLayer")
+            // mpsc::Sender debug impl is not very useful
+            .field("tx", &format_args!("<...>"))
+            .field("tx.capacity", &self.tx.capacity())
+            .field("flush", &self.flush)
+            .field("spawn_callsites", &self.spawn_callsites)
+            .field("waker_callsites", &self.waker_callsites)
+            .finish()
     }
 }
 

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -30,8 +30,11 @@ use crate::aggregator::TaskId;
 pub struct TasksLayer {
     tx: mpsc::Sender<Event>,
     flush: Arc<aggregator::Flush>,
-    spawn_callsites: Callsites,
-    waker_callsites: Callsites,
+
+    // For task spans, each runtime these will have like, 1-5 callsites in it, max, so
+    // 32 is probably fine. For async operations, we may need a bigger callsites array.
+    spawn_callsites: Callsites<32>,
+    waker_callsites: Callsites<32>,
 }
 
 pub struct Server {

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -31,9 +31,17 @@ pub struct TasksLayer {
     tx: mpsc::Sender<Event>,
     flush: Arc<aggregator::Flush>,
 
-    // For task spans, each runtime these will have like, 1-5 callsites in it, max, so
-    // 32 is probably fine. For async operations, we may need a bigger callsites array.
-    spawn_callsites: Callsites<32>,
+    /// Set of callsites for spans representing spawned tasks.
+    ///
+    /// For task spans, each runtime these will have like, 1-5 callsites in it, max, so
+    /// 16 is probably fine. For async operations, we may need a bigger callsites array.
+    spawn_callsites: Callsites<16>,
+
+    /// Set of callsites for events representing waker operations.
+    ///
+    /// 32 is probably a reasonable number of waker ops; it's a bit generous if
+    /// there's only one async runtime library in use, but if there are multiple,
+    /// they might all have their own sets of waker ops.
     waker_callsites: Callsites<32>,
 }
 


### PR DESCRIPTION
Currently, callsites arrays always have 32 elements. This is fine for
task spans and waker ops. However, when adding async resources and async
operations, these will likely need to be much longer.

This PR changes the `Callsites` type to have a const generic parameter
for the maximum number of callsites. When using `Callsites` to track
async ops and resources, we can provide a much larger length value.

I also tuned the length of the two callsites arrays we're currently using, and
added a quick `fmt::Debug` impl for `TasksLayer`.