### PR TITLE
feat(console): replace tasks kind column with state column 

### DIFF
--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -241,9 +241,9 @@ impl List {
 
 impl crate::tasks::TaskState {
     fn render(self) -> &'static str {
-        const STATE_RUNNING: &'static str = "\u{25B6}";
-        const STATE_IDLE: &'static str = "\u{23F8}";
-        const STATE_COMPLETED: &'static str = "\u{23F9}";
+        const STATE_RUNNING: &str = "\u{25B6}";
+        const STATE_IDLE: &str = "\u{23F8}";
+        const STATE_COMPLETED: &str = "\u{23F9}";
         match self {
             Self::Running => STATE_RUNNING,
             Self::Idle => STATE_IDLE,

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -110,7 +110,7 @@ impl List {
 
                 let mut row = Row::new(vec![
                     Cell::from(id_width.update_str(task.id().to_string())),
-                    Cell::from(task.state()),
+                    Cell::from(task.state().render()),
                     dur_cell(task.total(now)),
                     dur_cell(task.busy(now)),
                     dur_cell(task.idle(now)),
@@ -239,20 +239,15 @@ impl List {
     }
 }
 
-impl crate::tasks::Task {
-    fn state(&self) -> &'static str {
+impl crate::tasks::TaskState {
+    fn render(self) -> &'static str {
         const STATE_RUNNING: &'static str = "\u{25B6}";
         const STATE_IDLE: &'static str = "\u{23F8}";
         const STATE_COMPLETED: &'static str = "\u{23F9}";
-
-        if self.is_running() {
-            return STATE_RUNNING;
+        match self {
+            Self::Running => STATE_RUNNING,
+            Self::Idle => STATE_IDLE,
+            Self::Completed => STATE_COMPLETED,
         }
-
-        if self.is_completed() {
-            return STATE_COMPLETED;
-        }
-
-        STATE_IDLE
     }
 }


### PR DESCRIPTION
This branch replaces the "kind" column in the tasks list view with a new
"state" column that indicates whether the task is currently running,
idle, or terminated. The "kind" column was initially intended to
distinguish between Tokio's blocking tasks and async tasks, but the
task's fields column also conveys this information, so the "kind" column
was really just useful for indicating whether the task was active or
terminated. Distinguishing vs sleeping and idle tasks here makes this
column somewhat more useful.

The task list can also be sorted by the state column. We may want to
consider making this the default sorting in the future...

This currently uses the Unicode "play", "pause", and "stop" symbols, as
proposed in #25, to display the different task states. In a subsequent
change, I'll add support for detecting and determining whether UTF-8 is
supported by the terminal.

![image](https://user-images.githubusercontent.com/2796466/129458704-a5643d93-6fe1-492f-aafe-6f70a8338b78.png)
