### PR TITLE
feat(console): implement more design ideas from #25

### DIFF
--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 
-tokio = { version = "^1.7", features = ["sync", "time", "macros", "tracing"]}
+tokio = { version = "^1.10", features = ["sync", "time", "macros", "tracing"]}
 tokio-stream = "0.1"
 console-api = { path = "../console-api", features = ["transport"]}
 tonic = { version = "0.5", features = ["transport"] }

--- a/console-subscriber/examples/app.rs
+++ b/console-subscriber/examples/app.rs
@@ -21,13 +21,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     for opt in std::env::args().skip(1) {
         match &*opt {
             "blocks" => {
-                tokio::spawn(double_sleepy(1, 10));
+                tokio::task::Builder::new()
+                    .name("blocks")
+                    .spawn(double_sleepy(1, 10));
             }
             "coma" => {
-                tokio::spawn(std::future::pending::<()>());
+                tokio::task::Builder::new()
+                    .name("coma")
+                    .spawn(std::future::pending::<()>());
             }
             "burn" => {
-                tokio::spawn(burn(1, 10));
+                tokio::task::Builder::new().name("burn").spawn(burn(1, 10));
             }
             "help" | "-h" => {
                 eprintln!("{}", HELP);
@@ -41,8 +45,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
     }
 
-    let task1 = tokio::spawn(spawn_tasks(1, 10));
-    let task2 = tokio::spawn(spawn_tasks(10, 30));
+    let task1 = tokio::task::Builder::new()
+        .name("task1")
+        .spawn(spawn_tasks(1, 10));
+    let task2 = tokio::task::Builder::new()
+        .name("task2")
+        .spawn(spawn_tasks(10, 30));
 
     let result = tokio::try_join! {
         task1,
@@ -57,7 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 async fn spawn_tasks(min: u64, max: u64) {
     loop {
         for i in min..max {
-            tokio::spawn(wait(i));
+            tokio::task::Builder::new().name("wait").spawn(wait(i));
             tokio::time::sleep(Duration::from_secs(max) - Duration::from_secs(i)).await;
         }
     }

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -72,7 +72,7 @@ async fn main() -> color_eyre::Result<()> {
                     _ => {}
                 }
             },
-            task_update = conn.next_update() => tasks.update_tasks(task_update),
+            task_update = conn.next_update() => tasks.update_tasks(&view.styles, task_update),
             details_update = details_rx.recv() => {
                 if let Some(details_update) = details_update {
                     tasks.update_task_details(details_update);

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -7,9 +7,7 @@ use futures::stream::StreamExt;
 use tokio::sync::{mpsc, watch};
 use tui::{
     layout::{Constraint, Direction, Layout},
-    style::{Modifier, Style},
-    text::{Span, Spans},
-    widgets::{Block, Paragraph, Wrap},
+    widgets::{Paragraph, Wrap},
 };
 
 use crate::view::UpdateKind;
@@ -83,21 +81,10 @@ async fn main() -> color_eyre::Result<()> {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(0)
-                .constraints([Constraint::Length(2), Constraint::Percentage(95)].as_ref())
+                .constraints([Constraint::Length(1), Constraint::Percentage(95)].as_ref())
                 .split(f.size());
 
-            let header_block = Block::default().title(conn.render(&view.styles));
-
-            let text = vec![Spans::from(vec![
-                Span::styled(
-                    format!("{}", tasks.len()),
-                    Style::default().add_modifier(Modifier::BOLD),
-                ),
-                Span::raw(" tasks"),
-            ])];
-            let header = Paragraph::new(text)
-                .block(header_block)
-                .wrap(Wrap { trim: true });
+            let header = Paragraph::new(conn.render(&view.styles)).wrap(Wrap { trim: true });
             f.render_widget(header, chunks[0]);
             view.render(f, chunks[1], &mut tasks);
         })?;

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -114,10 +114,6 @@ pub(crate) enum FieldValue {
 impl State {
     const RETAIN_COMPLETED_FOR: usize = 6;
 
-    pub(crate) fn len(&self) -> usize {
-        self.tasks.len()
-    }
-
     pub(crate) fn last_updated_at(&self) -> Option<SystemTime> {
         self.last_updated_at
     }
@@ -308,11 +304,6 @@ impl Task {
     /// Returns the total number of times the task has been polled.
     pub(crate) fn total_polls(&self) -> u64 {
         self.stats.polls
-    }
-
-    /// Returns the number of updates since the task completed
-    pub(crate) fn completed_for(&self) -> usize {
-        self.completed_for
     }
 
     /// Returns the elapsed time since the task was last woken, relative to
@@ -653,7 +644,6 @@ impl TaskState {
             Self::Running => {
                 Span::styled(styles.if_utf8(RUNNING_UTF8, ">"), styles.fg(Color::Green))
             }
-
             Self::Idle => Span::raw(styles.if_utf8(IDLE_UTF8, ":")),
             Self::Completed => Span::raw(styles.if_utf8(COMPLETED_UTF8, "!")),
         }

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -579,14 +579,14 @@ impl Field {
             formatted.push(vec![
                 Span::styled(field.name.to_string(), key_style),
                 Span::styled("=", delim_style),
-                Span::styled(field.value.to_string(), val_style),
+                Span::styled(format!("{} ", field.value), val_style),
             ]);
             for field in fields {
                 formatted.push(vec![
-                    Span::styled(", ", delim_style),
+                    // Span::styled(", ", delim_style),
                     Span::styled(field.name.to_string(), key_style),
                     Span::styled("=", delim_style),
-                    Span::styled(field.value.to_string(), val_style),
+                    Span::styled(format!("{} ", field.value), val_style),
                 ])
             }
         }

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -645,15 +645,17 @@ impl FieldValue {
 }
 
 impl TaskState {
-    pub(crate) fn render(self, styles: &crate::view::Styles) -> &'static str {
+    pub(crate) fn render(self, styles: &crate::view::Styles) -> Span<'static> {
         const RUNNING_UTF8: &str = "\u{25B6}";
         const IDLE_UTF8: &str = "\u{23F8}";
         const COMPLETED_UTF8: &str = "\u{23F9}";
         match self {
-            Self::Running => styles.if_utf8(RUNNING_UTF8, ">"),
+            Self::Running => {
+                Span::styled(styles.if_utf8(RUNNING_UTF8, ">"), styles.fg(Color::Green))
+            }
 
-            Self::Idle => styles.if_utf8(IDLE_UTF8, ":"),
-            Self::Completed => styles.if_utf8(COMPLETED_UTF8, "!"),
+            Self::Idle => Span::raw(styles.if_utf8(IDLE_UTF8, ":")),
+            Self::Completed => Span::raw(styles.if_utf8(COMPLETED_UTF8, "!")),
         }
     }
 }

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -455,7 +455,7 @@ impl TryFrom<usize> for SortBy {
 
 impl Field {
     const SPAWN_LOCATION: &'static str = "spawn.location";
-    const NAME: &'static str = "name";
+    const NAME: &'static str = "task.name";
 
     /// Converts a wire-format `Field` into an internal `Field` representation,
     /// using the provided `Metadata` for the task span that the field came

--- a/console/src/view/styles.rs
+++ b/console/src/view/styles.rs
@@ -144,12 +144,14 @@ impl Styles {
         }
     }
 
-    pub fn borders(&self, borders: tui::widgets::Borders) -> tui::widgets::Borders {
+    pub fn border_block(&self) -> tui::widgets::Block<'_> {
         if self.utf8 {
-            borders
+            tui::widgets::Block::default()
+                .borders(tui::widgets::Borders::ALL)
+                .border_type(tui::widgets::BorderType::Rounded)
         } else {
             // TODO(eliza): configure an ascii-art border set instead?
-            tui::widgets::Borders::NONE
+            Default::default()
         }
     }
 }

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -108,7 +108,7 @@ impl TaskView {
         let attrs = Spans::from(vec![
             bold("ID: "),
             Span::raw(format!("{} ", task.id())),
-            bold(task.state().render(styles)),
+            Span::raw(task.state().render(styles)),
         ]);
         let target = Spans::from(vec![bold("Target: "), Span::raw(task.target())]);
         let total = Spans::from(vec![bold("Total Time: "), dur(styles, task.total(now))]);

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -14,7 +14,7 @@ use std::{
 use tui::{
     layout::{self, Layout},
     text::{Span, Spans, Text},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Paragraph},
 };
 
 pub(crate) struct TaskView {
@@ -140,12 +140,6 @@ impl TaskView {
 
         let wakeups = Spans::from(wakeups);
 
-        fn block_for<'a>(styles: &view::Styles, title: &'a str) -> Block<'a> {
-            Block::default()
-                .borders(styles.borders(Borders::ALL))
-                .title(title)
-        }
-
         let mut fields = Text::default();
         fields.extend(task.formatted_fields().iter().cloned().map(Spans::from));
 
@@ -165,7 +159,7 @@ impl TaskView {
                 .unwrap_or_default();
 
             let histogram_sparkline = MiniHistogram::default()
-                .block(block_for(styles, "Poll Times Histogram"))
+                .block(styles.border_block().title("Poll Times Histogram"))
                 .data(&chart_data)
                 .metadata(metadata)
                 .duration_precision(2);
@@ -173,15 +167,16 @@ impl TaskView {
             frame.render_widget(histogram_sparkline, sparkline_area);
         }
 
-        let task_widget = Paragraph::new(metrics).block(block_for(styles, "Task"));
-        let wakers_widget = Paragraph::new(vec![wakers, wakeups]).block(block_for(styles, "Waker"));
-        let fields_widget = Paragraph::new(fields).block(block_for(styles, "Fields"));
+        let task_widget = Paragraph::new(metrics).block(styles.border_block().title("Task"));
+        let wakers_widget =
+            Paragraph::new(vec![wakers, wakeups]).block(styles.border_block().title("Waker"));
+        let fields_widget = Paragraph::new(fields).block(styles.border_block().title("Fields"));
         let percentiles_widget = Paragraph::new(
             details
                 .map(|details| details.make_percentiles_widget(styles))
                 .unwrap_or_default(),
         )
-        .block(block_for(styles, "Poll Times Percentiles"));
+        .block(styles.border_block().title("Poll Times Percentiles"));
 
         frame.render_widget(Block::default().title(controls), controls_area);
         frame.render_widget(task_widget, stats_area[0]);

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -108,7 +108,7 @@ impl TaskView {
         let attrs = Spans::from(vec![
             bold("ID: "),
             Span::raw(format!("{} ", task.id())),
-            Span::raw(task.state().render(styles)),
+            task.state().render(styles),
         ]);
         let target = Spans::from(vec![bold("Target: "), Span::raw(task.target())]);
         let total = Spans::from(vec![bold("Total Time: "), dur(styles, task.total(now))]);

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -21,7 +21,7 @@ pub(crate) struct List {
 
 impl List {
     const HEADER: &'static [&'static str] = &[
-        "TID", "STATE", "TOTAL", "BUSY", "IDLE", "POLLS", "TARGET", "FIELDS",
+        "TID", "STATE", "NAME", "TOTAL", "BUSY", "IDLE", "POLLS", "TARGET", "FIELDS",
     ];
 
     pub(crate) fn update_input(&mut self, event: input::Event) {
@@ -101,10 +101,12 @@ impl List {
 
         // Start out wide enough to display the column headers...
         let mut id_width = view::Width::new(Self::HEADER[0].len() as u16);
-        let mut target_width = view::Width::new(Self::HEADER[6].len() as u16);
+        let mut name_width = view::Width::new(Self::HEADER[2].len() as u16);
+        let mut target_width = view::Width::new(Self::HEADER[7].len() as u16);
         let rows = {
             let id_width = &mut id_width;
             let target_width = &mut target_width;
+            let name_width = &mut name_width;
             self.sorted_tasks.iter().filter_map(move |task| {
                 let task = task.upgrade()?;
                 let task = task.borrow();
@@ -116,6 +118,7 @@ impl List {
                         width = id_width.chars() as usize
                     ))),
                     Cell::from(task.state().render(styles)),
+                    Cell::from(name_width.update_str(task.name().to_string())),
                     dur_cell(task.total(now)),
                     dur_cell(task.busy(now)),
                     dur_cell(task.idle(now)),
@@ -170,6 +173,7 @@ impl List {
         // How many characters wide are the fixed-length non-field columns?
         let fixed_col_width = id_width.chars()
             + STATE_LEN
+            + name_width.chars()
             + DUR_LEN as u16
             + DUR_LEN as u16
             + DUR_LEN as u16
@@ -183,6 +187,7 @@ impl List {
         let widths = &[
             id_width.constraint(),
             layout::Constraint::Length(STATE_LEN),
+            name_width.constraint(),
             layout::Constraint::Length(DUR_LEN as u16),
             layout::Constraint::Length(DUR_LEN as u16),
             layout::Constraint::Length(DUR_LEN as u16),

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -1,14 +1,14 @@
 use crate::{
     input,
-    tasks::{self, TaskRef},
+    tasks::{self, TaskRef, TaskState},
     view::{self, bold},
 };
 use std::convert::TryFrom;
 use tui::{
     layout,
     style::{self, Color, Style},
-    text::{self, Spans},
-    widgets::{Block, Cell, Row, Table, TableState},
+    text::{self, Span, Spans},
+    widgets::{Cell, Paragraph, Row, Table, TableState},
 };
 #[derive(Clone, Debug, Default)]
 pub(crate) struct List {
@@ -21,8 +21,12 @@ pub(crate) struct List {
 
 impl List {
     const HEADER: &'static [&'static str] = &[
-        "TID", "STATE", "NAME", "TOTAL", "BUSY", "IDLE", "POLLS", "TARGET", "FIELDS",
+        "ID", "State", "Name", "Total", "Busy", "Idle", "Polls", "Target", "Fields",
     ];
+
+    pub(crate) fn len(&self) -> usize {
+        self.sorted_tasks.len()
+    }
 
     pub(crate) fn update_input(&mut self, event: input::Event) {
         // Clippy likes to remind us that we could use an `if let` here, since
@@ -72,6 +76,20 @@ impl List {
         area: layout::Rect,
         state: &mut tasks::State,
     ) {
+        let chunks = layout::Layout::default()
+            .direction(layout::Direction::Vertical)
+            .margin(0)
+            .constraints(
+                [
+                    layout::Constraint::Length(1),
+                    layout::Constraint::Min(area.height - 1),
+                ]
+                .as_ref(),
+            )
+            .split(area);
+        let controls_area = chunks[0];
+        let tasks_area = chunks[1];
+
         let now = if let Some(now) = state.last_updated_at() {
             now
         } else {
@@ -103,14 +121,26 @@ impl List {
         let mut id_width = view::Width::new(Self::HEADER[0].len() as u16);
         let mut name_width = view::Width::new(Self::HEADER[2].len() as u16);
         let mut target_width = view::Width::new(Self::HEADER[7].len() as u16);
+        let mut num_idle = 0;
+        let mut num_running = 0;
         let rows = {
             let id_width = &mut id_width;
             let target_width = &mut target_width;
             let name_width = &mut name_width;
+            let num_running = &mut num_running;
+            let num_idle = &mut num_idle;
             self.sorted_tasks.iter().filter_map(move |task| {
                 let task = task.upgrade()?;
                 let task = task.borrow();
-                let is_terminated = task.completed_for() > 0;
+                let state = task.state();
+
+                // Count task states
+                match state {
+                    TaskState::Running => *num_running += 1,
+                    TaskState::Idle => *num_idle += 1,
+                    _ => {}
+                };
+
                 let mut row = Row::new(vec![
                     Cell::from(id_width.update_str(format!(
                         "{:>width$}",
@@ -132,35 +162,22 @@ impl List {
                             .collect::<Vec<_>>(),
                     )),
                 ]);
-                if is_terminated {
+                if state == TaskState::Completed {
                     row = row.style(styles.terminated());
                 }
                 Some(row)
             })
         };
 
-        let block = Block::default().title(vec![
-            text::Span::raw("controls: "),
-            bold(styles.if_utf8("\u{2190}\u{2192}", "left, right")),
-            text::Span::raw(" = select column (sort), "),
-            bold(styles.if_utf8("\u{2191}\u{2193}", "up, down")),
-            text::Span::raw(" = scroll, "),
-            bold(styles.if_utf8("\u{21B5}", "enter")),
-            text::Span::raw(" = task details, "),
-            bold("i"),
-            text::Span::raw(" = invert sort (highest/lowest), "),
-            bold("q"),
-            text::Span::raw(" = quit"),
-        ]);
-
-        let header_style = styles
-            .color(Color::Green)
-            .map(|green| Style::default().bg(green).fg(Color::Black))
-            .unwrap_or_else(|| Style::default().add_modifier(style::Modifier::REVERSED));
-        let selected_style = styles
-            .color(Color::Cyan)
-            .map(|cyan| Style::default().bg(cyan).fg(Color::Black))
-            .unwrap_or_else(|| Style::default().remove_modifier(style::Modifier::REVERSED));
+        let (selected_style, header_style) = if let Some(cyan) = styles.color(Color::Cyan) {
+            (Style::default().fg(cyan), Style::default())
+        } else {
+            (
+                Style::default().remove_modifier(style::Modifier::REVERSED),
+                Style::default().add_modifier(style::Modifier::REVERSED),
+            )
+        };
+        let header_style = header_style.add_modifier(style::Modifier::BOLD);
 
         let header = Row::new(Self::HEADER.iter().enumerate().map(|(idx, &value)| {
             let cell = Cell::from(value);
@@ -173,11 +190,19 @@ impl List {
         .height(1)
         .style(header_style);
 
-        let t = if self.sort_descending {
+        let table = if self.sort_descending {
             Table::new(rows)
         } else {
             Table::new(rows.rev())
         };
+
+        let block = styles.border_block().title(vec![
+            bold(format!("Tasks ({}) ", self.len())),
+            TaskState::Running.render(styles),
+            Span::from(format!(" Running ({}) ", num_running)),
+            TaskState::Idle.render(styles),
+            Span::from(format!(" Idle ({})", num_idle)),
+        ]);
 
         // How many characters wide are the fixed-length non-field columns?
         let fixed_col_width = id_width.chars()
@@ -204,14 +229,32 @@ impl List {
             target_width.constraint(),
             layout::Constraint::Min(fields_width),
         ];
-        let t = t
+
+        let table = table
             .header(header)
             .block(block)
             .widths(widths)
             .highlight_symbol(">> ")
             .highlight_style(Style::default().add_modifier(style::Modifier::BOLD));
 
-        frame.render_stateful_widget(t, area, &mut self.table_state);
+        frame.render_stateful_widget(table, tasks_area, &mut self.table_state);
+
+        let controls = tui::text::Text::from(Spans::from(vec![
+            Span::raw("controls: "),
+            bold(styles.if_utf8("\u{2190}\u{2192}", "left, right")),
+            text::Span::raw(" = select column (sort), "),
+            bold(styles.if_utf8("\u{2191}\u{2193}", "up, down")),
+            text::Span::raw(" = scroll, "),
+            bold(styles.if_utf8("\u{21B5}", "enter")),
+            text::Span::raw(" = task details, "),
+            bold("i"),
+            text::Span::raw(" = invert sort (highest/lowest), "),
+            bold("q"),
+            text::Span::raw(" = quit"),
+        ]));
+
+        frame.render_widget(Paragraph::new(controls), controls_area);
+
         self.sorted_tasks.retain(|t| t.upgrade().is_some());
     }
 

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -6,7 +6,7 @@ use crate::{
 use std::convert::TryFrom;
 use tui::{
     layout,
-    style::{self, Style},
+    style::{self, Color, Style},
     text::{self, Spans},
     widgets::{Block, Cell, Row, Table, TableState},
 };
@@ -153,16 +153,25 @@ impl List {
             text::Span::raw(" = quit"),
         ]);
 
+        let header_style = styles
+            .color(Color::Green)
+            .map(|green| Style::default().bg(green).fg(Color::Black))
+            .unwrap_or_else(|| Style::default().add_modifier(style::Modifier::REVERSED));
+        let selected_style = styles
+            .color(Color::Cyan)
+            .map(|cyan| Style::default().bg(cyan).fg(Color::Black))
+            .unwrap_or_else(|| Style::default().remove_modifier(style::Modifier::REVERSED));
+
         let header = Row::new(Self::HEADER.iter().enumerate().map(|(idx, &value)| {
             let cell = Cell::from(value);
             if idx == self.selected_column {
-                cell.style(Style::default().remove_modifier(style::Modifier::REVERSED))
+                cell.style(selected_style)
             } else {
                 cell
             }
         }))
         .height(1)
-        .style(Style::default().add_modifier(style::Modifier::REVERSED));
+        .style(header_style);
 
         let t = if self.sort_descending {
             Table::new(rows)

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -108,7 +108,7 @@ impl List {
             self.sorted_tasks.iter().filter_map(move |task| {
                 let task = task.upgrade()?;
                 let task = task.borrow();
-
+                let is_terminated = task.completed_for() > 0;
                 let mut row = Row::new(vec![
                     Cell::from(id_width.update_str(task.id().to_string())),
                     Cell::from(task.state().render(styles)),
@@ -125,7 +125,7 @@ impl List {
                             .collect::<Vec<_>>(),
                     )),
                 ]);
-                if task.completed_for() > 0 {
+                if is_terminated {
                     row = row.style(styles.terminated());
                 }
                 Some(row)

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -110,7 +110,11 @@ impl List {
                 let task = task.borrow();
                 let is_terminated = task.completed_for() > 0;
                 let mut row = Row::new(vec![
-                    Cell::from(id_width.update_str(task.id().to_string())),
+                    Cell::from(id_width.update_str(format!(
+                        "{:>width$}",
+                        task.id(),
+                        width = id_width.chars() as usize
+                    ))),
                     Cell::from(task.state().render(styles)),
                     dur_cell(task.total(now)),
                     dur_cell(task.busy(now)),


### PR DESCRIPTION
This branch implements a bit more of the design proposed by @pcwalton in
issue #25. I haven't implemented everything in the mockups linked in
that issue, because some features in the mocks depend on _data_ we don't
currently have. However, I've brought the design closer in line with the
proposal.

## Before

![image](https://user-images.githubusercontent.com/2796466/129774678-f1c0e5c5-7bb0-4d1c-a9e6-e0cbf679c523.png)
![image](https://user-images.githubusercontent.com/2796466/129774762-9a1c14de-4ad0-4678-9923-13971cb3a48b.png)

## After

![image](https://user-images.githubusercontent.com/2796466/129774465-7bd2ad2f-f1a3-4830-a8fa-f72667028fa1.png)
![image](https://user-images.githubusercontent.com/2796466/129774524-288c967b-6066-4f98-973d-099b3e6a2c55.png)
