### PR TITLE
feat(console): periodically shrink growable collections

### DIFF
--- a/console-subscriber/src/aggregator/shrink.rs
+++ b/console-subscriber/src/aggregator/shrink.rs
@@ -1,0 +1,227 @@
+use std::{
+    any::type_name,
+    collections::hash_map::{HashMap, RandomState},
+    hash::{BuildHasher, Hash},
+    mem,
+    ops::{Deref, DerefMut},
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ShrinkMap<K, V, S = RandomState> {
+    map: HashMap<K, V, S>,
+    shrink: Shrink,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ShrinkVec<T> {
+    vec: Vec<T>,
+    shrink: Shrink,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Shrink {
+    shrink_every: usize,
+    since_shrink: usize,
+    min_bytes: usize,
+}
+
+// === impl ShrinkMap ===
+
+impl<K, V> ShrinkMap<K, V>
+where
+    K: Hash + Eq,
+{
+    pub(crate) fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            shrink: Shrink::default(),
+        }
+    }
+}
+
+impl<K, V, S> ShrinkMap<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher,
+{
+    pub(crate) fn try_shrink(&mut self) {
+        self.shrink.try_shrink_map(&mut self.map)
+    }
+
+    pub(crate) fn retain_and_shrink(&mut self, f: impl FnMut(&K, &mut V) -> bool) {
+        let len0 = self.len();
+
+        self.retain(f);
+
+        if self.len() < len0 {
+            tracing::debug!(
+                len = self.len(),
+                dropped = len0.saturating_sub(self.len()),
+                data.key = %type_name::<K>(),
+                data.val = %type_name::<V>(),
+                "dropped unused entries"
+            );
+            self.try_shrink();
+        }
+    }
+}
+
+impl<K, V, S> Deref for ShrinkMap<K, V, S> {
+    type Target = HashMap<K, V, S>;
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl<K, V, S> DerefMut for ShrinkMap<K, V, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.map
+    }
+}
+
+impl<K, V> Default for ShrinkMap<K, V>
+where
+    K: Hash + Eq,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// === impl ShrinkVec ===
+
+impl<T> ShrinkVec<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            vec: Vec::new(),
+            shrink: Shrink::default(),
+        }
+    }
+
+    pub(crate) fn try_shrink(&mut self) {
+        self.shrink.try_shrink_vec(&mut self.vec)
+    }
+
+    pub(crate) fn retain_and_shrink(&mut self, f: impl FnMut(&T) -> bool) {
+        let len0 = self.len();
+
+        self.retain(f);
+
+        if self.len() < len0 {
+            tracing::debug!(
+                len = self.len(),
+                dropped = len0.saturating_sub(self.len()),
+                data = %type_name::<T>(),
+                "dropped unused data"
+            );
+            self.try_shrink();
+        }
+    }
+}
+
+impl<T> Deref for ShrinkVec<T> {
+    type Target = Vec<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.vec
+    }
+}
+
+impl<T> DerefMut for ShrinkVec<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.vec
+    }
+}
+
+impl<T> Default for ShrinkVec<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// === impl Shrink ===
+
+impl Shrink {
+    /// Shrinking every 60 flushes should be roughly every minute.
+    pub(crate) const DEFAULT_SHRINK_INTERVAL: usize = 60;
+
+    /// Don't bother if we'd free less than 4KB of memory.
+    // TODO(eliza): this number was chosen totally arbitrarily; it's the minimum
+    // page size on x86.
+    pub(crate) const DEFAULT_MIN_SIZE_BYTES: usize = 1024 * 4;
+
+    pub(crate) fn try_shrink_map<K, V, S>(&mut self, map: &mut HashMap<K, V, S>)
+    where
+        K: Hash + Eq,
+        S: BuildHasher,
+    {
+        if self.should_shrink::<(K, V)>(map.capacity(), map.len()) {
+            map.shrink_to_fit();
+        }
+    }
+
+    pub(crate) fn try_shrink_vec<T>(&mut self, vec: &mut Vec<T>) {
+        if self.should_shrink::<T>(vec.capacity(), vec.len()) {
+            vec.shrink_to_fit();
+        }
+    }
+
+    /// Returns `true` if we should shrink with a capacity of `capacity` Ts and
+    /// an actual length of `len` Ts.
+    fn should_shrink<T>(&mut self, capacity: usize, len: usize) -> bool {
+        // Has the required interval elapsed since the last shrink?
+        self.since_shrink = self.since_shrink.saturating_add(1);
+        if self.since_shrink < self.shrink_every {
+            tracing::trace!(
+                self.since_shrink,
+                self.shrink_every,
+                capacity_bytes = capacity * mem::size_of::<T>(),
+                used_bytes = len * mem::size_of::<T>(),
+                data = %type_name::<T>(),
+                "should_shrink: shrink interval has not elapsed"
+            );
+            return false;
+        }
+
+        // Okay, would we free up at least `min_bytes` by shrinking?
+        let capacity_bytes = capacity * mem::size_of::<T>();
+        let used_bytes = len * mem::size_of::<T>();
+        let diff = capacity_bytes.saturating_sub(used_bytes);
+        if diff < self.min_bytes {
+            tracing::trace!(
+                self.since_shrink,
+                self.shrink_every,
+                self.min_bytes,
+                freed_bytes = diff,
+                capacity_bytes,
+                used_bytes,
+                data = %type_name::<T>(),
+                "should_shrink: would not free sufficient bytes"
+            );
+            return false;
+        }
+
+        // Reset the clock! time to shrink!
+        self.since_shrink = 0;
+        tracing::debug!(
+            self.since_shrink,
+            self.shrink_every,
+            self.min_bytes,
+            freed_bytes = diff,
+            capacity_bytes,
+            used_bytes,
+            data = %type_name::<T>(),
+            "should_shrink: shrinking!"
+        );
+        true
+    }
+}
+
+impl Default for Shrink {
+    fn default() -> Self {
+        Self {
+            since_shrink: 0,
+            shrink_every: Self::DEFAULT_SHRINK_INTERVAL,
+            min_bytes: Self::DEFAULT_MIN_SIZE_BYTES,
+        }
+    }
+}

