### PR TITLE
feat(console): add self-wake percentage and warning

### DIFF
--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -400,15 +400,13 @@ where
             event.record(&mut visitor);
             if let Some((id, mut op)) = visitor.result() {
                 if op.is_wake() {
-                    eprintln!("WAKE {:?}", id);
                     // Are we currently inside the task's span? If so, the task
                     // has woken itself.
                     let self_wake = self
                         .current_spans
                         .get()
-                        .map(|spans| spans.borrow().iter().any(|span| dbg!(span) == &id))
+                        .map(|spans| spans.borrow().iter().any(|span| span == &id))
                         .unwrap_or(false);
-                    dbg!(self_wake);
                     op = op.self_wake(self_wake);
                 }
                 self.send(Event::Waker { id, op, at });

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -400,13 +400,15 @@ where
             event.record(&mut visitor);
             if let Some((id, mut op)) = visitor.result() {
                 if op.is_wake() {
+                    eprintln!("WAKE {:?}", id);
                     // Are we currently inside the task's span? If so, the task
                     // has woken itself.
                     let self_wake = self
                         .current_spans
                         .get()
-                        .map(|spans| spans.borrow().iter().any(|span| span == &id))
+                        .map(|spans| spans.borrow().iter().any(|span| dbg!(span) == &id))
                         .unwrap_or(false);
+                    dbg!(self_wake);
                     op = op.self_wake(self_wake);
                 }
                 self.send(Event::Waker { id, op, at });

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -20,6 +20,7 @@ mod conn;
 mod input;
 mod tasks;
 mod term;
+mod util;
 mod view;
 
 #[tokio::main]

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -22,6 +22,7 @@ mod tasks;
 mod term;
 mod util;
 mod view;
+mod warnings;
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -1,4 +1,4 @@
-use crate::view;
+use crate::{util::Percentage, view};
 use console_api as proto;
 use hdrhistogram::Histogram;
 use std::{
@@ -377,6 +377,11 @@ impl Task {
     /// Returns the total number of times this task has woken itself.
     pub(crate) fn self_wakes(&self) -> u64 {
         self.stats.self_wakes
+    }
+
+    /// Returns the percentage of this task's total wakeups that were self-wakes.
+    pub(crate) fn self_wake_percent(&self) -> f64 {
+        self.self_wakes().percent_of(self.wakes())
     }
 
     fn update(&mut self) {

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -380,7 +380,7 @@ impl Task {
     }
 
     /// Returns the percentage of this task's total wakeups that were self-wakes.
-    pub(crate) fn self_wake_percent(&self) -> f64 {
+    pub(crate) fn self_wake_percent(&self) -> u64 {
         self.self_wakes().percent_of(self.wakes())
     }
 

--- a/console/src/util.rs
+++ b/console/src/util.rs
@@ -2,18 +2,18 @@ pub(crate) trait Percentage {
     // Using an extension trait for this is maybe a bit excessive, but making it
     // a method has the nice advantage of making it *really* obvious which is
     // the total and which is the amount.
-    fn percent_of(self, total: Self) -> f64;
+    fn percent_of(self, total: Self) -> Self;
 }
 
 impl Percentage for usize {
-    fn percent_of(self, total: Self) -> f64 {
-        percentage(total as f64, self as f64)
+    fn percent_of(self, total: Self) -> Self {
+        percentage(total as f64, self as f64) as Self
     }
 }
 
 impl Percentage for u64 {
-    fn percent_of(self, total: Self) -> f64 {
-        percentage(total as f64, self as f64)
+    fn percent_of(self, total: Self) -> Self {
+        percentage(total as f64, self as f64) as Self
     }
 }
 

--- a/console/src/util.rs
+++ b/console/src/util.rs
@@ -1,0 +1,28 @@
+pub(crate) trait Percentage {
+    // Using an extension trait for this is maybe a bit excessive, but making it
+    // a method has the nice advantage of making it *really* obvious which is
+    // the total and which is the amount.
+    fn percent_of(self, total: Self) -> f64;
+}
+
+impl Percentage for usize {
+    fn percent_of(self, total: Self) -> f64 {
+        percentage(total as f64, self as f64)
+    }
+}
+
+impl Percentage for u64 {
+    fn percent_of(self, total: Self) -> f64 {
+        percentage(total as f64, self as f64)
+    }
+}
+
+pub(crate) fn percentage(total: f64, amount: f64) -> f64 {
+    debug_assert!(
+        total >= amount,
+        "assertion failed: total >= amount; total={}, amount={}",
+        total,
+        amount
+    );
+    (amount / total) * 100.0
+}

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -161,7 +161,7 @@ impl TaskView {
             waker_stats.push(Spans::from(vec![
                 bold("Self Wakes: "),
                 Span::from(format!(
-                    "{} times ({:.2}%)",
+                    "{} times ({}%)",
                     task.self_wakes(),
                     task.self_wake_percent()
                 )),

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -133,34 +133,40 @@ impl TaskView {
             dur(styles, task.idle(now)),
         ]));
 
-        let wakers = Spans::from(vec![
+        let mut waker_stats = vec![Spans::from(vec![
             bold("Current wakers: "),
             Span::from(format!("{} (", task.waker_count())),
             bold("clones: "),
             Span::from(format!("{}, ", task.waker_clones())),
             bold("drops: "),
             Span::from(format!("{})", task.waker_drops())),
-        ]);
+        ])];
 
         let mut wakeups = vec![
             bold("Woken: "),
             Span::from(format!("{} times", task.wakes())),
         ];
 
-        if task.self_wakes() > 0 {
-            wakeups.push(Span::raw(", "));
-            wakeups.push(bold("Self Wakes: "));
-            wakeups.push(Span::from(format!("{} times", task.self_wakes())));
-        }
-
         // If the task has been woken, add the time since wake to its stats as well.
         if let Some(since) = task.since_wake(now) {
+            wakeups.reserve(3);
             wakeups.push(Span::raw(", "));
             wakeups.push(bold("last woken:"));
             wakeups.push(Span::from(format!(" {:?} ago", since)));
         }
 
-        let wakeups = Spans::from(wakeups);
+        waker_stats.push(Spans::from(wakeups));
+
+        if task.self_wakes() > 0 {
+            waker_stats.push(Spans::from(vec![
+                bold("Self Wakes: "),
+                Span::from(format!(
+                    "{} times ({:.2}%)",
+                    task.self_wakes(),
+                    task.self_wake_percent()
+                )),
+            ]));
+        }
 
         let mut fields = Text::default();
         fields.extend(task.formatted_fields().iter().cloned().map(Spans::from));
@@ -190,8 +196,7 @@ impl TaskView {
         }
 
         let task_widget = Paragraph::new(metrics).block(styles.border_block().title("Task"));
-        let wakers_widget =
-            Paragraph::new(vec![wakers, wakeups]).block(styles.border_block().title("Waker"));
+        let wakers_widget = Paragraph::new(waker_stats).block(styles.border_block().title("Waker"));
         let fields_widget = Paragraph::new(fields).block(styles.border_block().title("Fields"));
         let percentiles_widget = Paragraph::new(
             details

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -126,7 +126,16 @@ impl List {
                 let task = task.upgrade()?;
                 let task = task.borrow();
                 let state = task.state();
-                warning_results.extend(warnings.iter().filter_map(|warning| warning.check(&*task)));
+                warning_results.extend(warnings.iter().filter_map(|warning| {
+                    let Spans(mut warning) = warning.check(&*task)?;
+                    let mut spans = Vec::with_capacity(warning.len() + 1);
+                    spans.push(Span::styled(
+                        styles.if_utf8("\u{26A0} ", "/!\\ "),
+                        styles.fg(Color::LightYellow),
+                    ));
+                    spans.append(&mut warning);
+                    Some(Spans::from(spans))
+                }));
                 // Count task states
                 match state {
                     TaskState::Running => *num_running += 1,

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -1,7 +1,8 @@
 use crate::{
     input,
-    tasks::{self, TaskRef, TaskState},
+    tasks::{self, Task, TaskRef, TaskState},
     view::{self, bold},
+    warnings,
 };
 use std::convert::TryFrom;
 use tui::{
@@ -10,8 +11,10 @@ use tui::{
     text::{self, Span, Spans},
     widgets::{Cell, Paragraph, Row, Table, TableState},
 };
-#[derive(Clone, Debug, Default)]
+
+#[derive(Debug)]
 pub(crate) struct List {
+    warnings: Vec<Box<dyn warnings::Warning<Task>>>,
     sorted_tasks: Vec<TaskRef>,
     sort_by: tasks::SortBy,
     table_state: TableState,
@@ -76,27 +79,6 @@ impl List {
         area: layout::Rect,
         state: &mut tasks::State,
     ) {
-        let chunks = layout::Layout::default()
-            .direction(layout::Direction::Vertical)
-            .margin(0)
-            .constraints(
-                [
-                    layout::Constraint::Length(1),
-                    layout::Constraint::Min(area.height - 1),
-                ]
-                .as_ref(),
-            )
-            .split(area);
-        let controls_area = chunks[0];
-        let tasks_area = chunks[1];
-
-        let now = if let Some(now) = state.last_updated_at() {
-            now
-        } else {
-            // If we have never gotten an update yet, skip...
-            return;
-        };
-
         const STATE_LEN: u16 = List::HEADER[1].len() as u16;
         const DUR_LEN: usize = 10;
         // This data is only updated every second, so it doesn't make a ton of
@@ -104,6 +86,13 @@ impl List {
         // there's room for the unit!)
         const DUR_PRECISION: usize = 4;
         const POLLS_LEN: usize = 5;
+
+        let now = if let Some(now) = state.last_updated_at() {
+            now
+        } else {
+            // If we have never gotten an update yet, skip...
+            return;
+        };
 
         self.sorted_tasks.extend(state.take_new_tasks());
         self.sort_by.sort(now, &mut self.sorted_tasks);
@@ -123,17 +112,21 @@ impl List {
         let mut target_width = view::Width::new(Self::HEADER[7].len() as u16);
         let mut num_idle = 0;
         let mut num_running = 0;
+        let mut warning_results = Vec::new();
         let rows = {
             let id_width = &mut id_width;
             let target_width = &mut target_width;
             let name_width = &mut name_width;
             let num_running = &mut num_running;
             let num_idle = &mut num_idle;
+            let warning_results = &mut warning_results;
+
+            let warnings = &self.warnings;
             self.sorted_tasks.iter().filter_map(move |task| {
                 let task = task.upgrade()?;
                 let task = task.borrow();
                 let state = task.state();
-
+                warning_results.extend(warnings.iter().filter_map(|warning| warning.check(&*task)));
                 // Count task states
                 match state {
                     TaskState::Running => *num_running += 1,
@@ -215,6 +208,33 @@ impl List {
             + POLLS_LEN as u16
             + target_width.chars();
         */
+        let layout = layout::Layout::default()
+            .direction(layout::Direction::Vertical)
+            .margin(0);
+        let (controls_area, tasks_area, warnings_area) = if warning_results.is_empty() {
+            let chunks = layout
+                .constraints(
+                    [
+                        layout::Constraint::Length(1),
+                        layout::Constraint::Min(area.height - 1),
+                    ]
+                    .as_ref(),
+                )
+                .split(area);
+            (chunks[0], chunks[1], None)
+        } else {
+            let chunks = layout
+                .constraints(
+                    [
+                        layout::Constraint::Length(1),
+                        layout::Constraint::Length(warning_results.len() as u16 + 2),
+                        layout::Constraint::Min(area.height - 1),
+                    ]
+                    .as_ref(),
+                )
+                .split(area);
+            (chunks[0], chunks[2], Some(chunks[1]))
+        };
 
         // Fill all remaining characters in the frame with the task's fields.
         //
@@ -259,6 +279,14 @@ impl List {
         ]));
 
         frame.render_widget(Paragraph::new(controls), controls_area);
+
+        if let Some(area) = warnings_area {
+            let block = styles.border_block().title(Spans::from(vec![
+                bold("Warnings"),
+                Span::from(format!(" ({})", warning_results.len())),
+            ]));
+            frame.render_widget(Paragraph::new(warning_results).block(block), area);
+        }
 
         self.sorted_tasks.retain(|t| t.upgrade().is_some());
     }
@@ -315,5 +343,18 @@ impl List {
                 self.sorted_tasks[selected].clone()
             })
             .unwrap_or_default()
+    }
+}
+
+impl Default for List {
+    fn default() -> Self {
+        Self {
+            warnings: vec![Box::new(warnings::SelfWakePercent::default())],
+            sorted_tasks: Vec::new(),
+            sort_by: tasks::SortBy::default(),
+            table_state: TableState::default(),
+            selected_column: 0,
+            sort_descending: false,
+        }
     }
 }

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -14,7 +14,7 @@ use tui::{
 
 #[derive(Debug)]
 pub(crate) struct List {
-    /// A list of linters (implementing the [`Warn`] trait) used to generate
+    /// A list of linters (implementing the [`warnings::Warn`] trait) used to generate
     /// warnings.
     linters: Vec<Box<dyn warnings::Warn<Task>>>,
     sorted_tasks: Vec<TaskRef>,

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -127,14 +127,20 @@ impl List {
                 let task = task.borrow();
                 let state = task.state();
                 warning_results.extend(warnings.iter().filter_map(|warning| {
-                    let Spans(mut warning) = warning.check(&*task)?;
-                    let mut spans = Vec::with_capacity(warning.len() + 1);
-                    spans.push(Span::styled(
-                        styles.if_utf8("\u{26A0} ", "/!\\ "),
-                        styles.fg(Color::LightYellow),
-                    ));
-                    spans.append(&mut warning);
-                    Some(Spans::from(spans))
+                    let warning = warning.check(&*task)?;
+                    let task = if let Some(name) = task.name() {
+                        Span::from(format!("Task '{}' (ID {}) ", name, task.id()))
+                    } else {
+                        Span::from(format!("Task ID {} ", task.id()))
+                    };
+                    Some(Spans::from(vec![
+                        Span::styled(
+                            styles.if_utf8("\u{26A0} ", "/!\\ "),
+                            styles.fg(Color::LightYellow),
+                        ),
+                        task,
+                        Span::from(warning),
+                    ]))
                 }));
                 // Count task states
                 match state {

--- a/console/src/warnings.rs
+++ b/console/src/warnings.rs
@@ -1,6 +1,6 @@
 use crate::tasks::Task;
 
-pub trait Warning<T>: std::fmt::Debug {
+pub trait Warn<T>: std::fmt::Debug {
     fn check(&self, val: &T) -> Option<String>;
 }
 
@@ -22,7 +22,7 @@ impl Default for SelfWakePercent {
     }
 }
 
-impl Warning<Task> for SelfWakePercent {
+impl Warn<Task> for SelfWakePercent {
     fn check(&self, task: &Task) -> Option<String> {
         let self_wakes = task.self_wake_percent();
         if self_wakes > self.min_percent {

--- a/console/src/warnings.rs
+++ b/console/src/warnings.rs
@@ -1,8 +1,7 @@
 use crate::tasks::Task;
-use tui::text::{Span, Spans};
 
 pub trait Warning<T>: std::fmt::Debug {
-    fn check(&self, val: &T) -> Option<tui::text::Spans>;
+    fn check(&self, val: &T) -> Option<String>;
 }
 
 #[derive(Clone, Debug)]
@@ -24,22 +23,13 @@ impl Default for SelfWakePercent {
 }
 
 impl Warning<Task> for SelfWakePercent {
-    fn check(&self, task: &Task) -> Option<tui::text::Spans> {
+    fn check(&self, task: &Task) -> Option<String> {
         let self_wakes = task.self_wake_percent();
         if self_wakes > self.min_percent {
-            let name = task.name();
-            let task = if name.is_empty() {
-                Span::from(format!("Task ID {} ", task.id()))
-            } else {
-                Span::from(format!("Task '{}' (ID {}) ", name, task.id()))
-            };
-            return Some(Spans::from(vec![
-                task,
-                Span::from(format!(
-                    "has woken itself for more than {:.2}% of its total wakeups ({:.2}%)",
-                    self.min_percent, self_wakes
-                )),
-            ]));
+            return Some(format!(
+                "has woken itself for more than {:.2}% of its total wakeups ({:.2}%)",
+                self.min_percent, self_wakes
+            ));
         }
 
         None

--- a/console/src/warnings.rs
+++ b/console/src/warnings.rs
@@ -29,9 +29,9 @@ impl Warning<Task> for SelfWakePercent {
         if self_wakes > self.min_percent {
             let name = task.name();
             let task = if name.is_empty() {
-                Span::from(format!("⚠ Task ID {} ", task.id()))
+                Span::from(format!("Task ID {} ", task.id()))
             } else {
-                Span::from(format!("⚠ Task '{}' (ID {}) ", name, task.id()))
+                Span::from(format!("Task '{}' (ID {}) ", name, task.id()))
             };
             return Some(Spans::from(vec![
                 task,

--- a/console/src/warnings.rs
+++ b/console/src/warnings.rs
@@ -6,12 +6,12 @@ pub trait Warn<T>: std::fmt::Debug {
 
 #[derive(Clone, Debug)]
 pub(crate) struct SelfWakePercent {
-    min_percent: f64,
+    min_percent: u64,
 }
 
 impl SelfWakePercent {
-    pub(crate) const DEFAULT_PERCENT: f64 = 50.0;
-    pub(crate) fn new(min_percent: f64) -> Self {
+    pub(crate) const DEFAULT_PERCENT: u64 = 50;
+    pub(crate) fn new(min_percent: u64) -> Self {
         Self { min_percent }
     }
 }
@@ -27,7 +27,7 @@ impl Warn<Task> for SelfWakePercent {
         let self_wakes = task.self_wake_percent();
         if self_wakes > self.min_percent {
             return Some(format!(
-                "has woken itself for more than {:.2}% of its total wakeups ({:.2}%)",
+                "has woken itself for more than {}% of its total wakeups ({}%)",
                 self.min_percent, self_wakes
             ));
         }

--- a/console/src/warnings.rs
+++ b/console/src/warnings.rs
@@ -1,0 +1,47 @@
+use crate::tasks::Task;
+use tui::text::{Span, Spans};
+
+pub trait Warning<T>: std::fmt::Debug {
+    fn check(&self, val: &T) -> Option<tui::text::Spans>;
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SelfWakePercent {
+    min_percent: f64,
+}
+
+impl SelfWakePercent {
+    pub(crate) const DEFAULT_PERCENT: f64 = 50.0;
+    pub(crate) fn new(min_percent: f64) -> Self {
+        Self { min_percent }
+    }
+}
+
+impl Default for SelfWakePercent {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_PERCENT)
+    }
+}
+
+impl Warning<Task> for SelfWakePercent {
+    fn check(&self, task: &Task) -> Option<tui::text::Spans> {
+        let self_wakes = task.self_wake_percent();
+        if self_wakes > self.min_percent {
+            let name = task.name();
+            let task = if name.is_empty() {
+                Span::from(format!("⚠ Task ID {} ", task.id()))
+            } else {
+                Span::from(format!("⚠ Task '{}' (ID {}) ", name, task.id()))
+            };
+            return Some(Spans::from(vec![
+                task,
+                Span::from(format!(
+                    "has woken itself for more than {:.2}% of its total wakeups ({:.2}%)",
+                    self.min_percent, self_wakes
+                )),
+            ]));
+        }
+
+        None
+    }
+}


### PR DESCRIPTION
Depends on #112

This branch builds on #112 by calculating the *percentage* of a task's
wakeups that were self-wakes, and displaying them in the tasks view. It
also adds the beginnings of a rudimentary "Warnings" system, and
displays warnings for any tasks who have woken themselves for more than
50% of their wakeups. There is a new `Warning` trait for generating
warnings that can be used to add new warnings in the future.

The warnings functionality can almost certainly be expanded --- for
example, it would be nice to be able to quicky jump to the details view
for a task that has warnings. In the future, I could imagine generating web
documentation with details about a particular warning and how to fix it,
like [clippy has][1], and linking to them from the console. But, this is a start,
at least!

[1]: https://rust-lang.github.io/rust-clippy/v0.0.174/
![image](https://user-images.githubusercontent.com/2796466/132146062-9599ba12-cb17-48f8-b15c-4ba91947e282.png)
![image](https://user-images.githubusercontent.com/2796466/132146081-6dac231c-e929-4f93-b6ef-ac16f1dd166d.png)

