### PR TITLE
feat: emit and show self-wake counts for tasks

### DIFF
--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -274,6 +274,7 @@ impl Default for TaskStats {
             wakes: 0,
             waker_clones: 0,
             waker_drops: 0,
+            self_wakes: 0,
             last_wake: None,
             // significant figures should be in the [0-5] range and memory usage
             // grows exponentially with higher a sigfig
@@ -664,13 +665,13 @@ impl Aggregator {
                 // "wasted" waker ops, but we'll leave that for another time.
                 if let Some(mut task_stats) = self.task_stats.update(&id) {
                     match op {
-                        WakeOp::Wake | WakeOp::WakeByRef => {
+                        WakeOp::Wake { self_wake } | WakeOp::WakeByRef { self_wake } => {
                             task_stats.wakes += 1;
                             task_stats.last_wake = Some(at);
 
-                            // If currently "inside" this task's poll, then the
-                            // task has woken itself.
-                            if task_stats.poll_stats.current_polls > 0 {
+                            // If the  task has woken itself, increment the
+                            // self-wake count.
+                            if self_wake {
                                 task_stats.self_wakes += 1;
                             }
 
@@ -682,7 +683,7 @@ impl Aggregator {
                             //
                             // see
                             // https://github.com/rust-lang/rust/blob/673d0db5e393e9c64897005b470bfeb6d5aec61b/library/core/src/task/wake.rs#L211-L212
-                            if let WakeOp::Wake = op {
+                            if let WakeOp::Wake { .. } = op {
                                 task_stats.waker_drops += 1;
                             }
                         }
@@ -873,6 +874,7 @@ impl ToProto for TaskStats {
             total_time: total_time(self.created_at, self.closed_at).map(Into::into),
             wakes: self.wakes,
             waker_clones: self.waker_clones,
+            self_wakes: self.self_wakes,
             waker_drops: self.waker_drops,
             last_wake: self.last_wake.map(Into::into),
         }

--- a/console-subscriber/src/stack.rs
+++ b/console-subscriber/src/stack.rs
@@ -49,6 +49,12 @@ impl SpanStack {
         false
     }
 
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Id> {
+        self.stack
+            .iter()
+            .filter_map(|ContextId { id, duplicate }| if *duplicate { None } else { Some(id) })
+    }
+
     pub(crate) fn stack(&self) -> &Vec<ContextId> {
         &self.stack
     }

--- a/console-subscriber/src/visitors.rs
+++ b/console-subscriber/src/visitors.rs
@@ -243,8 +243,8 @@ impl Visit for WakerVisitor {
     fn record_str(&mut self, field: &tracing_core::Field, value: &str) {
         if field.name() == "op" {
             self.op = Some(match value {
-                Self::WAKE => WakeOp::Wake,
-                Self::WAKE_BY_REF => WakeOp::WakeByRef,
+                Self::WAKE => WakeOp::Wake { self_wake: false },
+                Self::WAKE_BY_REF => WakeOp::WakeByRef { self_wake: false },
                 Self::CLONE => WakeOp::Clone,
                 Self::DROP => WakeOp::Drop,
                 _ => return,

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -101,6 +101,8 @@ struct Stats {
 
     /// The timestamp of when the task was last woken.
     last_wake: Option<SystemTime>,
+    /// Total number of times the task has woken itself.
+    self_wakes: u64,
 }
 
 #[derive(Debug)]
@@ -372,6 +374,11 @@ impl Task {
         self.stats.wakes
     }
 
+    /// Returns the total number of times this task has woken itself.
+    pub(crate) fn self_wakes(&self) -> u64 {
+        self.stats.self_wakes
+    }
+
     fn update(&mut self) {
         let completed = self.stats.total.is_some() && self.completed_for == 0;
         if completed {
@@ -420,6 +427,7 @@ impl From<proto::tasks::Stats> for Stats {
             waker_clones: pb.waker_clones,
             waker_drops: pb.waker_drops,
             last_wake: pb.last_wake.map(|v| v.try_into().unwrap()),
+            self_wakes: pb.self_wakes,
         }
     }
 }

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -131,6 +131,12 @@ impl TaskView {
             Span::from(format!("{} times", task.wakes())),
         ];
 
+        if task.self_wakes() > 0 {
+            wakeups.push(Span::raw(", "));
+            wakeups.push(bold("Self Wakes: "));
+            wakeups.push(Span::from(format!("{} times", task.self_wakes())));
+        }
+
         // If the task has been woken, add the time since wake to its stats as well.
         if let Some(since) = task.since_wake(now) {
             wakeups.push(Span::raw(", "));

--- a/proto/tasks.proto
+++ b/proto/tasks.proto
@@ -104,4 +104,6 @@ message Stats {
     optional google.protobuf.Timestamp last_wake = 6;
     // Contains task poll statistics.
     common.PollStats poll_stats = 7;
+    // The total number of times this task has woken itself.
+    uint64 self_wakes = 8;
 }


### PR DESCRIPTION
This counts all wakes of a task that happen while the task is "currently
polled". This could be from `task::yield_now()`, from `tokio::coop`, or
any other pattern that triggers the task to wake even though it's
currently being polled.

This implementation builds upon @seanmonstar's branch #55. However,
rather than detecting self-wakes by simply looking at _whether_ the task
is being polled at all, we instead detect them by checking whether the
task's span is on the current thread's stack of entered spans. This
approach should _not_ produce self-positives when a task is woken by
another thread while it is currently entered (as discussed in
https://github.com/tokio-rs/console/pull/55#discussion_r659223228).

Testing this with the "burn" subcommand for the example app, which
spawns one task that does a lot of self-wakes via `task::yield`,
indicates that it is, in fact, working properly. Here are the stats for the
`burn` task:
![image](https://user-images.githubusercontent.com/2796466/132136922-2d0d9fbd-e8eb-475c-8ab8-855f8fce5127.png)
Note the very large number of self-wakes.

In comparison, here are the task stats for a "normal" task, which does
not wake itself (and is instead woken by timers):
![image](https://user-images.githubusercontent.com/2796466/132136964-514d7560-074a-41b1-9d6b-621c0dfac935.png)
Note that no self-wakes stat is displayed.

Closes #55.