### PR TITLE
feat(subscriber): accept durations with units

### DIFF
--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -195,6 +195,7 @@ fn parse_duration(s: &str) -> Result<Duration, Box<dyn std::error::Error>> {
         .or_else(|| s.strip_suffix("minutes"))
     {
         return Ok(s
+            .trim()
             .parse::<u64>()
             .map(|mins| Duration::from_secs(mins * 60))
             .or_else(|_| {
@@ -205,6 +206,7 @@ fn parse_duration(s: &str) -> Result<Duration, Box<dyn std::error::Error>> {
 
     if let Some(s) = s.strip_suffix('h').or_else(|| s.strip_suffix("hours")) {
         return Ok(s
+            .trim()
             .parse::<u64>()
             .map(|hours| Duration::from_secs(hours * 60 * 60))
             .or_else(|_| {

--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -164,34 +164,26 @@ fn duration_from_env(var_name: &str) -> Option<Duration> {
 
 fn parse_duration(s: &str) -> Result<Duration, Box<dyn std::error::Error>> {
     let s = s.trim();
-
-    if let Some(s) = s.strip_suffix("ns") {
-        return Ok(Duration::from_nanos(s.trim().parse()?));
-    }
-
-    if let Some(s) = s.strip_suffix("us") {
-        return Ok(Duration::from_micros(s.trim().parse()?));
-    }
-
-    if let Some(s) = s.strip_suffix("ms") {
-        return Ok(Duration::from_millis(s.trim().parse()?));
-    }
-
     if let Some(s) = s
-        .strip_suffix('s')
-        .or_else(|| s.strip_suffix("sec"))
-        .or_else(|| s.strip_suffix("seconds"))
+        .strip_suffix('h')
+        .or_else(|| s.strip_suffix("hour"))
+        .or_else(|| s.strip_suffix("hours"))
     {
         return Ok(s
             .trim()
             .parse::<u64>()
-            .map(Duration::from_secs)
-            .or_else(|_| s.parse::<f64>().map(Duration::from_secs_f64))?);
+            .map(|hours| Duration::from_secs(hours * 60 * 60))
+            .or_else(|_| {
+                s.parse::<f64>()
+                    .map(|hours| Duration::from_secs_f64(hours * 60.0 * 60.0))
+            })?);
     }
 
     if let Some(s) = s
         .strip_suffix('m')
         .or_else(|| s.strip_suffix("min"))
+        .or_else(|| s.strip_suffix("mins"))
+        .or_else(|| s.strip_suffix("minute"))
         .or_else(|| s.strip_suffix("minutes"))
     {
         return Ok(s
@@ -204,15 +196,33 @@ fn parse_duration(s: &str) -> Result<Duration, Box<dyn std::error::Error>> {
             })?);
     }
 
-    if let Some(s) = s.strip_suffix('h').or_else(|| s.strip_suffix("hours")) {
+    if let Some(s) = s.strip_suffix("ms") {
+        return Ok(Duration::from_millis(s.trim().parse()?));
+    }
+
+    if let Some(s) = s.strip_suffix("us") {
+        return Ok(Duration::from_micros(s.trim().parse()?));
+    }
+
+    // Order matters here -- we have to try `ns` for nanoseconds after we try
+    // minutes, because `mins` ends in `ns`.
+    if let Some(s) = s.strip_suffix("ns") {
+        return Ok(Duration::from_nanos(s.trim().parse()?));
+    }
+
+    if let Some(s) = s
+        .strip_suffix("sec")
+        .or_else(|| s.strip_suffix("secs"))
+        .or_else(|| s.strip_suffix("seconds"))
+        // Order matters here -- we have to try `s` for seconds _last_, because
+        // every other plural and subsecond unit also ends in `s`...
+        .or_else(|| s.strip_suffix('s'))
+    {
         return Ok(s
             .trim()
             .parse::<u64>()
-            .map(|hours| Duration::from_secs(hours * 60 * 60))
-            .or_else(|_| {
-                s.parse::<f64>()
-                    .map(|hours| Duration::from_secs_f64(hours * 60.0 * 60.0))
-            })?);
+            .map(Duration::from_secs)
+            .or_else(|_| s.parse::<f64>().map(Duration::from_secs_f64))?);
     }
 
     Err("expected an integer followed by one of {`ns`, `us`, `ms`, `s`, `sec`, `m`, `min`, `h`, `hours`}".into())

--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -292,4 +292,48 @@ mod tests {
             ],
         )
     }
+
+    #[test]
+    fn parse_fractional_hours() {
+        test_parse_durations(
+            Duration::from_millis(1500 * 60 * 60),
+            &["1.5h", "1.5 h", " 1.5 h", "1.5 hours", "1.5hours"],
+        )
+    }
+
+    #[test]
+    fn parse_fractional_mins() {
+        test_parse_durations(
+            Duration::from_millis(1500 * 60),
+            &[
+                "1.5m",
+                "1.5 m",
+                "1.5 m",
+                "1.5 minutes",
+                "1.5 minutes",
+                "  1.5 minutes",
+                "1.5 min",
+                " 1.5 min",
+                "1.5min",
+            ],
+        )
+    }
+
+    #[test]
+    fn parse_fractional_secs() {
+        test_parse_durations(
+            Duration::from_millis(1500),
+            &[
+                "1.5s",
+                "1.5 s",
+                "1.5 s",
+                "1.5 seconds",
+                "1.5 seconds",
+                "  1.5 seconds",
+                "1.5 sec",
+                " 1.5 sec",
+                "1.5sec",
+            ],
+        )
+    }
 }

--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -169,8 +169,8 @@ fn parse_duration(s: &str) -> Result<Duration, Box<dyn std::error::Error>> {
         .or_else(|| s.strip_suffix("hour"))
         .or_else(|| s.strip_suffix("hours"))
     {
+        let s = s.trim();
         return Ok(s
-            .trim()
             .parse::<u64>()
             .map(|hours| Duration::from_secs(hours * 60 * 60))
             .or_else(|_| {
@@ -186,8 +186,8 @@ fn parse_duration(s: &str) -> Result<Duration, Box<dyn std::error::Error>> {
         .or_else(|| s.strip_suffix("minute"))
         .or_else(|| s.strip_suffix("minutes"))
     {
+        let s = s.trim();
         return Ok(s
-            .trim()
             .parse::<u64>()
             .map(|mins| Duration::from_secs(mins * 60))
             .or_else(|_| {
@@ -218,8 +218,8 @@ fn parse_duration(s: &str) -> Result<Duration, Box<dyn std::error::Error>> {
         // every other plural and subsecond unit also ends in `s`...
         .or_else(|| s.strip_suffix('s'))
     {
+        let s = s.trim();
         return Ok(s
-            .trim()
             .parse::<u64>()
             .map(Duration::from_secs)
             .or_else(|_| s.parse::<f64>().map(Duration::from_secs_f64))?);


### PR DESCRIPTION
This branch updates the `console-subscriber` env var parsing code to accept
durations with units. Durations may now be given in any of `ns`, `us`,
`ms`, `s`, `sec`, `seconds`, `m`, `min`, `minutes`, `h`, or `hours`.
Durations specified in seconds or a larger unit may also be given as fractional values,
such as `1.5min`.

As a follow-up, we may also want to allow specifying durations as a
combination of multiple units, such as `3h15m`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>