### PR TITLE
feat(console): comprehensive color configuration

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -3,20 +3,25 @@ name = "console"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "David Barsky <me@davidbarsky.com>"]
 edition = "2018"
+repository = "https://github.com/tokio-rs/console"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+atty = "0.2"
 console-api = { path = "../console-api", features = ["transport"]}
+clap = "3.0.0-beta.2"
 tokio = { version = "1", features = ["full", "rt-multi-thread"]}
 tonic = { version = "0.5", features = ["transport"] }
 futures = "0.3"
 tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
 chrono = "0.4"
 tracing = "0.1"
+tracing-subscriber = "0.2.16"
+tracing-journald = "0.1"
 prost-types = "0.8"
 crossterm = { version = "0.20", features = ["event-stream"] }
-color-eyre = "0.5"
+color-eyre = { version = "0.5", features = ["issue-url"] }
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
 h2 = "0.3"
 regex = "1.5"

--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -78,7 +78,7 @@ pub struct ColorToggles {
 
 impl Config {
     pub fn trace_init(&mut self) -> color_eyre::Result<()> {
-        let filter = std::mem::replace(&mut self.env_filter, Default::default());
+        let filter = std::mem::take(&mut self.env_filter);
         use tracing_subscriber::prelude::*;
 
         // If we're on a Linux distro with journald, try logging to the system

--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -1,0 +1,162 @@
+use crate::view::Palette;
+use clap::{ArgGroup, Clap, ValueHint};
+use std::process::Command;
+use tonic::transport::Uri;
+
+#[derive(Clap, Debug)]
+#[clap(
+    name = clap::crate_name!(),
+    author,
+    about,
+    version,
+)]
+#[deny(missing_docs)]
+pub struct Config {
+    /// The address of a console-enabled process to connect to.
+    ///
+    /// This may be an IP address and port, or a DNS name.
+    #[clap(default_value = "http://127.0.0.1:6669", value_hint = ValueHint::Url)]
+    pub(crate) target_addr: Uri,
+
+    /// Log level filter for the console's internal diagnostics.
+    ///
+    /// The console will log to stderr if a log level filter is provided. Since
+    /// the console application runs interactively, stderr should generally be
+    /// redirected to a file to avoid interfering with the console's text output.
+    #[clap(long = "log", env = "RUST_LOG", default_value = "off")]
+    pub(crate) env_filter: tracing_subscriber::EnvFilter,
+
+    #[clap(flatten)]
+    pub(crate) color_options: Colors,
+}
+
+#[derive(Clap, Debug, Copy, Clone)]
+#[clap(group = ArgGroup::new("colors").conflicts_with("no-colors"))]
+pub struct Colors {
+    /// Disable ANSI colors entirely.
+    #[clap(name = "no-colors", long = "no-colors")]
+    no_colors: bool,
+
+    /// Overrides the value of the `COLORTERM` environment variable.
+    ///
+    /// If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
+    #[clap(
+        long = "colorterm",
+        name = "truecolor",
+        env = "COLORTERM",
+        parse(from_str = parse_true_color),
+        possible_values = &["24bit", "truecolor"],
+    )]
+    truecolor: bool,
+
+    /// Explicitly set which color palette to use.
+    #[clap(
+        long,
+        possible_values = &["8", "16", "256", "all", "off"],
+        group = "colors",
+        conflicts_with_all = &["no-colors", "truecolor"]
+    )]
+    palette: Option<Palette>,
+
+    #[clap(flatten)]
+    toggles: ColorToggles,
+}
+
+/// Toggles on and off color coding for individual UI elements.
+#[derive(Clap, Debug, Copy, Clone)]
+pub struct ColorToggles {
+    /// Disable color-coding for duration units.
+    #[clap(long = "no-duration-colors", parse(from_flag = std::ops::Not::not), group = "colors")]
+    pub(crate) color_durations: bool,
+
+    /// Disable color-coding for terminated tasks.
+    #[clap(long = "no-terminated-colors", parse(from_flag = std::ops::Not::not), group = "colors")]
+    pub(crate) color_terminated: bool,
+}
+
+// === impl Config ===
+
+impl Config {
+    pub fn trace_init(&mut self) -> color_eyre::Result<()> {
+        let filter = std::mem::replace(&mut self.env_filter, Default::default());
+        use tracing_subscriber::prelude::*;
+
+        // If we're on a Linux distro with journald, try logging to the system
+        // journal so we don't interfere with text output.
+        let journald = tracing_journald::layer().ok();
+
+        // Otherwise, log to stderr and rely on the user redirecting output.
+        let fmt = if journald.is_none() {
+            Some(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(std::io::stderr)
+                    .with_ansi(atty::is(atty::Stream::Stderr)),
+            )
+        } else {
+            None
+        };
+
+        tracing_subscriber::registry()
+            .with(journald)
+            .with(fmt)
+            .with(filter)
+            .try_init()?;
+
+        Ok(())
+    }
+}
+
+// === impl Colors ===
+
+impl Colors {
+    /// Determines the color palette to use.
+    ///
+    /// The color palette is determined based on the following (in order):
+    /// - Any palette explicitly set via the command-line options
+    /// - The terminal's advertised support for true colors via the `COLORTERM`
+    ///   env var.
+    /// - Checking the `terminfo` database via `tput`
+    pub(crate) fn determine_palette(&self) -> Palette {
+        // Did the user explicitly disable colors?
+        if self.no_colors {
+            tracing::debug!("colors explicitly disabled by `--no-colors`");
+            return Palette::NoColors;
+        }
+
+        // Did the user explicitly select a palette?
+        if let Some(palette) = self.palette {
+            tracing::debug!(?palette, "colors selected via `--palette`");
+            return palette;
+        }
+
+        // Does the terminal advertise truecolor support via the COLORTERM env var?
+        if self.truecolor {
+            tracing::debug!("millions of colors enabled via `COLORTERM=truecolor`");
+            return Palette::All;
+        }
+
+        // Okay, try to use `tput` to ask the terminfo database how many colors
+        // are supported...
+        let tput = Command::new("tput").arg("colors").output();
+        tracing::debug!(?tput, "checking `tput colors`");
+        if let Ok(output) = tput {
+            let stdout = String::from_utf8(output.stdout);
+            tracing::debug!(?stdout, "`tput colors` succeeded");
+            return stdout
+                .map_err(|err| tracing::warn!(%err, "`tput colors` stdout was not utf-8 (this shouldn't happen)"))
+                .and_then(|s| s.parse::<Palette>().map_err(|_| tracing::warn!(palette = ?s, "invalid color palette from `tput colors`")))
+                .unwrap_or_default();
+        }
+
+        Palette::NoColors
+    }
+
+    pub(crate) fn toggles(&self) -> ColorToggles {
+        self.toggles
+    }
+}
+
+fn parse_true_color(s: &str) -> bool {
+    let s = s.trim();
+    s.eq_ignore_ascii_case("truecolor") || s.eq_ignore_ascii_case("24bit")
+}

