### PR TITLE
feat(console): make utf-8 support configurable

### DIFF
--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -27,15 +27,23 @@ pub struct Config {
     pub(crate) env_filter: tracing_subscriber::EnvFilter,
 
     #[clap(flatten)]
-    pub(crate) color_options: Colors,
+    pub(crate) view_options: ViewOptions,
 }
 
-#[derive(Clap, Debug, Copy, Clone)]
+#[derive(Clap, Debug, Clone)]
 #[clap(group = ArgGroup::new("colors").conflicts_with("no-colors"))]
-pub struct Colors {
+pub struct ViewOptions {
     /// Disable ANSI colors entirely.
     #[clap(name = "no-colors", long = "no-colors")]
     no_colors: bool,
+
+    /// Overrides the terminal's default language.
+    #[clap(long = "lang", env = "LANG")]
+    lang: String,
+
+    /// Explicitly use only ASCII characters.
+    #[clap(long = "ascii-only")]
+    ascii_only: bool,
 
     /// Overrides the value of the `COLORTERM` environment variable.
     ///
@@ -106,9 +114,13 @@ impl Config {
     }
 }
 
-// === impl Colors ===
+// === impl ViewOptions ===
 
-impl Colors {
+impl ViewOptions {
+    pub fn is_utf8(&self) -> bool {
+        self.lang.ends_with("UTF-8") && !self.ascii_only
+    }
+
     /// Determines the color palette to use.
     ///
     /// The color palette is determined based on the following (in order):

--- a/console/src/conn.rs
+++ b/console/src/conn.rs
@@ -112,7 +112,7 @@ impl Connection {
         }
     }
 
-    pub fn render(&self, colors: &crate::view::Colors) -> tui::text::Spans {
+    pub fn render(&self, styles: &crate::view::Styles) -> tui::text::Spans {
         use tui::{
             style::{Color, Modifier},
             text::{Span, Spans},
@@ -120,15 +120,15 @@ impl Connection {
         let state = match self.state {
             State::Connected { .. } => Span::styled(
                 "(CONNECTED)",
-                colors.fg(Color::Green).add_modifier(Modifier::BOLD),
+                styles.fg(Color::Green).add_modifier(Modifier::BOLD),
             ),
             State::Disconnected(d) if d == Duration::from_secs(0) => Span::styled(
                 "(CONNECTING)",
-                colors.fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                styles.fg(Color::Yellow).add_modifier(Modifier::BOLD),
             ),
             State::Disconnected(d) => Span::styled(
                 format!("(RECONNECTING IN {:?})", d),
-                colors.fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                styles.fg(Color::Yellow).add_modifier(Modifier::BOLD),
             ),
         };
         Spans::from(vec![

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -25,10 +25,10 @@ mod view;
 async fn main() -> color_eyre::Result<()> {
     let mut args = config::Config::parse();
     args.trace_init()?;
-    tracing::debug!(?args.target_addr, ?args.color_options);
+    tracing::debug!(?args.target_addr, ?args.view_options);
 
-    let colors = view::Colors::from_config(args.color_options);
-    colors.error_init()?;
+    let styles = view::Styles::from_config(args.view_options);
+    styles.error_init()?;
 
     let target = args.target_addr;
     tracing::info!(?target, "using target addr");
@@ -43,7 +43,7 @@ async fn main() -> color_eyre::Result<()> {
 
     let mut tasks = State::default();
     let mut input = input::EventStream::new();
-    let mut view = view::View::new(colors);
+    let mut view = view::View::new(styles);
 
     loop {
         tokio::select! { biased;
@@ -86,7 +86,7 @@ async fn main() -> color_eyre::Result<()> {
                 .constraints([Constraint::Length(2), Constraint::Percentage(95)].as_ref())
                 .split(f.size());
 
-            let header_block = Block::default().title(conn.render(&view.colors));
+            let header_block = Block::default().title(conn.render(&view.styles));
 
             let text = vec![Spans::from(vec![
                 Span::styled(

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -578,3 +578,16 @@ impl FieldValue {
         }
     }
 }
+
+impl TaskState {
+    pub(crate) fn render(self, styles: &crate::view::Styles) -> &'static str {
+        const RUNNING_UTF8: &'static str = "\u{25B6}";
+        const IDLE_UTF8: &'static str = "\u{23F8}";
+        const COMPLETED_UTF8: &'static str = "\u{23F9}";
+        match self {
+            Self::Running => styles.if_utf8(RUNNING_UTF8, ">"),
+            Self::Idle => styles.if_utf8(IDLE_UTF8, ":"),
+            Self::Completed => styles.if_utf8(COMPLETED_UTF8, "!"),
+        }
+    }
+}

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -581,9 +581,9 @@ impl FieldValue {
 
 impl TaskState {
     pub(crate) fn render(self, styles: &crate::view::Styles) -> &'static str {
-        const RUNNING_UTF8: &'static str = "\u{25B6}";
-        const IDLE_UTF8: &'static str = "\u{23F8}";
-        const COMPLETED_UTF8: &'static str = "\u{23F9}";
+        const RUNNING_UTF8: &str = "\u{25B6}";
+        const IDLE_UTF8: &str = "\u{23F8}";
+        const COMPLETED_UTF8: &str = "\u{23F9}";
         match self {
             Self::Running => styles.if_utf8(RUNNING_UTF8, ">"),
             Self::Idle => styles.if_utf8(IDLE_UTF8, ":"),

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -6,11 +6,11 @@ use tui::{
     text::Span,
 };
 
-mod colors;
 mod mini_histogram;
+mod styles;
 mod task;
 mod tasks;
-pub(crate) use self::colors::{Colors, Palette};
+pub(crate) use self::styles::{Palette, Styles};
 
 pub struct View {
     /// The tasks list is stored separately from the currently selected state,
@@ -22,7 +22,7 @@ pub struct View {
     /// it to remain sorted that way when we return to it.
     list: tasks::List,
     state: ViewState,
-    pub(crate) colors: Colors,
+    pub(crate) styles: Styles,
 }
 
 enum ViewState {
@@ -58,11 +58,11 @@ macro_rules! key {
 }
 
 impl View {
-    pub fn new(colors: Colors) -> Self {
+    pub fn new(styles: Styles) -> Self {
         Self {
             state: ViewState::TasksList,
             list: tasks::List::default(),
-            colors,
+            styles,
         }
     }
 
@@ -113,13 +113,13 @@ impl View {
     ) {
         match self.state {
             ViewState::TasksList => {
-                self.list.render(&self.colors, frame, area, tasks);
+                self.list.render(&self.styles, frame, area, tasks);
             }
             ViewState::TaskInstance(ref mut view) => {
                 let now = tasks
                     .last_updated_at()
                     .expect("task view implies we've received an update");
-                view.render(&self.colors, frame, area, now);
+                view.render(&self.styles, frame, area, now);
             }
         }
 

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -33,7 +33,7 @@ impl TaskView {
 
     pub(crate) fn render<B: tui::backend::Backend>(
         &mut self,
-        colors: &view::Colors,
+        styles: &view::Styles,
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
         now: SystemTime,
@@ -75,45 +75,45 @@ impl TaskView {
             )
             .split(chunks[1]);
 
-        let histogram_area = Layout::default()
-            .direction(layout::Direction::Horizontal)
-            .constraints(
-                [
-                    // 24 chars is long enough for the title "Poll Times Percentiles"
-                    layout::Constraint::Length(24),
-                    layout::Constraint::Min(50),
-                ]
-                .as_ref(),
-            )
-            .split(chunks[2]);
+        // Only split the histogram area in half if we're also drawing a
+        // sparkline (which requires UTF-8 characters).
+        let histogram_area = if styles.utf8 {
+            Layout::default()
+                .direction(layout::Direction::Horizontal)
+                .constraints(
+                    [
+                        // 24 chars is long enough for the title "Poll Times Percentiles"
+                        layout::Constraint::Length(24),
+                        layout::Constraint::Min(50),
+                    ]
+                    .as_ref(),
+                )
+                .split(chunks[2])
+        } else {
+            vec![chunks[2]]
+        };
 
         let percentiles_area = histogram_area[0];
-        let sparkline_area = histogram_area[1];
 
         let fields_area = chunks[3];
 
         let controls = Spans::from(vec![
             Span::raw("controls: "),
-            bold("esc"),
+            bold(styles.if_utf8("\u{238B} esc", "esc")),
             Span::raw(" = return to task list, "),
             bold("q"),
             Span::raw(" = quit"),
         ]);
 
-        let attrs = Spans::from(vec![bold("ID: "), Span::raw(task.id().to_string())]);
+        let attrs = Spans::from(vec![
+            bold("ID: "),
+            Span::raw(format!("{} ", task.id())),
+            bold(task.state().render(styles)),
+        ]);
         let target = Spans::from(vec![bold("Target: "), Span::raw(task.target())]);
-
-        let mut total = vec![bold("Total Time: "), dur(colors, task.total(now))];
-
-        // TODO(eliza): maybe surface how long the task has been completed, as well?
-        if task.is_completed() {
-            total.push(Span::raw(" (completed)"));
-        };
-
-        let total = Spans::from(total);
-
-        let busy = Spans::from(vec![bold("Busy: "), dur(colors, task.busy(now))]);
-        let idle = Spans::from(vec![bold("Idle: "), dur(colors, task.idle(now))]);
+        let total = Spans::from(vec![bold("Total Time: "), dur(styles, task.total(now))]);
+        let busy = Spans::from(vec![bold("Busy: "), dur(styles, task.busy(now))]);
+        let idle = Spans::from(vec![bold("Idle: "), dur(styles, task.idle(now))]);
 
         let metrics = vec![attrs, target, total, busy, idle];
 
@@ -140,50 +140,54 @@ impl TaskView {
 
         let wakeups = Spans::from(wakeups);
 
-        fn block_for(title: &str) -> Block {
-            Block::default().borders(Borders::ALL).title(title)
+        fn block_for<'a>(styles: &view::Styles, title: &'a str) -> Block<'a> {
+            Block::default()
+                .borders(styles.borders(Borders::ALL))
+                .title(title)
         }
 
         let mut fields = Text::default();
         fields.extend(task.formatted_fields().iter().cloned().map(Spans::from));
 
-        // Bit of a deadlock: We cannot know the highest bucket value without determining the number of buckets,
-        // and we cannot determine the number of buckets without knowing the width of the chart area which depends on
-        // the number of digits in the highest bucket value.
-        // So just assume here the number of digits in the highest bucket value is 3.
-        // If we overshoot, there will be empty columns/buckets at the right end of the chart.
-        // If we undershoot, the rightmost 1-2 columns/buckets will be hidden.
-        // We could get the max bucket value from the previous render though...
-        let (chart_data, metadata) = details
-            .map(|d| d.make_chart_data(sparkline_area.width - 3))
-            .unwrap_or_default();
+        // If UTF-8 is disabled we can't draw the histogram sparklne.
+        if styles.utf8 {
+            let sparkline_area = histogram_area[1];
 
-        let histogram_sparkline = MiniHistogram::default()
-            .block(
-                Block::default()
-                    .title("Poll Times Histogram")
-                    .borders(Borders::ALL),
-            )
-            .data(&chart_data)
-            .metadata(metadata)
-            .duration_precision(2);
+            // Bit of a deadlock: We cannot know the highest bucket value without determining the number of buckets,
+            // and we cannot determine the number of buckets without knowing the width of the chart area which depends on
+            // the number of digits in the highest bucket value.
+            // So just assume here the number of digits in the highest bucket value is 3.
+            // If we overshoot, there will be empty columns/buckets at the right end of the chart.
+            // If we undershoot, the rightmost 1-2 columns/buckets will be hidden.
+            // We could get the max bucket value from the previous render though...
+            let (chart_data, metadata) = details
+                .map(|d| d.make_chart_data(sparkline_area.width - 3))
+                .unwrap_or_default();
 
-        let task_widget = Paragraph::new(metrics).block(block_for("Task"));
-        let wakers_widget = Paragraph::new(vec![wakers, wakeups]).block(block_for("Waker"));
-        let fields_widget = Paragraph::new(fields).block(block_for("Fields"));
+            let histogram_sparkline = MiniHistogram::default()
+                .block(block_for(styles, "Poll Times Histogram"))
+                .data(&chart_data)
+                .metadata(metadata)
+                .duration_precision(2);
+
+            frame.render_widget(histogram_sparkline, sparkline_area);
+        }
+
+        let task_widget = Paragraph::new(metrics).block(block_for(styles, "Task"));
+        let wakers_widget = Paragraph::new(vec![wakers, wakeups]).block(block_for(styles, "Waker"));
+        let fields_widget = Paragraph::new(fields).block(block_for(styles, "Fields"));
         let percentiles_widget = Paragraph::new(
             details
-                .map(|details| details.make_percentiles_widget(colors))
+                .map(|details| details.make_percentiles_widget(styles))
                 .unwrap_or_default(),
         )
-        .block(block_for("Poll Times Percentiles"));
+        .block(block_for(styles, "Poll Times Percentiles"));
 
         frame.render_widget(Block::default().title(controls), controls_area);
         frame.render_widget(task_widget, stats_area[0]);
         frame.render_widget(wakers_widget, stats_area[1]);
         frame.render_widget(fields_widget, fields_area);
         frame.render_widget(percentiles_widget, percentiles_area);
-        frame.render_widget(histogram_sparkline, sparkline_area);
     }
 }
 
@@ -233,7 +237,7 @@ impl Details {
     }
 
     /// Get the important percentile values from the histogram
-    fn make_percentiles_widget(&self, colors: &view::Colors) -> Text<'static> {
+    fn make_percentiles_widget(&self, styles: &view::Styles) -> Text<'static> {
         let mut text = Text::default();
         let histogram = self.poll_times_histogram();
         let percentiles = histogram.iter().flat_map(|histogram| {
@@ -243,7 +247,7 @@ impl Details {
             pairs.map(|pair| {
                 Spans::from(vec![
                     bold(format!("p{:>2}: ", pair.0)),
-                    dur(colors, Duration::from_nanos(pair.1)),
+                    dur(styles, Duration::from_nanos(pair.1)),
                 ])
             })
         });
@@ -252,10 +256,10 @@ impl Details {
     }
 }
 
-fn dur(colors: &view::Colors, dur: std::time::Duration) -> Span<'static> {
+fn dur(styles: &view::Styles, dur: std::time::Duration) -> Span<'static> {
     const DUR_PRECISION: usize = 4;
     // TODO(eliza): can we not have to use `format!` to make a string here? is
     // there a way to just give TUI a `fmt::Debug` implementation, or does it
     // have to be given a string in order to do layout stuff?
-    colors.time_units(format!("{:.prec$?}", dur, prec = DUR_PRECISION))
+    styles.time_units(format!("{:.prec$?}", dur, prec = DUR_PRECISION))
 }

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -67,7 +67,7 @@ impl List {
 
     pub(crate) fn render<B: tui::backend::Backend>(
         &mut self,
-        colors: &view::Colors,
+        styles: &view::Styles,
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
         state: &mut tasks::State,
@@ -91,7 +91,7 @@ impl List {
         self.sort_by.sort(now, &mut self.sorted_tasks);
 
         let dur_cell = |dur: std::time::Duration| -> Cell<'static> {
-            Cell::from(colors.time_units(format!(
+            Cell::from(styles.time_units(format!(
                 "{:>width$.prec$?}",
                 dur,
                 width = DUR_LEN,
@@ -111,7 +111,7 @@ impl List {
 
                 let mut row = Row::new(vec![
                     Cell::from(id_width.update_str(task.id().to_string())),
-                    Cell::from(task.state().render()),
+                    Cell::from(task.state().render(styles)),
                     dur_cell(task.total(now)),
                     dur_cell(task.busy(now)),
                     dur_cell(task.idle(now)),
@@ -126,7 +126,7 @@ impl List {
                     )),
                 ]);
                 if task.completed_for() > 0 {
-                    row = row.style(colors.terminated());
+                    row = row.style(styles.terminated());
                 }
                 Some(row)
             })
@@ -134,11 +134,11 @@ impl List {
 
         let block = Block::default().title(vec![
             text::Span::raw("controls: "),
-            bold("\u{2190}\u{2192}"),
+            bold(styles.if_utf8("\u{2190}\u{2192}", "left, right")),
             text::Span::raw(" = select column (sort), "),
-            bold("\u{2191}\u{2193}"),
+            bold(styles.if_utf8("\u{2191}\u{2193}", "up, down")),
             text::Span::raw(" = scroll, "),
-            bold("enter"),
+            bold(styles.if_utf8("\u{21B5}", "enter")),
             text::Span::raw(" = task details, "),
             bold("i"),
             text::Span::raw(" = invert sort (highest/lowest), "),
@@ -237,18 +237,5 @@ impl List {
                 self.sorted_tasks[selected].clone()
             })
             .unwrap_or_default()
-    }
-}
-
-impl crate::tasks::TaskState {
-    fn render(self) -> &'static str {
-        const STATE_RUNNING: &str = "\u{25B6}";
-        const STATE_IDLE: &str = "\u{23F8}";
-        const STATE_COMPLETED: &str = "\u{23F9}";
-        match self {
-            Self::Running => STATE_RUNNING,
-            Self::Idle => STATE_IDLE,
-            Self::Completed => STATE_COMPLETED,
-        }
     }
 }


### PR DESCRIPTION
Depends on #88 
Depends on #89 

This branch builds on the CLI flags added in #88 to also add support for
disabling the use of non-ASCII characters in the console. The console
will now attempt to detect whether the terminal supports UTF-8 by
inspecting the `LANG` environment variable. If the value ends with
`UTF-8`, unicode characters will be used. If it does not, the console
will run in an ASCII-only mode. Furthermore, the CLI now includes a
`--lang` flag to override the value of the `LANG` environment variable,
and a `--ascii-only` flag to force the ASCII-only mode.

When Unicode support is disabled, we do the following:
- replace the "play", "pause", and "stop" characters added in #89 with
  `>`, `:` and `!`, respectively. I'm open to suggestions, if anyone
  can think of better ASCII characters to represent the "running",
  "idle", and "completed" states.
- the use of Unicode characters for the left, right, up, and down arrow
  keys, enter key, and escape key in the controls list is replaced with
  simply spelling out the names of those keys.
- the use of Unicode box-drawing characters in the task details window
  is avoided by disabling borders entirely. It would be nice to
  eventually replace this with ASCII art borders, but TUI doesn't have
  a way to provide a custom character set for borders, as far as I can
  tell.
- the Unicode micro symbol (mu) in microsecond durations is replaced
  with `u`, for `us`.
- the poll time histogram is disabled entirely, since TUI's sparklines
  rely on Unicode block characters.

This was implemented by changing the `view::Colors` struct, which
determines what colors are enabled based on the configuration, to
`view::Styles`, and making it also responsible for determining what
character set is enabled. It now is responsible for determining how to
style more UI elements.

### Screenshots:

```console
$ cargo run
```

Task list:

![image](https://user-images.githubusercontent.com/2796466/129485918-0421ae73-4104-446c-89cd-7f1266e75fb2.png)

Task details:

![image](https://user-images.githubusercontent.com/2796466/129485929-31106520-5676-4ec9-8aae-b13b831c1686.png)

```console
$ cargo run -- --ascii-only
```

Task list:

![image](https://user-images.githubusercontent.com/2796466/129485971-de66611e-10ac-4325-9bd3-27aaafdf8cd8.png)

Task details:

![image](https://user-images.githubusercontent.com/2796466/129486005-5c964369-adeb-4b62-b7cc-8dd96044e53c.png)

### Future Work

- Handle cases where `LANG` includes other Unicode character sets
  (e.g. UTF-16)?
- Also use `LANG` and other locale env variables for localization.
  Right now, we only look at the last part of the `LANG` variable,
  which determines the character set, but the first part of it
  determines the locale (e.g. on my machine, `LANG=en_US.UTF-8`).
  Doing proper localizations is likely to be a big pile of work,
  though, just in terms of actually translating text into languages
  other than English. There are probably existing libraries that
  could be used for the 'mechanical' parts (actually switching UI
  text), but the translations kind of inherently require human
  intervention...
- Use ASCII art borders when Unicode is disabled?
- Figure out an acceptable way to draw the histograms without
  Unicode characters? This may not really be possible...