### PR TITLE
docs: fix protobuf link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ toolkit consists of multiple components:
 
 [gRPC]: https://grpc.io/
 [protocol buffers]: https://developers.google.com/protocol-buffers
-[the protobuf definitions]: ./proto
+[the protobuf definitions]: https://github.com/tokio-rs/console/tree/main/console-api/proto
 [`tonic`]: https://lib.rs/crates/tonic
 [Tokio]: https://tokio.rs
 


### PR DESCRIPTION
The protobufs were moved in PR #141, but I forgot to update the link in
the README file. My bad!