--- a/console/src/view/colors.rs
+++ b/console/src/view/colors.rs
@@ -1,0 +1,154 @@
+use crate::config;
+use std::{borrow::Cow, str::FromStr};
+use tui::{
+    style::{Color, Modifier, Style},
+    text::Span,
+};
+
+#[derive(Debug, Clone)]
+pub struct Colors {
+    palette: Palette,
+    toggles: config::ColorToggles,
+}
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[repr(u8)]
+pub enum Palette {
+    NoColors,
+    /// Use ANSI 8 color palette only.
+    Ansi8,
+    /// Use ANSI 16 color palette only.
+    Ansi16,
+    /// Enable ANSI 256-color palette.
+    Ansi256,
+    /// Enable all RGB colors.
+    All,
+}
+
+fn fg_style(color: Color) -> Style {
+    Style::default().fg(color)
+}
+
+// === impl Colors ===
+
+impl Colors {
+    pub fn from_config(config: config::Colors) -> Self {
+        Self {
+            palette: config.determine_palette(),
+            toggles: config.toggles(),
+        }
+    }
+
+    pub fn error_init(&self) -> color_eyre::Result<()> {
+        use color_eyre::config::{HookBuilder, Theme};
+
+        let mut builder = HookBuilder::new()
+            .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
+            .add_issue_metadata("version", env!("CARGO_PKG_VERSION"));
+        if self.palette == Palette::NoColors {
+            // disable colors in error reports
+            builder = builder.theme(Theme::new());
+        }
+        builder.install()
+    }
+
+    pub fn time_units<'a>(&self, text: impl Into<Cow<'a, str>>) -> Span<'a> {
+        let text = text.into();
+        if !self.toggles.color_durations {
+            return Span::raw(text);
+        }
+
+        let style = match self.palette {
+            Palette::NoColors => return Span::raw(text),
+            Palette::Ansi8 | Palette::Ansi16 => match text.as_ref() {
+                s if s.ends_with("ps") => fg_style(Color::Blue),
+                s if s.ends_with("ns") => fg_style(Color::Green),
+                s if s.ends_with("µs") || s.ends_with("us") => fg_style(Color::Yellow),
+                s if s.ends_with("ms") => fg_style(Color::Red),
+                s if s.ends_with('s') => fg_style(Color::Magenta),
+                _ => Style::default(),
+            },
+            Palette::Ansi256 | Palette::All => match text.as_ref() {
+                s if s.ends_with("ps") => fg_style(Color::Indexed(40)), // green 3
+                s if s.ends_with("ns") => fg_style(Color::Indexed(41)), // spring green 3
+                s if s.ends_with("µs") || s.ends_with("us") => fg_style(Color::Indexed(42)), // spring green 2
+                s if s.ends_with("ms") => fg_style(Color::Indexed(43)), // cyan 3
+                s if s.ends_with('s') => fg_style(Color::Indexed(44)),  // dark turquoise,
+                _ => Style::default(),
+            },
+        };
+
+        Span::styled(text, style)
+    }
+
+    pub fn terminated(&self) -> Style {
+        if !self.toggles.color_terminated {
+            return Style::default();
+        }
+
+        Style::default().add_modifier(Modifier::DIM)
+    }
+
+    pub fn fg(&self, color: Color) -> Style {
+        if let Some(color) = self.color(color) {
+            Style::default().fg(color)
+        } else {
+            Style::default()
+        }
+    }
+
+    pub fn color(&self, color: Color) -> Option<Color> {
+        use Palette::*;
+        match (self.palette, color) {
+            // If colors are disabled, no colors.
+            (NoColors, _) => None,
+            // If true RGB color is enabled, any color is enabled.
+            (All, color) => Some(color),
+            // If ANSI 256 colors are enabled, we can't use RGB true colors...
+            (Ansi256, Color::Rgb(_, _, _)) => None,
+            // ...but we can use anything else.
+            (Ansi256, color) => Some(color),
+            // If we are using only ANSI 16 or ANSI 8 colors, disable RGB true
+            // colors and ANSI 256 indexed colors.
+            (_, Color::Rgb(_, _, _)) | (Ansi16, Color::Indexed(_)) => None,
+            // If we are using ANSI 16 colors and the color is not RGB or
+            // indexed, allow it.
+            (Ansi16, color) => Some(color),
+            // If we are using ANSI 8 colors, try to translate ANSI 16 colors
+            // 'light' variants to their 8 color equivalents...
+            (Ansi8, Color::LightRed) => Some(Color::Red),
+            (Ansi8, Color::LightGreen) => Some(Color::Green),
+            (Ansi8, Color::LightYellow) => Some(Color::Yellow),
+            (Ansi8, Color::LightBlue) => Some(Color::Blue),
+            (Ansi8, Color::LightMagenta) => Some(Color::Magenta),
+            (Ansi8, Color::Cyan) => Some(Color::Cyan),
+            // Otherwise, if a previous case didn't match, the color is enabled
+            // by the current palette.
+            (_, _) => Some(color),
+        }
+    }
+}
+
+// === impl Palette ===
+
+impl FromStr for Palette {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "0" => Ok(Palette::NoColors),
+            "8" => Ok(Palette::Ansi8),
+            "16" => Ok(Palette::Ansi16),
+            "256" => Ok(Palette::Ansi256),
+            s if s.eq_ignore_ascii_case("all") => Ok(Palette::All),
+            s if s.eq_ignore_ascii_case("off") => Ok(Palette::NoColors),
+            _ => Err("invalid color palette"),
+        }
+    }
+}
+
+impl Default for Palette {
+    fn default() -> Self {
+        Self::NoColors
+    }
+}

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -67,6 +67,7 @@ impl List {
 
     pub(crate) fn render<B: tui::backend::Backend>(
         &mut self,
+        colors: &view::Colors,
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
         state: &mut tasks::State,
@@ -89,14 +90,14 @@ impl List {
         self.sorted_tasks.extend(state.take_new_tasks());
         self.sort_by.sort(now, &mut self.sorted_tasks);
 
-        fn dur_cell(dur: std::time::Duration) -> Cell<'static> {
-            Cell::from(view::color_time_units(format!(
+        let dur_cell = |dur: std::time::Duration| -> Cell<'static> {
+            Cell::from(colors.time_units(format!(
                 "{:>width$.prec$?}",
                 dur,
                 width = DUR_LEN,
                 prec = DUR_PRECISION,
             )))
-        }
+        };
 
         // Start out wide enough to display the column headers...
         let mut id_width = view::Width::new(Self::HEADER[0].len() as u16);
@@ -127,7 +128,7 @@ impl List {
                     )),
                 ]);
                 if task.completed_for() > 0 {
-                    row = row.style(Style::default().add_modifier(style::Modifier::DIM));
+                    row = row.style(colors.terminated());
                 }
                 Some(row)
             })


### PR DESCRIPTION
This branch updates the console application to:
- Detect what colors are supported by the current terminal and choose
  them accordingly
- Allow user settings to override the color palette
- Allow user settings to override whether particular UI elements are
  colored

This change is rather complicated. It introduces `clap` for CLI
arguments, to allow the user to override the color palette.

When the color palette is _not_ overridden, the console will determine
what colors the terminal supports via the following process:
- If the `COLORTERM` environment variable is set to "24bit" or
  "truecolor", this indicates that the terminal supports 24-bit RGB
  color. In that case, all colors are used.
- Otherwise, the console attempts to use `tput colors` to query the
  `terminfo` database to see what colors the current terminal supports.
- If the call to `tput colors` fails, we assume no colors are supported.

Additionally, new CLI args allow the user to toggle whether durations
are color-coded, and whether terminated tasks are dimmed. In the future,
we will probably also want to add support for parsing these from a
config file --- in general, users probably won't want to set these
preferences from the command line every time they run the console.
However, I decided to punt on adding a config file in this PR --- the
addition of new CLI arg parsing logic is a big enough change. We can add
a simple TOML file or something in a follow-up change.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>