### PR TITLE
proto: represent readiness as bool

### DIFF
--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -724,7 +724,7 @@ impl Aggregator {
                 op_name,
                 async_op_id,
                 task_id,
-                readiness,
+                is_ready,
             } => {
                 let async_op_id = self.ids.id_for(async_op_id);
                 let resource_id = self.ids.id_for(resource_id);
@@ -735,9 +735,7 @@ impl Aggregator {
                 async_op_stats.task_id.get_or_insert(task_id);
                 async_op_stats.resource_id.get_or_insert(resource_id);
 
-                if readiness == proto::Readiness::Pending
-                    && async_op_stats.poll_stats.first_poll.is_none()
-                {
+                if !is_ready && async_op_stats.poll_stats.first_poll.is_none() {
                     async_op_stats.poll_stats.first_poll = Some(at);
                 }
 
@@ -747,7 +745,7 @@ impl Aggregator {
                     name: op_name,
                     task_id: Some(task_id.into()),
                     async_op_id: Some(async_op_id.into()),
-                    readiness: readiness as i32,
+                    is_ready,
                 };
 
                 self.all_poll_ops.push(poll_op.clone());

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -142,7 +142,7 @@ enum Event {
         op_name: String,
         async_op_id: span::Id,
         task_id: span::Id,
-        readiness: proto::Readiness,
+        is_ready: bool,
     },
     StateUpdate {
         metadata: &'static Metadata<'static>,
@@ -407,7 +407,7 @@ where
                 Some(resource_id) if self.is_id_resource(resource_id, &ctx) => {
                     let mut poll_op_visitor = PollOpVisitor::default();
                     event.record(&mut poll_op_visitor);
-                    if let Some((op_name, readiness)) = poll_op_visitor.result() {
+                    if let Some((op_name, is_ready)) = poll_op_visitor.result() {
                         let task_and_async_op_ids = self.current_spans.get().and_then(|stack| {
                             let stack = stack.borrow();
                             let task_id =
@@ -426,7 +426,7 @@ where
                                 op_name,
                                 async_op_id,
                                 task_id,
-                                readiness,
+                                is_ready,
                             });
                         }
                         // else poll op event should be emitted in the context of an async op and task spans

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -122,9 +122,3 @@ message PollStats {
     // not reflecting any inprogress polls.
     google.protobuf.Duration busy_time = 6;
 }
-
-// Indicates the readiness of a pollable entity (i.e task, resource).
-enum Readiness {
-    READY = 0;
-    PENDING = 1;
-}

--- a/proto/resources.proto
+++ b/proto/resources.proto
@@ -87,5 +87,5 @@ message PollOp {
     // Identifies the async op ID that this poll op is part of.
     common.Id async_op_id = 6;
     // Whether this poll op has returned with ready or pending.
-    common.Readiness readiness = 7;
+    bool is_ready = 7;
 }


### PR DESCRIPTION
Based on some [earlier feedback](https://github.com/tokio-rs/console/pull/77#discussion_r695031627), this PR changes the proto definition so
readiness of a poll op is represented via a bool. The relevant changes have been made to: https://github.com/tokio-rs/tokio/pull/4072

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>