### PR TITLE
feat(subscriber): use per-layer filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
 dependencies = [
  "lazy_static",
 ]
@@ -1561,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+checksum = "f7d29c0f56bcd17117430bc60fd10624b419ab8a3b5c358796a31e9a37a83a65"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -18,7 +18,7 @@ console-api = { path = "../console-api", features = ["transport"]}
 tonic = { version = "0.5", features = ["transport"] }
 tracing-core = "0.1.18"
 tracing = "0.1.26"
-tracing-subscriber = { version = "0.2.19", default-features = false, features = ["fmt", "registry", "env-filter"] }
+tracing-subscriber = { version = "0.2.21", default-features = false, features = ["fmt", "registry"] }
 futures = { version = "0.3", default-features = false }
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
 serde = { version = "1", features = ["derive"] }

--- a/console-subscriber/examples/app.rs
+++ b/console-subscriber/examples/app.rs
@@ -65,15 +65,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 async fn spawn_tasks(min: u64, max: u64) {
     loop {
         for i in min..max {
+            tracing::trace!(i, "spawning wait task");
             tokio::task::Builder::new().name("wait").spawn(wait(i));
-            tokio::time::sleep(Duration::from_secs(max) - Duration::from_secs(i)).await;
+
+            let sleep = Duration::from_secs(max) - Duration::from_secs(i);
+            tracing::trace!(?sleep, "sleeping...");
+            tokio::time::sleep(sleep).await;
         }
     }
 }
 
 #[tracing::instrument]
 async fn wait(seconds: u64) {
+    tracing::debug!("waiting...");
     tokio::time::sleep(Duration::from_secs(seconds)).await;
+    tracing::trace!("done!");
 }
 
 #[tracing::instrument]


### PR DESCRIPTION
Currently, the `console_subscriber::build()` and
`console_subscriber::init()` functions configure an `EnvFilter` that
enables the `tokio` and `runtime` targets, plus any targets configured
by `RUST_LOG`. This means that the `tokio` spans used by the console
will always be enabled at the `TRACE` level for all layers. This
includes the `fmt` layer we previously added in `init`.

Since this resulted in the `fmt` layer logs being cluttered with a bunch
of `tokio=trace` spans and events even when only high-level application
logs are enabled by `RUST_LOG`, we removed the `fmt` layer in PR #64.

However, tokio-rs/tracing#1523 was recently merged and [released][1],
adding support for [per-layer filtering][2] to `tracing-subscriber`. We
can now use the per-layer filtering API to selectively enable the
`tokio`/`runtime` spans and events at the `TRACE` level _only_ for the
`TasksLayer`, and add a filter to the `fmt` layer based on `RUST_LOG`.
This allows us to put back the `fmt` layer in
`console_subscriber::init`.

Now, if we run the example app (which uses `init`) with a `RUST_LOG`
value that enables only the app's logs, we get nice output:

![image](https://user-images.githubusercontent.com/2796466/133124582-608c2b72-db2f-4588-bb75-585312ac8d66.png)

However, we can also enable the `console-subscriber` crate's internal
logging:

![image](https://user-images.githubusercontent.com/2796466/133124746-7df10f14-cf8c-40ef-96f3-5046039a8577.png)

And, we can still enable `tokio=trace` ourselves, if we actually _want_
to see all the task spans and waker events:

![image](https://user-images.githubusercontent.com/2796466/133124851-3e4af25a-06a4-4912-9950-bfbab6dba4c7.png)

I also added some `trace!` and `debug!` macros in `examples/app.rs` to
demo that `console_subscriber::init()` also enables logging.

Closes #76