### PR TITLE
fix(console): remove backticks from mangled PR review suggestion

### DIFF
--- a/console-subscriber/src/visitors.rs
+++ b/console-subscriber/src/visitors.rs
@@ -1,5 +1,4 @@
 //! These visitors are responsible for extracting the relevant
-```
 //! fields from tracing metadata and producing the parts
 //! needed to construct `Event` instances.
 


### PR DESCRIPTION
This is my fault, sorry --- I messed up a review suggestion for PR #104
and broke the build.

This should get it compiley again.