### PR TITLE
feat(console): add wake-to-poll histogram

### DIFF
--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -102,6 +102,9 @@ async fn main() -> color_eyre::Result<()> {
                 if let Some(task_update) = instrument_update.task_update {
                     tasks.update_tasks(&view.styles, task_update, instrument_update.new_metadata, now);
                 }
+                if let Some(serialized_histogram) = instrument_update.wake_to_poll_times_histogram {
+                    tasks.update_wake_to_poll_histogram(serialized_histogram);
+                }
             }
             details_update = details_rx.recv() => {
                 if let Some(details_update) = details_update {

--- a/console/src/tasks.rs
+++ b/console/src/tasks.rs
@@ -26,6 +26,7 @@ pub(crate) struct State {
     current_task_details: DetailsRef,
     temporality: Temporality,
     retain_for: Option<Duration>,
+    wake_to_poll_times_histogram: Option<Histogram<u64>>,
 }
 
 #[derive(Debug)]
@@ -251,6 +252,16 @@ impl State {
 
             *self.current_task_details.borrow_mut() = Some(details);
         }
+    }
+
+    pub(crate) fn wake_to_poll_times_histogram_ref(&self) -> Option<&Histogram<u64>> {
+        self.wake_to_poll_times_histogram.as_ref()
+    }
+
+    pub(crate) fn update_wake_to_poll_histogram(&mut self, data: Vec<u8>) {
+        self.wake_to_poll_times_histogram = hdrhistogram::serialization::Deserializer::new()
+            .deserialize(&mut Cursor::new(&data))
+            .ok();
     }
 
     pub(crate) fn unset_task_details(&mut self) {

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -7,6 +7,7 @@ use tui::{
 };
 
 mod mini_histogram;
+mod percentiles;
 mod styles;
 mod task;
 mod tasks;

--- a/console/src/view/percentiles.rs
+++ b/console/src/view/percentiles.rs
@@ -1,0 +1,93 @@
+use std::time::Duration;
+
+use hdrhistogram::Histogram;
+use tui::{
+    style::Style,
+    text::{Span, Spans, Text},
+    widgets::{Block, Paragraph, Widget},
+};
+
+use crate::view::{bold, styles::DUR_PRECISION};
+
+use super::Styles;
+
+pub(crate) struct Percentiles<'a> {
+    block: Option<Block<'a>>,
+    style: Style,
+    histogram: Option<&'a Histogram<u64>>,
+    styles: Option<&'a Styles>,
+}
+
+impl<'a> Default for Percentiles<'a> {
+    fn default() -> Self {
+        Percentiles {
+            block: None,
+            style: Default::default(),
+            histogram: None,
+            styles: None,
+        }
+    }
+}
+
+impl<'a> Widget for Percentiles<'a> {
+    fn render(mut self, area: tui::layout::Rect, buf: &mut tui::buffer::Buffer) {
+        let inner_area = match self.block.take() {
+            Some(b) => {
+                let inner_area = b.inner(area);
+                b.render(area, buf);
+                inner_area
+            }
+            None => area,
+        };
+
+        if inner_area.height < 1 {
+            return;
+        }
+
+        let percentiles = self.histogram.iter().flat_map(|histogram| {
+            let pairs = [10f64, 25f64, 50f64, 75f64, 90f64, 95f64, 99f64]
+                .iter()
+                .map(move |i| (*i, histogram.value_at_percentile(*i)));
+            pairs.map(|pair| {
+                let dur = if let Some(styles) = self.styles {
+                    styles.dur(Duration::from_nanos(pair.1))
+                } else {
+                    Span::raw(format!("{:.prec$?}", pair.1, prec = DUR_PRECISION))
+                };
+
+                Spans::from(vec![bold(format!("p{:>2}: ", pair.0)), dur])
+            })
+        });
+
+        let mut text = Text::default();
+        text.extend(percentiles);
+        let paragraph = Paragraph::new(text);
+        paragraph.render(inner_area, buf);
+    }
+}
+
+impl<'a> Percentiles<'a> {
+    #[allow(dead_code)]
+    pub fn block(mut self, block: Block<'a>) -> Percentiles<'a> {
+        self.block = Some(block);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn style(mut self, style: Style) -> Percentiles<'a> {
+        self.style = style;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn histogram(mut self, histogram: &'a Histogram<u64>) -> Percentiles<'a> {
+        self.histogram = Some(histogram);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn styles(mut self, styles: &'a Styles) -> Percentiles<'a> {
+        self.styles = Some(styles);
+        self
+    }
+}

--- a/console/src/view/styles.rs
+++ b/console/src/view/styles.rs
@@ -5,6 +5,8 @@ use tui::{
     text::Span,
 };
 
+pub(crate) const DUR_PRECISION: usize = 4;
+
 #[derive(Debug, Clone)]
 pub struct Styles {
     palette: Palette,
@@ -60,6 +62,13 @@ impl Styles {
         } else {
             ascii
         }
+    }
+
+    pub fn dur<'a>(&self, dur: std::time::Duration) -> Span<'a> {
+        // TODO(eliza): can we not have to use `format!` to make a string here? is
+        // there a way to just give TUI a `fmt::Debug` implementation, or does it
+        // have to be given a string in order to do layout stuff?
+        self.time_units(format!("{:.prec$?}", dur, prec = DUR_PRECISION))
     }
 
     pub fn time_units<'a>(&self, text: impl Into<Cow<'a, str>>) -> Span<'a> {

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -1,11 +1,8 @@
 use crate::{
     input,
-    tasks::{Details, DetailsRef, Task},
+    tasks::{DetailsRef, Task},
     util::Percentage,
-    view::{
-        self, bold,
-        mini_histogram::{HistogramMetadata, MiniHistogram},
-    },
+    view::{self, bold, mini_histogram::MiniHistogram, percentiles::Percentiles},
 };
 use std::{
     cell::RefCell,
@@ -46,10 +43,6 @@ impl TaskView {
         // - logs?
 
         let task = &*self.task.borrow();
-        let details_ref = self.details.borrow();
-        let details = details_ref
-            .as_ref()
-            .filter(|details| details.task_id() == task.id());
 
         let warnings: Vec<_> = task
             .warnings()
@@ -116,26 +109,6 @@ impl TaskView {
             )
             .split(stats_area);
 
-        // Only split the histogram area in half if we're also drawing a
-        // sparkline (which requires UTF-8 characters).
-        let poll_dur_area = if styles.utf8 {
-            Layout::default()
-                .direction(layout::Direction::Horizontal)
-                .constraints(
-                    [
-                        // 24 chars is long enough for the title "Poll Times Percentiles"
-                        layout::Constraint::Length(24),
-                        layout::Constraint::Min(50),
-                    ]
-                    .as_ref(),
-                )
-                .split(poll_dur_area)
-        } else {
-            vec![poll_dur_area]
-        };
-
-        let percentiles_area = poll_dur_area[0];
-
         let controls = Spans::from(vec![
             Span::raw("controls: "),
             bold(styles.if_utf8("\u{238B} esc", "esc")),
@@ -167,12 +140,12 @@ impl TaskView {
             let percent = amt.as_secs_f64().percent_of(total.as_secs_f64());
             Spans::from(vec![
                 bold(name),
-                dur(styles, amt),
+                styles.dur(amt),
                 Span::from(format!(" ({:.2}%)", percent)),
             ])
         };
 
-        metrics.push(Spans::from(vec![bold("Total Time: "), dur(styles, total)]));
+        metrics.push(Spans::from(vec![bold("Total Time: "), styles.dur(total)]));
         metrics.push(dur_percent("Busy: ", task.busy(now)));
         metrics.push(dur_percent("Idle: ", task.idle(now)));
 
@@ -214,30 +187,6 @@ impl TaskView {
         let mut fields = Text::default();
         fields.extend(task.formatted_fields().iter().cloned().map(Spans::from));
 
-        // If UTF-8 is disabled we can't draw the histogram sparklne.
-        if styles.utf8 {
-            let sparkline_area = poll_dur_area[1];
-
-            // Bit of a deadlock: We cannot know the highest bucket value without determining the number of buckets,
-            // and we cannot determine the number of buckets without knowing the width of the chart area which depends on
-            // the number of digits in the highest bucket value.
-            // So just assume here the number of digits in the highest bucket value is 3.
-            // If we overshoot, there will be empty columns/buckets at the right end of the chart.
-            // If we undershoot, the rightmost 1-2 columns/buckets will be hidden.
-            // We could get the max bucket value from the previous render though...
-            let (chart_data, metadata) = details
-                .map(|d| d.make_chart_data(sparkline_area.width - 3))
-                .unwrap_or_default();
-
-            let histogram_sparkline = MiniHistogram::default()
-                .block(styles.border_block().title("Poll Times Histogram"))
-                .data(&chart_data)
-                .metadata(metadata)
-                .duration_precision(2);
-
-            frame.render_widget(histogram_sparkline, sparkline_area);
-        }
-
         if let Some(warnings_area) = warnings_area {
             let warnings = List::new(warnings).block(styles.border_block().title("Warnings"));
             frame.render_widget(warnings, warnings_area);
@@ -246,90 +195,70 @@ impl TaskView {
         let task_widget = Paragraph::new(metrics).block(styles.border_block().title("Task"));
         let wakers_widget = Paragraph::new(waker_stats).block(styles.border_block().title("Waker"));
         let fields_widget = Paragraph::new(fields).block(styles.border_block().title("Fields"));
-        let percentiles_widget = Paragraph::new(
-            details
-                .map(|details| details.make_percentiles_widget(styles))
-                .unwrap_or_default(),
-        )
-        .block(styles.border_block().title("Poll Times Percentiles"));
 
         frame.render_widget(Block::default().title(controls), controls_area);
         frame.render_widget(task_widget, stats_area[0]);
         frame.render_widget(wakers_widget, stats_area[1]);
         frame.render_widget(fields_widget, fields_area);
-        frame.render_widget(percentiles_widget, percentiles_area);
+        self.render_poll_dur(styles, frame, poll_dur_area);
     }
-}
 
-impl Details {
-    /// From the histogram, build a visual representation by trying to make as
-    // many buckets as the width of the render area.
-    fn make_chart_data(&self, width: u16) -> (Vec<u64>, HistogramMetadata) {
-        self.poll_times_histogram()
-            .map(|histogram| {
-                let step_size =
-                    ((histogram.max() - histogram.min()) as f64 / width as f64).ceil() as u64 + 1;
-                // `iter_linear` panics if step_size is 0
-                let data = if step_size > 0 {
-                    let mut found_first_nonzero = false;
-                    let data: Vec<u64> = histogram
-                        .iter_linear(step_size)
-                        .filter_map(|value| {
-                            let count = value.count_since_last_iteration();
-                            // Remove the 0s from the leading side of the buckets.
-                            // Because HdrHistogram can return empty buckets depending
-                            // on its internal state, as it approximates values.
-                            if count == 0 && !found_first_nonzero {
-                                None
-                            } else {
-                                found_first_nonzero = true;
-                                Some(count)
-                            }
-                        })
-                        .collect();
-                    data
-                } else {
-                    Vec::new()
-                };
-                let max_bucket = data.iter().max().copied().unwrap_or_default();
-                let min_bucket = data.iter().min().copied().unwrap_or_default();
-                (
-                    data,
-                    HistogramMetadata {
-                        max_value: histogram.max(),
-                        min_value: histogram.min(),
-                        max_bucket,
-                        min_bucket,
-                    },
+    fn render_poll_dur<B: tui::backend::Backend>(
+        &self,
+        styles: &view::Styles,
+        frame: &mut tui::terminal::Frame<B>,
+        area: layout::Rect,
+    ) {
+        let task = &*self.task.borrow();
+        let details_ref = self.details.borrow();
+        let details = details_ref
+            .as_ref()
+            .filter(|details| details.task_id() == task.id());
+        let histogram = details
+            .map(|d| d.poll_times_histogram())
+            .unwrap_or_default();
+
+        // Only render the histogram if UTF-8 is enabled,
+        // because sparkline requires UTF-8 characters
+        let percentiles_area = if styles.utf8 {
+            let areas = Layout::default()
+                .direction(layout::Direction::Horizontal)
+                .constraints(
+                    [
+                        // 24 chars is long enough for the title "Poll Times Percentiles"
+                        layout::Constraint::Length(24),
+                        layout::Constraint::Min(50),
+                    ]
+                    .as_ref(),
                 )
-            })
-            .unwrap_or_default()
-    }
+                .split(area);
+            let (percentiles_area, histogram_area) = (areas[0], areas[1]);
 
-    /// Get the important percentile values from the histogram
-    fn make_percentiles_widget(&self, styles: &view::Styles) -> Text<'static> {
-        let mut text = Text::default();
-        let histogram = self.poll_times_histogram();
-        let percentiles = histogram.iter().flat_map(|histogram| {
-            let pairs = [10f64, 25f64, 50f64, 75f64, 90f64, 95f64, 99f64]
-                .iter()
-                .map(move |i| (*i, histogram.value_at_percentile(*i)));
-            pairs.map(|pair| {
-                Spans::from(vec![
-                    bold(format!("p{:>2}: ", pair.0)),
-                    dur(styles, Duration::from_nanos(pair.1)),
-                ])
-            })
-        });
-        text.extend(percentiles);
-        text
-    }
-}
+            if let Some(histogram) = histogram {
+                let histogram_widget = MiniHistogram::default()
+                    .block(styles.border_block().title("Poll Times Histogram"))
+                    .histogram(histogram)
+                    .duration_precision(2);
+                frame.render_widget(histogram_widget, histogram_area);
+            } else {
+                let histogram_widget = styles.border_block().title("Poll Times Histogram");
+                frame.render_widget(histogram_widget, histogram_area);
+            }
 
-fn dur(styles: &view::Styles, dur: std::time::Duration) -> Span<'static> {
-    const DUR_PRECISION: usize = 4;
-    // TODO(eliza): can we not have to use `format!` to make a string here? is
-    // there a way to just give TUI a `fmt::Debug` implementation, or does it
-    // have to be given a string in order to do layout stuff?
-    styles.time_units(format!("{:.prec$?}", dur, prec = DUR_PRECISION))
+            percentiles_area
+        } else {
+            area
+        };
+
+        if let Some(histogram) = histogram {
+            let percentiles_widget = Percentiles::default()
+                .block(styles.border_block().title("Poll Times Percentiles"))
+                .styles(styles)
+                .histogram(histogram);
+            frame.render_widget(percentiles_widget, percentiles_area);
+        } else {
+            let percentiles_widget = styles.border_block().title("Poll Times Percentiles");
+            frame.render_widget(percentiles_widget, percentiles_area);
+        }
+    }
 }

--- a/proto/instrument.proto
+++ b/proto/instrument.proto
@@ -57,6 +57,9 @@ message Update {
 
     // Any new span metadata that was registered since the last update.
     common.RegisterMetadata new_metadata = 5;
+
+    // HdrHistogram.rs `Histogram` serialized to binary in the V2 format
+    optional bytes wake_to_poll_times_histogram = 6;
 }
 
 message PauseResponse {


### PR DESCRIPTION
- refactored MiniHistogram so wake to poll histogram can reuse some
  code from poll duration histogram
- added Percentiles widget so wake to poll can reuse code from poll
  duration histogram

for https://github.com/tokio-rs/console/issues/50