### PR TITLE
make the console binary vendorable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,31 +238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.1.0"
-dependencies = [
- "atty",
- "chrono",
- "clap",
- "color-eyre",
- "console-api",
- "crossterm",
- "futures",
- "h2",
- "hdrhistogram",
- "humantime",
- "once_cell",
- "prost-types",
- "regex",
- "tokio",
- "tonic",
- "tracing",
- "tracing-journald",
- "tracing-subscriber",
- "tui",
-]
-
-[[package]]
 name = "console-api"
 version = "0.1.0"
 dependencies = [
@@ -1353,6 +1328,31 @@ dependencies = [
  "tokio-macros",
  "tracing",
  "winapi",
+]
+
+[[package]]
+name = "tokio-console"
+version = "0.1.0"
+dependencies = [
+ "atty",
+ "chrono",
+ "clap",
+ "color-eyre",
+ "console-api",
+ "crossterm",
+ "futures",
+ "h2",
+ "hdrhistogram",
+ "humantime",
+ "once_cell",
+ "prost-types",
+ "regex",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-journald",
+ "tracing-subscriber",
+ "tui",
 ]
 
 [[package]]

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
-name = "console"
+name = "tokio-console"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "David Barsky <me@davidbarsky.com>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/console"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 atty = "0.2"

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -1,0 +1,1 @@
+// this file is here to make a binary target so that cargo metadata works with this crate

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = """
     rustup install nightly --profile minimal \
         && cargo doc --no-deps --all-features -p console-subscriber -p console-api \
-        && cargo doc --no-deps --all-features --document-private-items -p console
+        && cargo doc --no-deps --all-features --document-private-items -p tokio-console
     """
   environment = { RUSTDOCFLAGS= "--cfg docsrs -D warnings" }
   publish = "target/doc"


### PR DESCRIPTION
I am back with "pls help me make this crate vendorable"

2 main changes here:

1. Rename the crate to something not taken on `crates.io` (`cargo vendor` appears to be interested in clashing names, even if I import this crate as `tokio-console = { package = console ... }`. This will be required when its launched crates.io anyways
2. add a dummy `lib.rs` to add a library target to the binary crate in addition to the binary target. Currently, the way our system works is it uses cargo metadata to find all the metadata for all the crates we have vendored. Cargo does NOT add binary-only crates to this, but DOES add info about binary targets if the crate also has a lib target. See https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/cargo.20metadata.20with.20binary.20git.20dep for more info. This is a far simpler fix than doing something like copying and renaming the crate locally.

`cargo run` still works in the workspace