--- a/console-subscriber/src/aggregator/task_data.rs
+++ b/console-subscriber/src/aggregator/task_data.rs
@@ -1,12 +1,14 @@
 use super::TaskId;
 use std::{
     collections::HashMap,
+    mem,
     ops::{Deref, DerefMut},
 };
 
-#[derive(Default)]
 pub(crate) struct TaskData<T> {
     data: HashMap<TaskId, (T, bool)>,
+    shrink_every: usize,
+    since_shrink: usize,
 }
 
 pub(crate) struct Updating<'a, T>(&'a mut (T, bool));
@@ -14,9 +16,20 @@ pub(crate) struct Updating<'a, T>(&'a mut (T, bool));
 // === impl TaskData ===
 
 impl<T> TaskData<T> {
+    /// Shrinking every 60 flushes should be roughly every minute.
+    pub(crate) const DEFAULT_SHRINK_INTERVAL: usize = 60;
+
+    // APPROXIMATE memory used per entry. This is a lower-bound, not an accurate
+    // size measurement, since the hashmap may use additional heap memory beyond
+    // the size of a key + value pair.
+    const APPROX_ENTRY_SZ: usize =
+        mem::size_of::<T>() + mem::size_of::<TaskId>() + mem::size_of::<bool>();
+
     pub(crate) fn new() -> Self {
         Self {
             data: HashMap::new(),
+            shrink_every: Self::DEFAULT_SHRINK_INTERVAL,
+            since_shrink: 0,
         }
     }
 
@@ -62,8 +75,55 @@ impl<T> TaskData<T> {
         self.data.len()
     }
 
-    pub(crate) fn retain(&mut self, mut f: impl FnMut(&TaskId, &mut T, bool) -> bool) {
-        self.data.retain(|id, (data, dirty)| f(id, data, *dirty))
+    fn size_estimate_bytes(&self) -> usize {
+        self.data.capacity() * Self::APPROX_ENTRY_SZ
+    }
+
+    pub(crate) fn retain(&mut self, mut f: impl FnMut(&TaskId, &mut T, bool) -> bool) -> bool {
+        let len_0 = self.len();
+
+        self.data.retain(|id, (data, dirty)| f(id, data, *dirty));
+
+        let len_1 = self.len();
+
+        // If no data was dropped on this pass, we're done!
+        if len_1 == len_0 {
+            tracing::trace!(
+                len = len_0,
+                size_estimate_bytes = self.size_estimate_bytes(),
+                data = %std::any::type_name::<T>(),
+                "no closed data was droppable",
+            );
+            return false;
+        }
+
+        // If we dropped some data, consider shrinking the hashmap.
+        let should_shrink = self.since_shrink >= self.shrink_every;
+        tracing::debug!(
+            dropped = len_0 - len_1,
+            len = len_1,
+            should_shrink,
+            since_shrink = self.since_shrink,
+            size_estimate_bytes = self.size_estimate_bytes(),
+            data = %std::any::type_name::<T>(),
+            "dropped closed data",
+        );
+
+        if should_shrink {
+            let size_0 = self.size_estimate_bytes();
+            self.since_shrink = 0;
+            self.data.shrink_to_fit();
+            tracing::debug!(
+                freed_bytes = size_0.saturating_sub(self.size_estimate_bytes()),
+                size_estimate_bytes = self.size_estimate_bytes(),
+                "shrank to fit"
+            );
+        } else {
+            self.since_shrink += 1;
+            tracing::trace!(self.since_shrink, size_estimate_bytes = %format_args!("{}B", self.size_estimate_bytes()));
+        }
+
+        true
     }
 }
 

--- a/console-subscriber/src/aggregator/task_data.rs
+++ b/console-subscriber/src/aggregator/task_data.rs
@@ -1,0 +1,89 @@
+use super::TaskId;
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
+
+#[derive(Default)]
+pub(crate) struct TaskData<T> {
+    data: HashMap<TaskId, (T, bool)>,
+}
+
+pub(crate) struct Updating<'a, T>(&'a mut (T, bool));
+
+// === impl TaskData ===
+
+impl<T> TaskData<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn update_or_default(&mut self, id: TaskId) -> Updating<'_, T>
+    where
+        T: Default,
+    {
+        Updating(self.data.entry(id).or_default())
+    }
+
+    pub(crate) fn update(&mut self, id: &TaskId) -> Option<Updating<'_, T>> {
+        self.data.get_mut(id).map(Updating)
+    }
+
+    pub(crate) fn insert(&mut self, id: TaskId, data: T) {
+        self.data.insert(id, (data, true));
+    }
+
+    pub(crate) fn since_last_update(&mut self) -> impl Iterator<Item = (&TaskId, &mut T)> {
+        self.data.iter_mut().filter_map(|(id, (data, dirty))| {
+            if *dirty {
+                *dirty = false;
+                Some((id, data))
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(crate) fn all(&self) -> impl Iterator<Item = (&TaskId, &T)> {
+        self.data.iter().map(|(id, (data, _))| (id, data))
+    }
+
+    pub(crate) fn get(&self, id: &TaskId) -> Option<&T> {
+        self.data.get(id).map(|(data, _)| data)
+    }
+
+    pub(crate) fn contains(&self, id: &TaskId) -> bool {
+        self.data.contains_key(id)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub(crate) fn retain(&mut self, mut f: impl FnMut(&TaskId, &mut T, bool) -> bool) {
+        self.data.retain(|id, (data, dirty)| f(id, data, *dirty))
+    }
+}
+
+// === impl Updating ===
+
+impl<'a, T> Deref for Updating<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0 .0
+    }
+}
+
+impl<'a, T> DerefMut for Updating<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0 .0
+    }
+}
+
+impl<'a, T> Drop for Updating<'a, T> {
+    fn drop(&mut self) {
+        self.0 .1 = true;
+    }
+}

