### PR TITLE
feat(console): display warnings in task details *and* list

### DIFF
--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -44,7 +44,12 @@ async fn main() -> color_eyre::Result<()> {
     // A channel to send the task details update stream (no need to keep outdated details in the memory)
     let (details_tx, mut details_rx) = mpsc::channel::<TaskDetails>(2);
 
-    let mut tasks = State::default();
+    let mut tasks = State::default()
+        // TODO(eliza): allow configuring the list of linters via the
+        // CLI/possibly a config file?
+        .with_linters(vec![warnings::Linter::new(
+            warnings::SelfWakePercent::default(),
+        )]);
     let mut input = input::EventStream::new();
     let mut view = view::View::new(styles);
 

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -36,9 +36,9 @@ enum Temporality {
 #[derive(Debug, Copy, Clone)]
 #[repr(usize)]
 pub(crate) enum SortBy {
-    Tid = 0,
-    State = 1,
-    Warns = 2,
+    Warns = 0,
+    Tid = 1,
+    State = 2,
     Name = 3,
     Total = 4,
     Busy = 5,

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -137,12 +137,14 @@ impl Width {
     }
 
     pub(crate) fn update_str<S: AsRef<str>>(&mut self, s: S) -> S {
-        let len = s.as_ref().len();
+        self.update_len(s.as_ref().len());
+        s
+    }
+    pub(crate) fn update_len(&mut self, len: usize) {
         let max = cmp::max(self.curr as usize, len);
         // Cap since a string could be stupid-long and not fit in a u16.
         // 100 is arbitrarily chosen, to keep the UI sane.
         self.curr = cmp::min(max, 100) as u16;
-        s
     }
 
     pub(crate) fn constraint(&self) -> layout::Constraint {

--- a/console/src/view/styles.rs
+++ b/console/src/view/styles.rs
@@ -113,6 +113,20 @@ impl Styles {
         }
     }
 
+    pub fn warning_wide(&self) -> Span<'static> {
+        Span::styled(
+            self.if_utf8("\u{26A0} ", "/!\\ "),
+            self.fg(Color::LightYellow).add_modifier(Modifier::BOLD),
+        )
+    }
+
+    pub fn warning_narrow(&self) -> Span<'static> {
+        Span::styled(
+            self.if_utf8("\u{26A0} ", "! "),
+            self.fg(Color::LightYellow).add_modifier(Modifier::BOLD),
+        )
+    }
+
     pub fn color(&self, color: Color) -> Option<Color> {
         use Palette::*;
         match (self.palette, color) {

--- a/console/src/view/tasks.rs
+++ b/console/src/view/tasks.rs
@@ -11,7 +11,7 @@ use tui::{
     widgets::{self, Cell, ListItem, Paragraph, Row, Table, TableState},
 };
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct List {
     sorted_tasks: Vec<TaskRef>,
     sort_by: tasks::SortBy,
@@ -22,7 +22,7 @@ pub(crate) struct List {
 
 impl List {
     const HEADER: &'static [&'static str] = &[
-        "ID", "State", "Warn", "Name", "Total", "Busy", "Idle", "Polls", "Target", "Fields",
+        "Warn", "ID", "State", "Name", "Total", "Busy", "Idle", "Polls", "Target", "Fields",
     ];
 
     pub(crate) fn len(&self) -> usize {
@@ -77,7 +77,7 @@ impl List {
         area: layout::Rect,
         state: &mut tasks::State,
     ) {
-        const STATE_LEN: u16 = List::HEADER[1].len() as u16;
+        const STATE_LEN: u16 = List::HEADER[2].len() as u16;
         const DUR_LEN: usize = 10;
         // This data is only updated every second, so it doesn't make a ton of
         // sense to have a lot of precision in timestamps (and this makes sure
@@ -105,8 +105,8 @@ impl List {
         };
 
         // Start out wide enough to display the column headers...
-        let mut id_width = view::Width::new(Self::HEADER[0].len() as u16);
-        let mut warn_width = view::Width::new(Self::HEADER[2].len() as u16);
+        let mut warn_width = view::Width::new(Self::HEADER[0].len() as u16);
+        let mut id_width = view::Width::new(Self::HEADER[1].len() as u16);
         let mut name_width = view::Width::new(Self::HEADER[3].len() as u16);
         let mut target_width = view::Width::new(Self::HEADER[8].len() as u16);
         let mut num_idle = 0;
@@ -143,13 +143,13 @@ impl List {
                 };
 
                 let mut row = Row::new(vec![
+                    warnings,
                     Cell::from(id_width.update_str(format!(
                         "{:>width$}",
                         task.id(),
                         width = id_width.chars() as usize
                     ))),
                     Cell::from(task.state().render(styles)),
-                    warnings,
                     Cell::from(name_width.update_str(task.name().unwrap_or("").to_string())),
                     dur_cell(task.total(now)),
                     dur_cell(task.busy(now)),
@@ -264,9 +264,9 @@ impl List {
         // See https://github.com/fdehau/tui-rs/issues/525
         let fields_width = layout::Constraint::Percentage(100);
         let widths = &[
+            warn_width.constraint(),
             id_width.constraint(),
             layout::Constraint::Length(STATE_LEN),
-            warn_width.constraint(),
             name_width.constraint(),
             layout::Constraint::Length(DUR_LEN as u16),
             layout::Constraint::Length(DUR_LEN as u16),
@@ -363,5 +363,18 @@ impl List {
                 self.sorted_tasks[selected].clone()
             })
             .unwrap_or_default()
+    }
+}
+
+impl Default for List {
+    fn default() -> Self {
+        let sort_by = tasks::SortBy::default();
+        List {
+            sorted_tasks: Default::default(),
+            sort_by,
+            table_state: Default::default(),
+            selected_column: sort_by as usize,
+            sort_descending: false,
+        }
     }
 }

--- a/console/src/warnings.rs
+++ b/console/src/warnings.rs
@@ -1,18 +1,111 @@
 use crate::tasks::Task;
+use std::{fmt::Debug, rc::Rc};
 
-pub trait Warn<T>: std::fmt::Debug {
-    fn check(&self, val: &T) -> Option<String>;
+/// A warning for a particular type of monitored entity (e.g. task or resource).
+///
+/// This trait implements the logic for detecting a particular warning, and
+/// generating a warning message describing it. The [`Linter`] type wraps an
+/// instance of this trait to track active instances of the warning.
+pub trait Warn<T>: Debug {
+    /// Returns `true` if the warning applies to `val`.
+    fn check(&self, val: &T) -> bool;
+
+    /// Formats a description of the warning detected for a *specific* `val`.
+    ///
+    /// This may include dynamically formatted content specific to `val`, such
+    /// as the specific numeric value that was over the line for detecting the
+    /// warning.
+    ///
+    /// This should be a complete sentence describing the warning. For example,
+    /// for the [`SelfWakePercent`] warning, this returns a string like:
+    ///
+    /// > "This task has woken itself for more than 50% of its total wakeups (86%)"
+    fn format(&self, val: &T) -> String;
+
+    /// Returns a string summarizing the warning *in general*, suitable for
+    /// displaying in a list of all detected warnings.
+    ///
+    /// The list entry will begin with a count of the number of monitored
+    /// entities for which the warning was detected. Therefore, this should be a
+    /// sentence fragment suitable to follow a count. For example, for the
+    /// [`SelfWakePercent`] warning, this method will return a string like
+    ///
+    /// > "tasks have woken themselves more than 50% of the time"
+    ///
+    /// so that the warnings list can read
+    ///
+    /// > "45 tasks have woken themselves more than 50% of the time"
+    ///
+    /// If the warning is configurable (for example, [`SelfWakePercent`] allows
+    /// customizing the percentage used to detect the warning), this string may
+    /// be formatted dynamically for the *linter*, but not for the individual
+    /// instances of the lint that were detected.
+    //
+    // TODO(eliza): it would be nice if we had separate plural and singular
+    // versions of this, like "56 tasks have..." vs "1 task has...".
+    fn summary(&self) -> &str;
+}
+
+#[derive(Debug)]
+pub(crate) struct Linter<T>(Rc<dyn Warn<T>>);
+
+impl<T> Linter<T> {
+    pub(crate) fn new<W>(warning: W) -> Self
+    where
+        W: Warn<T> + 'static,
+    {
+        Self(Rc::new(warning))
+    }
+
+    /// Checks if the warning applies to a particular entity, returning a clone
+    /// of `Self` if it does.
+    ///
+    /// The cloned instance of `Self` should be held by the entity that
+    /// generated the warning, so that it can be formatted. Holding the clone of
+    /// `Self` will increment the warning count for that entity.
+    pub(crate) fn check(&self, val: &T) -> Option<Self> {
+        if self.0.check(val) {
+            Some(Self(self.0.clone()))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the number of monitored entities that currently have this warning.
+    pub(crate) fn count(&self) -> usize {
+        Rc::strong_count(&self.0) - 1
+    }
+
+    pub(crate) fn format(&self, val: &T) -> String {
+        debug_assert!(
+            self.0.check(val),
+            "tried to format a warning for a {} that did not have that warning!",
+            std::any::type_name::<T>()
+        );
+        self.0.format(val)
+    }
+
+    pub(crate) fn summary(&self) -> &str {
+        self.0.summary()
+    }
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct SelfWakePercent {
     min_percent: u64,
+    description: String,
 }
 
 impl SelfWakePercent {
     pub(crate) const DEFAULT_PERCENT: u64 = 50;
     pub(crate) fn new(min_percent: u64) -> Self {
-        Self { min_percent }
+        Self {
+            min_percent,
+            description: format!(
+                "tasks have woken themselves over {}% of the time",
+                min_percent
+            ),
+        }
     }
 }
 
@@ -23,15 +116,20 @@ impl Default for SelfWakePercent {
 }
 
 impl Warn<Task> for SelfWakePercent {
-    fn check(&self, task: &Task) -> Option<String> {
-        let self_wakes = task.self_wake_percent();
-        if self_wakes > self.min_percent {
-            return Some(format!(
-                "has woken itself for more than {}% of its total wakeups ({}%)",
-                self.min_percent, self_wakes
-            ));
-        }
+    fn summary(&self) -> &str {
+        self.description.as_str()
+    }
 
-        None
+    fn check(&self, task: &Task) -> bool {
+        let self_wakes = task.self_wake_percent();
+        self_wakes > self.min_percent
+    }
+
+    fn format(&self, task: &Task) -> String {
+        let self_wakes = task.self_wake_percent();
+        format!(
+            "This task has woken itself for more than {}% of its total wakeups ({}%)",
+            self.min_percent, self_wakes
+        )
     }
 }


### PR DESCRIPTION
The current method of displaying warnings is as list of all individual
tasks with warnings on the task list screen. As discussed in the
comments on PR #113, this may not be the ideal approach when there are a
very large number of tasks with warnings.

This branch changes this behavior so that the details of a particular
warning for a given task is shown only on the task details screen. On
the task list screen, we instead list the different _categories_ of
warnings that were detected, along with the number of tasks with that
warning. This means that when a large number of tasks have warnings, we
will only use a number of lines equal to the number of different
categories of warning that were detected, rather than the number of
individual tasks that have that warning.

Each individual task that has warnings shows a warning icon and count in
a new column in the task list table. This makes it easy for the user to
find the tasks that have warnings and get details on them, including
sorting by the number of warnings.

Implementing this required some refactoring of how warnings are
implemented. This includes:

* Changing the `Warn` trait to have separate methods for detecting a
  warning, formatting the warning for an individual task instance, and
  summarizing the warning for the list of detected warning types
* Introducing a new `Linter` struct that wraps a `dyn Warning` in an
  `Rc` and clones it into tasks that have lints. This allows the task
  details screen to determine how to format the lint when it is needed.
  It also allows tracking the total number of tasks that have a given
  warning, by using the `Rc`'s reference count.
## Screenshots

To demonstrate how this design saves screen real estate when there are
many tasks with warnings, I modified the `burn` example to spawn
several burn tasks rather than just one.

Before, we spent several lines on warnings (one for each task):
![warn_old](https://user-images.githubusercontent.com/2796466/132567589-862d1f82-1b8a-481e-9ce0-fc0798319c8a.png)

After, we only need one line:
![warnings1](https://user-images.githubusercontent.com/2796466/132567656-2c1473fb-22a2-45bb-99b1-c23cce4d86dd.png)

The detailed warning text for the individual tasks are displayed on the
task details view:
![warnings1_details](https://user-images.githubusercontent.com/2796466/132567713-8e1162f4-f989-488b-b347-f8837ba67d65.png)

And, it still looks okay in ASCII-only mode:
![warnings1_ascii-only](https://user-images.githubusercontent.com/2796466/132567772-9d6ed35d-254d-4b9e-bf6e-eef1819c211c.png)
![warnings1_details_ascii-only](https://user-images.githubusercontent.com/2796466/132567783-a88e4730-0a0d-4240-a285-a99bc2ff1047.png)
