### PR TITLE
subscriber: support runtime:: target for tracing events

### DIFF
--- a/console-subscriber/src/init.rs
+++ b/console-subscriber/src/init.rs
@@ -80,7 +80,9 @@ pub fn init() {
 pub fn build() -> ConsoleSubscriberLayer {
     let (layer, server) = TasksLayer::builder().with_default_env().build();
 
-    let filter = EnvFilter::from_default_env().add_directive("tokio=trace".parse().unwrap());
+    let filter = EnvFilter::from_default_env()
+        .add_directive("tokio=trace".parse().unwrap())
+        .add_directive("runtime=trace".parse().unwrap());
 
     let console_subscriber = tracing_subscriber::registry().with(filter).with(layer);
 

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -340,11 +340,10 @@ where
             (_, "runtime::waker") | (_, "tokio::task::waker") => self.waker_callsites.insert(meta),
             (ResourceVisitor::RES_SPAN_NAME, _) => self.resource_callsites.insert(meta),
             (AsyncOpVisitor::ASYNC_OP_SPAN_NAME, _) => self.async_op_callsites.insert(meta),
-            (_, PollOpVisitor::POLL_OP_EVENT_TARGET) | (_, "tokio::resource::poll_op") => {
-                self.poll_op_callsites.insert(meta)
+            (_, PollOpVisitor::POLL_OP_EVENT_TARGET) => self.poll_op_callsites.insert(meta),
+            (_, StateUpdateVisitor::STATE_UPDATE_EVENT_TARGET) => {
+                self.state_update_callsites.insert(meta)
             }
-            (_, StateUpdateVisitor::STATE_UPDATE_EVENT_TARGET)
-            | (_, "tokio::resource::state_update") => self.state_update_callsites.insert(meta),
             (_, _) => {}
         }
 


### PR DESCRIPTION
Currently the subscriber has an `EnvFilter` that filters out anything that is not
part of the `tokio::` target. However the convention for targets is `runtime::`. This
PR adds the needed directive to the `EnvFilter`. 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>