--- a/console-subscriber/src/aggregator/task_data.rs
+++ b/console-subscriber/src/aggregator/task_data.rs
@@ -1,33 +1,18 @@
-use super::TaskId;
-use std::{
-    any::type_name,
-    collections::HashMap,
-    hash::Hash,
-    mem,
-    ops::{Deref, DerefMut},
-};
+use super::{shrink::ShrinkMap, TaskId};
+use std::ops::{Deref, DerefMut};
 
 pub(crate) struct TaskData<T> {
-    data: HashMap<TaskId, (T, bool)>,
-    shrink: Shrink,
+    data: ShrinkMap<TaskId, (T, bool)>,
 }
 
 pub(crate) struct Updating<'a, T>(&'a mut (T, bool));
-
-#[derive(Debug)]
-pub(crate) struct Shrink {
-    shrink_every: usize,
-    since_shrink: usize,
-    min_bytes: usize,
-}
 
 // === impl TaskData ===
 
 impl<T> TaskData<T> {
     pub(crate) fn new() -> Self {
         Self {
-            data: HashMap::new(),
-            shrink: Shrink::default(),
+            data: ShrinkMap::new(),
         }
     }
 
@@ -69,37 +54,9 @@ impl<T> TaskData<T> {
         self.data.contains_key(id)
     }
 
-    pub(crate) fn len(&self) -> usize {
-        self.data.len()
-    }
-
-    pub(crate) fn retain(&mut self, mut f: impl FnMut(&TaskId, &mut T, bool) -> bool) -> bool {
-        let len_0 = self.len();
-
-        self.data.retain(|id, (data, dirty)| f(id, data, *dirty));
-
-        let len_1 = self.len();
-
-        // If no data was dropped on this pass, we're done!
-        if len_1 == len_0 {
-            tracing::trace!(
-                len = len_0,
-                data = %type_name::<T>(),
-                "no closed data was droppable",
-            );
-            return false;
-        }
-
-        // If we dropped some data, consider shrinking the hashmap.
-        tracing::debug!(
-            len = len_1,
-            dropped = len_0.saturating_sub(len_1),
-            data = %type_name::<T>(),
-            "dropped closed data"
-        );
-        self.shrink.try_shrink_map(&mut self.data);
-
-        true
+    pub(crate) fn retain_and_shrink(&mut self, mut f: impl FnMut(&TaskId, &mut T, bool) -> bool) {
+        self.data
+            .retain_and_shrink(|id, (data, dirty)| f(id, data, *dirty));
     }
 }
 
@@ -121,92 +78,5 @@ impl<'a, T> DerefMut for Updating<'a, T> {
 impl<'a, T> Drop for Updating<'a, T> {
     fn drop(&mut self) {
         self.0 .1 = true;
-    }
-}
-
-// === impl Shrink ===
-
-impl Shrink {
-    /// Shrinking every 60 flushes should be roughly every minute.
-    pub(crate) const DEFAULT_SHRINK_INTERVAL: usize = 60;
-
-    /// Don't bother if we'd free less than 4KB of memory.
-    // TODO(eliza): this number was chosen totally arbitrarily; it's the minimum
-    // page size on x86.
-    pub(crate) const DEFAULT_MIN_SIZE_BYTES: usize = 1024 * 4;
-
-    pub(crate) fn try_shrink_map<K, V>(&mut self, map: &mut HashMap<K, V>)
-    where
-        K: Hash + Eq,
-    {
-        if self.should_shrink::<(K, V)>(map.capacity(), map.len()) {
-            map.shrink_to_fit();
-        }
-    }
-
-    pub(crate) fn try_shrink_vec<T>(&mut self, vec: &mut Vec<T>) {
-        if self.should_shrink::<T>(vec.capacity(), vec.len()) {
-            vec.shrink_to_fit();
-        }
-    }
-
-    /// Returns `true` if we should shrink with a capacity of `capacity` Ts and
-    /// an actual length of `len` Ts.
-    fn should_shrink<T>(&mut self, capacity: usize, len: usize) -> bool {
-        // Has the required interval elapsed since the last shrink?
-        self.since_shrink = self.since_shrink.saturating_add(1);
-        if self.since_shrink < self.shrink_every {
-            tracing::trace!(
-                self.since_shrink,
-                self.shrink_every,
-                capacity_bytes = capacity * mem::size_of::<T>(),
-                used_bytes = len * mem::size_of::<T>(),
-                data = %type_name::<T>(),
-                "should_shrink: shrink interval has not elapsed"
-            );
-            return false;
-        }
-
-        // Okay, would we free up at least `min_bytes` by shrinking?
-        let capacity_bytes = capacity * mem::size_of::<T>();
-        let used_bytes = len * mem::size_of::<T>();
-        let diff = capacity_bytes.saturating_sub(used_bytes);
-        if diff < self.min_bytes {
-            tracing::trace!(
-                self.since_shrink,
-                self.shrink_every,
-                self.min_bytes,
-                freed_bytes = diff,
-                capacity_bytes,
-                used_bytes,
-                data = %type_name::<T>(),
-                "should_shrink: would not free sufficient bytes"
-            );
-            return false;
-        }
-
-        // Reset the clock! time to shrink!
-        self.since_shrink = 0;
-        tracing::debug!(
-            self.since_shrink,
-            self.shrink_every,
-            self.min_bytes,
-            freed_bytes = diff,
-            capacity_bytes,
-            used_bytes,
-            data = %type_name::<T>(),
-            "should_shrink: shrinking!"
-        );
-        true
-    }
-}
-
-impl Default for Shrink {
-    fn default() -> Self {
-        Self {
-            since_shrink: 0,
-            shrink_every: Self::DEFAULT_SHRINK_INTERVAL,
-            min_bytes: Self::DEFAULT_MIN_SIZE_BYTES,
-        }
     }
 }


### PR DESCRIPTION
The `Aggregator` task spawned by the console subscriber contains a
number of growable collections (`HashMap`s and `Vec`s) that are used to
store aggregated task data, as well as handles for RPC channels. These
will grow over time as more values are added. In a long-running program,
they may eventually become quite large. Because the Rust standard
library's collections have amortized reallocation behavior, the memory
use of a `HashMap` or `Vec` is _not_ O(_n_), where _n_ is the current
number of elements. Instead, the memory use is O(max(_n_)) --- the
_largest_ number of elements that have _ever_ been in that collection
over the entire lifetime of the program.

In some cases, such as when a bursty workload results in spikes in the
number of spawned tasks, the allocated capacity of these collections may
be significantly higher than the actual amount of space needed to store
the current values in the collection.

In order to avoid unbounded memory growth when using the console
subscriber, this branch adds periodic `shrink_to_fit` calls to the
`Aggregator` task's `Vec`s and `HashMap`s. Of course, we don't want to
call `shrink_to_fit` every time elements are removed from a collection
--- this would negate the performance benefits of amortized
reallocation, since we would constantly be reallocating and coping the
collection into new allocations. Instead, we want to have some kind of
heuristic that ensures we shrink collections occasionally to avoid
unbounded growth, but don't do it so often that the program spends all
its time `malloc`ing and copying. 

This branch currently implements a fairly simple heuristic where we
decide to shrink based on two factors: a counter and interval between
shrinks, and a minimum number of bytes necessary to shrink. The way this
works is: every time we call `retain` on a collection and actually
remove elements, we increment the counter. If the count is greater than
the minimum interval between shrinks, *and* the difference between the
collection's allocated capacity and its actual used size (the amount of
space that would be freed by shrinking) is over the minimum number of
bytes, we call `shrink_to_fit` and reset the counter. Otherwise, we keep
going. The counter and interval ensure that we only shrink occasionally,
instead of after every `retain` call, while the minimum number of bytes
ensures we don't call `shrink_to_fit` when we are close to the current
allocated capacity and would only free up a small amount of storage
anyway.

The default values for these constants are currently an interval of at
least 60 retains between shrinks, and a minimum freed bytes of 4kb. Both
of these values were chosen totally arbitrarily and there's definitely a
lot of room for tuning them, but I just wanted to pick something for
now.

In the future, we may want to consider a smarter heuristic, such as
tracking a moving average of collection capacity and length, and
shrinking back to the average capacity after we have returned to the
average _length_ after a significant deviation in length. The idea
behind this that we  allow the collection to "warm up" to the maximum
size needed for "normal" program operation, and stay there without
causing unnecessary reallocations when everything is normal. If,
however, we have to grow the collection significantly to compensate for
a sudden spike in the number of tasks, we would eventually return to the
size where normal operation doesn't require us to grow the collection.
However, this kind of approach is significantly more complex than the
simple heuristic in this PR, so I thought we ought to save that for
later.