### PR TITLE
console: prevent huge take names from panicking

### DIFF
--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -138,7 +138,10 @@ impl Width {
 
     pub(crate) fn update_str<S: AsRef<str>>(&mut self, s: S) -> S {
         let len = s.as_ref().len();
-        self.curr = cmp::max(self.curr, len as u16);
+        let max = cmp::max(self.curr as usize, len);
+        // Cap since a string could be stupid-long and not fit in a u16.
+        // 100 is arbitrarily chosen, to keep the UI sane.
+        self.curr = cmp::min(max, 100) as u16;
         s
     }
 

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -204,6 +204,7 @@ impl List {
             Span::from(format!(" Idle ({})", num_idle)),
         ]);
 
+        /* TODO: use this to adjust the max size of name and target columns...
         // How many characters wide are the fixed-length non-field columns?
         let fixed_col_width = id_width.chars()
             + STATE_LEN
@@ -213,11 +214,15 @@ impl List {
             + DUR_LEN as u16
             + POLLS_LEN as u16
             + target_width.chars();
+        */
+
         // Fill all remaining characters in the frame with the task's fields.
-        // TODO(eliza): there's gotta be a nicer way to do this in `tui`...what
-        // we want is really just a constraint that says "always use all the
-        // characters remaining".
-        let fields_width = frame.size().width - fixed_col_width;
+        //
+        // Ideally we'd use Min(0), and it would fill the rest of the space. But that is broken
+        // in tui 0.16. We can use Percentage to fill the space for now.
+        //
+        // See https://github.com/fdehau/tui-rs/issues/525
+        let fields_width = layout::Constraint::Percentage(100);
         let widths = &[
             id_width.constraint(),
             layout::Constraint::Length(STATE_LEN),
@@ -227,7 +232,7 @@ impl List {
             layout::Constraint::Length(DUR_LEN as u16),
             layout::Constraint::Length(POLLS_LEN as u16),
             target_width.constraint(),
-            layout::Constraint::Min(fields_width),
+            fields_width,
         ];
 
         let table = table


### PR DESCRIPTION
If a task name were too long, calculating the remaining width for the
fields column would panic on a subtraction overflow. This removes the
need to calculate the remainder, by just setting a percentage constraint
instead.

This also caps the `view::Width` so that an excessively long string
doesn't overflow the stored `u16`.