### PR TITLE
console: add LostWaker lint

### DIFF
--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -47,9 +47,10 @@ async fn main() -> color_eyre::Result<()> {
     let mut tasks = State::default()
         // TODO(eliza): allow configuring the list of linters via the
         // CLI/possibly a config file?
-        .with_linters(vec![warnings::Linter::new(
-            warnings::SelfWakePercent::default(),
-        )]);
+        .with_linters(vec![
+            warnings::Linter::new(warnings::SelfWakePercent::default()),
+            warnings::Linter::new(warnings::LostWaker),
+        ]);
     let mut input = input::EventStream::new();
     let mut view = view::View::new(styles);
 

--- a/console/src/warnings.rs
+++ b/console/src/warnings.rs
@@ -133,3 +133,20 @@ impl Warn<Task> for SelfWakePercent {
         )
     }
 }
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct LostWaker;
+
+impl Warn<Task> for LostWaker {
+    fn summary(&self) -> &str {
+        "tasks have lost their waker"
+    }
+
+    fn check(&self, task: &Task) -> bool {
+        !task.is_completed() && task.waker_count() == 0
+    }
+
+    fn format(&self, _: &Task) -> String {
+        "This task has lost its waker, and will never be woken again.".into()
+    }
+}


### PR DESCRIPTION
This lint will warn when a task that isn't completed has no more wakers,
implying the task will never wake up again.

Note that this depends on #126 in most cases.

![image](https://user-images.githubusercontent.com/2796466/132753053-2a8e18be-3251-41c3-92e5-1e0d0939b369.png)
