### PR TITLE
feat(console): add name to task details

### DIFF
--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -283,8 +283,8 @@ impl Task {
         &self.target
     }
 
-    pub(crate) fn name(&self) -> &str {
-        self.name.as_ref().map(AsRef::as_ref).unwrap_or_default()
+    pub(crate) fn name(&self) -> Option<&str> {
+        self.name.as_ref().map(AsRef::as_ref)
     }
 
     pub(crate) fn formatted_fields(&self) -> &[Vec<Span<'static>>] {

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -55,7 +55,7 @@ impl TaskView {
             .constraints(
                 [
                     layout::Constraint::Length(1),
-                    layout::Constraint::Length(7),
+                    layout::Constraint::Length(8),
                     layout::Constraint::Length(9),
                     layout::Constraint::Percentage(60),
                 ]
@@ -105,17 +105,33 @@ impl TaskView {
             Span::raw(" = quit"),
         ]);
 
-        let attrs = Spans::from(vec![
+        // Just preallocate capacity for ID, name, target, total, busy, and idle.
+        let mut metrics = Vec::with_capacity(6);
+        metrics.push(Spans::from(vec![
             bold("ID: "),
             Span::raw(format!("{} ", task.id())),
             task.state().render(styles),
-        ]);
-        let target = Spans::from(vec![bold("Target: "), Span::raw(task.target())]);
-        let total = Spans::from(vec![bold("Total Time: "), dur(styles, task.total(now))]);
-        let busy = Spans::from(vec![bold("Busy: "), dur(styles, task.busy(now))]);
-        let idle = Spans::from(vec![bold("Idle: "), dur(styles, task.idle(now))]);
+        ]));
 
-        let metrics = vec![attrs, target, total, busy, idle];
+        if let Some(name) = task.name() {
+            metrics.push(Spans::from(vec![bold("Name: "), Span::raw(name)]));
+        }
+        metrics.push(Spans::from(vec![
+            bold("Target: "),
+            Span::raw(task.target()),
+        ]));
+        metrics.push(Spans::from(vec![
+            bold("Total Time: "),
+            dur(styles, task.total(now)),
+        ]));
+        metrics.push(Spans::from(vec![
+            bold("Busy: "),
+            dur(styles, task.busy(now)),
+        ]));
+        metrics.push(Spans::from(vec![
+            bold("Idle: "),
+            dur(styles, task.idle(now)),
+        ]));
 
         let wakers = Spans::from(vec![
             bold("Current wakers: "),

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -148,7 +148,7 @@ impl List {
                         width = id_width.chars() as usize
                     ))),
                     Cell::from(task.state().render(styles)),
-                    Cell::from(name_width.update_str(task.name().to_string())),
+                    Cell::from(name_width.update_str(task.name().unwrap_or("").to_string())),
                     dur_cell(task.total(now)),
                     dur_cell(task.busy(now)),
                     dur_cell(task.idle(now)),


### PR DESCRIPTION
Currently, the task details view doesn't actually show the task's name.
This commit changes it to add the name if the task has one. If there's no
name, the name is not displayed.

I also changed `Task::name` to return an `Option` so that we can more
easily detect whether or not the task has a name (rather than checking
if the string is empty).

Screenshot:
![image](https://user-images.githubusercontent.com/2796466/132244984-783d247c-45d6-4202-bae7-f768f7740d5f.png)
