### PR TITLE
feat(subscriber): spill callsites into hash set 

### DIFF
--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+parking_lot = ["parking_lot_crate", "tracing-subscriber/parking_lot"]
 
 [dependencies]
 
@@ -19,6 +22,9 @@ futures = { version = "0.3", default-features = false }
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# The parking_lot dependency is renamed, because we want our `parking_lot`
+# feature to also enable `tracing-subscriber`'s parking_lot feature flag.
+parking_lot_crate = { package = "parking_lot", version = "0.11", optional = true }
 
 [dev-dependencies]
 

--- a/console-subscriber/src/callsites.rs
+++ b/console-subscriber/src/callsites.rs
@@ -1,10 +1,8 @@
+use crate::sync::RwLock;
 use std::{
     collections::HashSet,
     fmt, ptr,
-    sync::{
-        atomic::{AtomicPtr, AtomicUsize, Ordering},
-        PoisonError, RwLock,
-    },
+    sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
 use tracing_core::{callsite, Metadata};
 
@@ -39,10 +37,7 @@ impl<const MAX_CALLSITES: usize> Callsites<MAX_CALLSITES> {
         } else {
             // Otherwise, we've filled the callsite array (sad!). Spill over
             // into a hash set.
-            self.spill
-                .write()
-                .unwrap_or_else(PoisonError::into_inner)
-                .insert(callsite.callsite());
+            self.spill.write().insert(callsite.callsite());
         }
     }
 
@@ -79,10 +74,7 @@ impl<const MAX_CALLSITES: usize> Callsites<MAX_CALLSITES> {
 
     #[cold]
     fn check_spill(&self, callsite: &'static Metadata<'static>) -> bool {
-        self.spill
-            .read()
-            .unwrap_or_else(PoisonError::into_inner)
-            .contains(&callsite.callsite())
+        self.spill.read().contains(&callsite.callsite())
     }
 }
 

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -21,6 +21,7 @@ mod builder;
 mod callsites;
 mod init;
 mod record;
+pub(crate) mod sync;
 
 use aggregator::Aggregator;
 pub use builder::Builder;

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -40,15 +40,16 @@ pub struct TasksLayer {
     /// Set of callsites for spans representing spawned tasks.
     ///
     /// For task spans, each runtime these will have like, 1-5 callsites in it, max, so
-    /// 16 is probably fine. For async operations, we may need a bigger callsites array.
-    spawn_callsites: Callsites<16>,
+    /// 8 should be plenty. If several runtimes are in use, we may have to spill
+    /// over into the backup hashmap, but it's unlikely.
+    spawn_callsites: Callsites<8>,
 
     /// Set of callsites for events representing waker operations.
     ///
-    /// 32 is probably a reasonable number of waker ops; it's a bit generous if
+    /// 16 is probably a reasonable number of waker ops; it's a bit generous if
     /// there's only one async runtime library in use, but if there are multiple,
     /// they might all have their own sets of waker ops.
-    waker_callsites: Callsites<32>,
+    waker_callsites: Callsites<16>,
 }
 
 pub struct Server {

--- a/console-subscriber/src/sync.rs
+++ b/console-subscriber/src/sync.rs
@@ -1,0 +1,49 @@
+// Some of these methods and re-exports may not be used currently.
+#![allow(dead_code, unused_imports)]
+
+#[cfg(feature = "parking_lot")]
+pub(crate) use parking_lot_crate::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+#[cfg(not(feature = "parking_lot"))]
+pub(crate) use self::std_impl::*;
+
+#[cfg(not(feature = "parking_lot"))]
+mod std_impl {
+    use std::sync::{self, PoisonError, TryLockError};
+    pub use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+
+    #[derive(Debug, Default)]
+    pub(crate) struct RwLock<T: ?Sized>(sync::RwLock<T>);
+
+    impl<T> RwLock<T> {
+        pub(crate) fn new(data: T) -> Self {
+            Self(sync::RwLock::new(data))
+        }
+    }
+
+    impl<T: ?Sized> RwLock<T> {
+        pub(crate) fn read(&self) -> RwLockReadGuard<'_, T> {
+            self.0.read().unwrap_or_else(PoisonError::into_inner)
+        }
+
+        pub(crate) fn try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
+            match self.0.try_read() {
+                Ok(guard) => Some(guard),
+                Err(TryLockError::Poisoned(p)) => Some(p.into_inner()),
+                Err(TryLockError::WouldBlock) => None,
+            }
+        }
+
+        pub(crate) fn write(&self) -> RwLockWriteGuard<'_, T> {
+            self.0.write().unwrap_or_else(PoisonError::into_inner)
+        }
+
+        pub(crate) fn try_write(&self) -> Option<RwLockWriteGuard<'_, T>> {
+            match self.0.try_write() {
+                Ok(guard) => Some(guard),
+                Err(TryLockError::Poisoned(p)) => Some(p.into_inner()),
+                Err(TryLockError::WouldBlock) => None,
+            }
+        }
+    }
+}


### PR DESCRIPTION
This changes the `Callsites` behavior when the array of callsites is
full. Currently, we panic in this case. This means that we are quite
generous with array sizes, for cases where, e.g., multiple async
runtimes are in use. However, being more generous with the array's
length makes the linear search performance worse.

This branch replaces the panicking behavior with a spillover behavior.
Once the array of callsites is full, we will now store any additional
callsites in a `HashSet`, rather than panicking. This means we can make
the arrays a bit shorter, and (perhaps more importantly) it means we
will no longer panic in the (rare) case where an app contains a big pile
of interesting callsites.

The spillover `HashSet` is protected by a `RwLock`, which is kind of
a bummer, since it may be locked when checking if a span/event is
in the set of callsites we care about (but only if we have spilled over).
However, it should be _contended_ only very rarely, since writes only
occur when registering a new callsite. 

I added an optional `parking_lot` feature to use `parking_lot`'s
`RwLock` implementation, which likely offers better performance than
`std`'s lock (especially when uncontended, which this lock often is).
The feature is disabled by default, for users who don't want the
additional dependency.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
