### PR TITLE
feat(console): add busy and idle percentages to task details

### DIFF
--- a/console/src/util.rs
+++ b/console/src/util.rs
@@ -17,6 +17,12 @@ impl Percentage for u64 {
     }
 }
 
+impl Percentage for f64 {
+    fn percent_of(self, total: Self) -> Self {
+        percentage(total, self)
+    }
+}
+
 pub(crate) fn percentage(total: f64, amount: f64) -> f64 {
     debug_assert!(
         total >= amount,


### PR DESCRIPTION
This commit adds the percentage of a task's total lifetime that was
spent busy and idle to the task details screen, next to the busy and
idle time as durations. This should help make differences in scale
between these values clearer (which may not be immediately from the
durations due to differing units).

![image](https://user-images.githubusercontent.com/2796466/132955711-e553bc7a-e14d-4280-aa29-e8ace10c3fb0.png)

In the future, we may also want to add similar percentages to the task
list view, either as part of the `Busy` and `Idle` columns or as
separate columns?