### PR TITLE
subscriber: remove trace event calls from the subscriber

### DIFF
--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -516,10 +516,8 @@ impl Flush {
             .is_ok()
         {
             self.should_flush.notify_one();
-            tracing::trace!("flush triggered");
         } else {
             // someone else already did it, that's fine...
-            tracing::trace!("flush already triggered");
         }
     }
 }


### PR DESCRIPTION
It was noted that emitting a tracing event inside the subscriber could
trigger a deadlock, since `std::sync::Once` is not re-entrant. This
removes the tracing from the subscriber `Layer` methods.

If the capacity was full, sending the event was spawned into tokio, but
the event might not have been inside a runtime in the first place. And
it essentially turns it into an unbounded queue. So that is also
removed.

It also changes from using a constant `FLUSH_AT_CAPACITY` to a struct
field that is based on the configured event buffer capacity. A value of
half the buffer capacity was chosen, since hitting a full channel will
now mean the event is completely lost.

Fixes #27 