### PR TITLE
fix(console): don't crash if `COLORTERM`/`LANG` is not set

### DIFF
--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -157,7 +157,7 @@ impl ViewOptions {
             return stdout
                 .map_err(|err| tracing::warn!(%err, "`tput colors` stdout was not utf-8 (this shouldn't happen)"))
                 .and_then(|s| {
-                    let palette = s.trim().parse::<Palette>();
+                    let palette = s.parse::<Palette>();
                     tracing::debug!(?palette, "parsed `tput colors`");
                     palette.map_err(|_| tracing::warn!(palette = ?s, "invalid color palette from `tput colors`"))
                 })

--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -55,7 +55,7 @@ pub struct ViewOptions {
         parse(from_str = parse_true_color),
         possible_values = &["24bit", "truecolor"],
     )]
-    truecolor: bool,
+    truecolor: Option<bool>,
 
     /// Explicitly set which color palette to use.
     #[clap(
@@ -142,7 +142,7 @@ impl ViewOptions {
         }
 
         // Does the terminal advertise truecolor support via the COLORTERM env var?
-        if self.truecolor {
+        if self.truecolor.unwrap_or(false) {
             tracing::debug!("millions of colors enabled via `COLORTERM=truecolor`");
             return Palette::All;
         }

--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -156,7 +156,11 @@ impl ViewOptions {
             tracing::debug!(?stdout, "`tput colors` succeeded");
             return stdout
                 .map_err(|err| tracing::warn!(%err, "`tput colors` stdout was not utf-8 (this shouldn't happen)"))
-                .and_then(|s| s.parse::<Palette>().map_err(|_| tracing::warn!(palette = ?s, "invalid color palette from `tput colors`")))
+                .and_then(|s| {
+                    let palette = s.trim().parse::<Palette>();
+                    tracing::debug!(?palette, "parsed `tput colors`");
+                    palette.map_err(|_| tracing::warn!(palette = ?s, "invalid color palette from `tput colors`"))
+                })
                 .unwrap_or_default();
         }
 

--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -38,7 +38,7 @@ pub struct ViewOptions {
     no_colors: bool,
 
     /// Overrides the terminal's default language.
-    #[clap(long = "lang", env = "LANG")]
+    #[clap(long = "lang", env = "LANG", default_value = "en_us.UTF-8")]
     lang: String,
 
     /// Explicitly use only ASCII characters.

--- a/console/src/view/styles.rs
+++ b/console/src/view/styles.rs
@@ -162,7 +162,7 @@ impl FromStr for Palette {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.trim() {
             "0" => Ok(Palette::NoColors),
             "8" => Ok(Palette::Ansi8),
             "16" => Ok(Palette::Ansi16),


### PR DESCRIPTION
Currently, the console CLI/env var handling code _requires_ the
`COLORTERM` env variable. This isn't correct, as some terminals may not
set it. In that case, we should assume the terminal isn't advertising
24-bit color support, rather than crashing.

Currently, this happens if I unset the env variable:

```console
$ unset COLORTERM

$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.32s
     Running `target/debug/console`
error: The following required arguments were not provided:
    --colorterm <truecolor>

USAGE:
    console [FLAGS] [OPTIONS] --lang <LANG> --colorterm <truecolor> [TARGET_ADDR]

```

After this branch, if I unset `COLORTERM`, the console just runs without
colors.

Similarly, the `LANG` environment variable is no longer required, either.
If it's unset, we'll default to `en_us.UTF-8`. Possibly, we should *really*
be falling back to ASCII if `$LANG` is not set, but _most_ terminals really
ought to support UTF-8...

Finally, this fixes a bug in the way we parse `tput colors` output. The output
ends in a newline, but our parsing code doesn't handle whitespace...so we 
will currently always assume no colors are supported if we fall back to `tput`.
This branch adds a `trim` call.