### PR TITLE
refac(console): refactor table view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "tokio"
 version = "1.11.0"
-source = "git+https://github.com/zaharidichev/tokio?branch=zd/instrument-sleep#b1c8f3e73109f8b158da4aa9762162e09d08bb87"
+source = "git+https://github.com/zaharidichev/tokio?branch=zd/instrument-sleep#02a41078e2f14848536f9f4da29352a8823613d9"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "1.3.0"
-source = "git+https://github.com/zaharidichev/tokio?branch=zd/instrument-sleep#b1c8f3e73109f8b158da4aa9762162e09d08bb87"
+source = "git+https://github.com/zaharidichev/tokio?branch=zd/instrument-sleep#02a41078e2f14848536f9f4da29352a8823613d9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/console/src/state/mod.rs
+++ b/console/src/state/mod.rs
@@ -1,0 +1,371 @@
+use crate::view;
+use crate::warnings::Linter;
+use console_api as proto;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    convert::TryInto,
+    fmt,
+    io::Cursor,
+    rc::Rc,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+use tasks::{Details, Task, TasksState};
+use tui::{
+    style::{Color, Modifier},
+    text::Span,
+};
+
+pub mod tasks;
+
+pub(crate) type DetailsRef = Rc<RefCell<Option<Details>>>;
+
+#[derive(Default, Debug)]
+pub(crate) struct State {
+    metas: HashMap<u64, Metadata>,
+    last_updated_at: Option<SystemTime>,
+    temporality: Temporality,
+    tasks_state: TasksState,
+    current_task_details: DetailsRef,
+    retain_for: Option<Duration>,
+}
+
+#[derive(Debug)]
+enum Temporality {
+    Live,
+    Paused,
+}
+
+#[derive(Debug)]
+pub(crate) struct Metadata {
+    field_names: Vec<Arc<str>>,
+    target: Arc<str>,
+    id: u64,
+    //TODO: add more metadata as needed
+}
+
+#[derive(Debug)]
+pub(crate) struct Field {
+    pub(crate) name: Arc<str>,
+    pub(crate) value: FieldValue,
+}
+
+#[derive(Debug)]
+pub(crate) enum FieldValue {
+    Bool(bool),
+    Str(String),
+    U64(u64),
+    I64(i64),
+    Debug(String),
+}
+
+impl State {
+    pub(crate) fn with_retain_for(mut self, retain_for: Option<Duration>) -> Self {
+        self.retain_for = retain_for;
+        self
+    }
+
+    pub(crate) fn with_task_linters(
+        mut self,
+        linters: impl IntoIterator<Item = Linter<Task>>,
+    ) -> Self {
+        self.tasks_state.linters.extend(linters.into_iter());
+        self
+    }
+
+    pub(crate) fn last_updated_at(&self) -> Option<SystemTime> {
+        self.last_updated_at
+    }
+
+    pub(crate) fn update(
+        &mut self,
+        styles: &view::Styles,
+        current_view: &view::ViewState,
+        update: proto::instrument::Update,
+    ) {
+        if let Some(now) = update.now.map(|v| v.try_into().unwrap()) {
+            self.last_updated_at = Some(now);
+        }
+
+        if let Some(new_metadata) = update.new_metadata {
+            let metas = new_metadata.metadata.into_iter().filter_map(|meta| {
+                let id = meta.id?.id;
+                let metadata = meta.metadata?;
+                Some((id, Metadata::from_proto(metadata, id)))
+            });
+            self.metas.extend(metas);
+        }
+
+        if let Some(tasks_update) = update.task_update {
+            self.tasks_state.update_tasks(
+                styles,
+                tasks_update,
+                &self.metas,
+                current_view.is_tasks_view(),
+            )
+        }
+    }
+
+    pub(crate) fn retain_active(&mut self) {
+        if self.is_paused() {
+            return;
+        }
+
+        if let (Some(now), Some(retain_for)) = (self.last_updated_at(), self.retain_for) {
+            self.tasks_state.retain_active(now, retain_for);
+        }
+    }
+
+    pub(crate) fn task_details_ref(&self) -> DetailsRef {
+        self.current_task_details.clone()
+    }
+
+    pub(crate) fn tasks_state(&mut self) -> &TasksState {
+        &self.tasks_state
+    }
+
+    pub(crate) fn tasks_state_mut(&mut self) -> &mut TasksState {
+        &mut self.tasks_state
+    }
+
+    pub(crate) fn update_task_details(&mut self, update: proto::tasks::TaskDetails) {
+        if let Some(id) = update.task_id {
+            let details = Details {
+                task_id: id.id,
+                poll_times_histogram: update.poll_times_histogram.and_then(|data| {
+                    hdrhistogram::serialization::Deserializer::new()
+                        .deserialize(&mut Cursor::new(&data))
+                        .ok()
+                }),
+                last_updated_at: update.now.map(|now| now.try_into().unwrap()),
+            };
+
+            *self.current_task_details.borrow_mut() = Some(details);
+        }
+    }
+
+    pub(crate) fn unset_task_details(&mut self) {
+        *self.current_task_details.borrow_mut() = None;
+    }
+
+    // temporality methods
+
+    pub(crate) fn pause(&mut self) {
+        self.temporality = Temporality::Paused;
+    }
+
+    pub(crate) fn resume(&mut self) {
+        self.temporality = Temporality::Live;
+    }
+
+    pub(crate) fn is_paused(&self) -> bool {
+        matches!(self.temporality, Temporality::Paused)
+    }
+}
+
+impl Default for Temporality {
+    fn default() -> Self {
+        Self::Live
+    }
+}
+
+impl Metadata {
+    fn from_proto(pb: proto::Metadata, id: u64) -> Self {
+        Self {
+            field_names: pb.field_names.into_iter().map(|n| n.into()).collect(),
+            target: pb.target.into(),
+            id,
+        }
+    }
+}
+
+// === impl Field ===
+
+impl Field {
+    const SPAWN_LOCATION: &'static str = "spawn.location";
+    const NAME: &'static str = "task.name";
+
+    /// Converts a wire-format `Field` into an internal `Field` representation,
+    /// using the provided `Metadata` for the task span that the field came
+    /// from.
+    ///
+    /// If the field is invalid or it has a string value which is empty, this
+    /// returns `None`.
+    fn from_proto(
+        proto::Field {
+            name,
+            metadata_id,
+            value,
+        }: proto::Field,
+        meta: &Metadata,
+    ) -> Option<Self> {
+        use proto::field::Name;
+        let name: Arc<str> = match name? {
+            Name::StrName(n) => n.into(),
+            Name::NameIdx(idx) => {
+                let meta_id = metadata_id.map(|m| m.id);
+                if meta_id != Some(meta.id) {
+                    tracing::warn!(
+                        task.meta_id = meta.id,
+                        field.meta.id = ?meta_id,
+                        field.name_index = idx,
+                        ?meta,
+                        "skipping malformed field name (metadata id mismatch)"
+                    );
+                    debug_assert_eq!(
+                        meta_id,
+                        Some(meta.id),
+                        "malformed field name: metadata ID mismatch! (name idx={}; metadata={:#?})",
+                        idx,
+                        meta,
+                    );
+                    return None;
+                }
+                match meta.field_names.get(idx as usize).cloned() {
+                    Some(name) => name,
+                    None => {
+                        tracing::warn!(
+                            task.meta_id = meta.id,
+                            field.meta.id = ?meta_id,
+                            field.name_index = idx,
+                            ?meta,
+                            "missing field name for index"
+                        );
+                        return None;
+                    }
+                }
+            }
+        };
+
+        debug_assert!(
+            value.is_some(),
+            "missing field value for field `{:?}` (metadata={:#?})",
+            name,
+            meta,
+        );
+        let mut value = FieldValue::from(value?)
+            // if the value is an empty string, just skip it.
+            .ensure_nonempty()?;
+
+        if &*name == Field::SPAWN_LOCATION {
+            value = value.truncate_registry_path();
+        }
+
+        Some(Self { name, value })
+    }
+
+    fn make_formatted(styles: &view::Styles, fields: &mut Vec<Field>) -> Vec<Vec<Span<'static>>> {
+        use std::cmp::Ordering;
+
+        let key_style = styles.fg(Color::LightBlue).add_modifier(Modifier::BOLD);
+        let delim_style = styles.fg(Color::LightBlue).add_modifier(Modifier::DIM);
+        let val_style = styles.fg(Color::Yellow);
+
+        fields.sort_unstable_by(|left, right| {
+            if &*left.name == Field::NAME {
+                return Ordering::Less;
+            }
+
+            if &*right.name == Field::NAME {
+                return Ordering::Greater;
+            }
+
+            if &*left.name == Field::SPAWN_LOCATION {
+                return Ordering::Greater;
+            }
+
+            if &*right.name == Field::SPAWN_LOCATION {
+                return Ordering::Less;
+            }
+
+            left.name.cmp(&right.name)
+        });
+
+        let mut formatted = Vec::with_capacity(fields.len());
+        let mut fields = fields.iter();
+        if let Some(field) = fields.next() {
+            formatted.push(vec![
+                Span::styled(field.name.to_string(), key_style),
+                Span::styled("=", delim_style),
+                Span::styled(format!("{} ", field.value), val_style),
+            ]);
+            for field in fields {
+                formatted.push(vec![
+                    // Span::styled(", ", delim_style),
+                    Span::styled(field.name.to_string(), key_style),
+                    Span::styled("=", delim_style),
+                    Span::styled(format!("{} ", field.value), val_style),
+                ])
+            }
+        }
+        formatted
+    }
+}
+
+// === impl FieldValue ===
+
+impl fmt::Display for FieldValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FieldValue::Bool(v) => fmt::Display::fmt(v, f)?,
+            FieldValue::Str(v) => fmt::Display::fmt(v, f)?,
+            FieldValue::U64(v) => fmt::Display::fmt(v, f)?,
+            FieldValue::Debug(v) => fmt::Display::fmt(v, f)?,
+            FieldValue::I64(v) => fmt::Display::fmt(v, f)?,
+        }
+
+        Ok(())
+    }
+}
+
+impl FieldValue {
+    /// Truncates paths including `.cargo/registry`.
+    fn truncate_registry_path(self) -> Self {
+        match self {
+            FieldValue::Str(s) | FieldValue::Debug(s) => {
+                FieldValue::Debug(truncate_registry_path(s))
+            }
+
+            f => f,
+        }
+    }
+
+    /// If `self` is an empty string, returns `None`. Otherwise, returns `Some(self)`.
+    fn ensure_nonempty(self) -> Option<Self> {
+        match self {
+            FieldValue::Debug(s) | FieldValue::Str(s) if s.is_empty() => None,
+            val => Some(val),
+        }
+    }
+}
+
+impl From<proto::field::Value> for FieldValue {
+    fn from(pb: proto::field::Value) -> Self {
+        match pb {
+            proto::field::Value::BoolVal(v) => Self::Bool(v),
+            proto::field::Value::StrVal(v) => Self::Str(v),
+            proto::field::Value::I64Val(v) => Self::I64(v),
+            proto::field::Value::U64Val(v) => Self::U64(v),
+            proto::field::Value::DebugVal(v) => Self::Debug(v),
+        }
+    }
+}
+
+fn truncate_registry_path(s: String) -> String {
+    use once_cell::sync::OnceCell;
+    use regex::Regex;
+    use std::borrow::Cow;
+
+    static REGEX: OnceCell<Regex> = OnceCell::new();
+    let regex = REGEX.get_or_init(|| {
+        Regex::new(r#".*/\.cargo(/registry/src/[^/]*/|/git/checkouts/)"#)
+            .expect("failed to compile regex")
+    });
+
+    return match regex.replace(&s, "<cargo>/") {
+        Cow::Owned(s) => s,
+        // String was not modified, return the original.
+        Cow::Borrowed(_) => s.to_string(),
+    };
+}

--- a/console/src/state/tasks.rs
+++ b/console/src/state/tasks.rs
@@ -1,3 +1,4 @@
+use super::{Field, Metadata};
 use crate::{util::Percentage, view, warnings::Linter};
 use console_api as proto;
 use hdrhistogram::Histogram;
@@ -5,33 +6,24 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     convert::{TryFrom, TryInto},
-    fmt,
-    io::Cursor,
     rc::{Rc, Weak},
     sync::Arc,
     time::{Duration, SystemTime},
 };
-use tui::{
-    style::{Color, Modifier},
-    text::Span,
-};
+use tui::{style::Color, text::Span};
 
 #[derive(Default, Debug)]
-pub(crate) struct State {
+pub(crate) struct TasksState {
     tasks: HashMap<u64, Rc<RefCell<Task>>>,
-    metas: HashMap<u64, Metadata>,
-    linters: Vec<Linter<Task>>,
-    last_updated_at: Option<SystemTime>,
     new_tasks: Vec<TaskRef>,
-    current_task_details: DetailsRef,
-    temporality: Temporality,
-    retain_for: Option<Duration>,
+    pub(crate) linters: Vec<Linter<Task>>,
 }
 
-#[derive(Debug)]
-enum Temporality {
-    Live,
-    Paused,
+#[derive(Debug, Default)]
+pub(crate) struct Details {
+    pub(crate) task_id: u64,
+    pub(crate) poll_times_histogram: Option<Histogram<u64>>,
+    pub(crate) last_updated_at: Option<SystemTime>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -55,37 +47,21 @@ pub(crate) enum TaskState {
 }
 
 pub(crate) type TaskRef = Weak<RefCell<Task>>;
-pub(crate) type DetailsRef = Rc<RefCell<Option<Details>>>;
 
 #[derive(Debug)]
 pub(crate) struct Task {
     id: u64,
     fields: Vec<Field>,
     formatted_fields: Vec<Vec<Span<'static>>>,
-    stats: Stats,
+    stats: TaskStats,
     target: Arc<str>,
     name: Option<Arc<str>>,
     /// Currently active warnings for this task.
     warnings: Vec<Linter<Task>>,
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct Details {
-    task_id: u64,
-    poll_times_histogram: Option<Histogram<u64>>,
-    last_updated_at: Option<SystemTime>,
-}
-
 #[derive(Debug)]
-pub(crate) struct Metadata {
-    field_names: Vec<Arc<str>>,
-    target: Arc<str>,
-    id: u64,
-    //TODO: add more metadata as needed
-}
-
-#[derive(Debug)]
-struct Stats {
+struct TaskStats {
     polls: u64,
     created_at: SystemTime,
     dropped_at: Option<SystemTime>,
@@ -110,36 +86,7 @@ struct Stats {
     self_wakes: u64,
 }
 
-#[derive(Debug)]
-pub(crate) struct Field {
-    pub(crate) name: Arc<str>,
-    pub(crate) value: FieldValue,
-}
-
-#[derive(Debug)]
-pub(crate) enum FieldValue {
-    Bool(bool),
-    Str(String),
-    U64(u64),
-    I64(i64),
-    Debug(String),
-}
-
-impl State {
-    pub(crate) fn with_retain_for(mut self, retain_for: Option<Duration>) -> Self {
-        self.retain_for = retain_for;
-        self
-    }
-
-    pub(crate) fn with_linters(mut self, linters: impl IntoIterator<Item = Linter<Task>>) -> Self {
-        self.linters.extend(linters.into_iter());
-        self
-    }
-
-    pub(crate) fn last_updated_at(&self) -> Option<SystemTime> {
-        self.last_updated_at
-    }
-
+impl TasksState {
     /// Returns any new tasks that were added since the last task update.
     pub(crate) fn take_new_tasks(&mut self) -> impl Iterator<Item = TaskRef> + '_ {
         self.new_tasks.drain(..)
@@ -149,28 +96,16 @@ impl State {
         &mut self,
         styles: &view::Styles,
         update: proto::tasks::TaskUpdate,
-        new_metadata: Option<proto::RegisterMetadata>,
-        now: Option<SystemTime>,
+        metas: &HashMap<u64, Metadata>,
+        clear_new_list: bool,
     ) {
-        if let Some(now) = now {
-            self.last_updated_at = Some(now);
-        }
-
-        if let Some(new_metadata) = new_metadata {
-            let metas = new_metadata.metadata.into_iter().filter_map(|meta| {
-                let id = meta.id?.id;
-                let metadata = meta.metadata?;
-                Some((id, Metadata::from_proto(metadata, id)))
-            });
-            self.metas.extend(metas);
-        }
-
         let mut stats_update = update.stats_update;
         let new_list = &mut self.new_tasks;
-        new_list.clear();
+        if clear_new_list {
+            new_list.clear();
+        }
         let linters = &self.linters;
 
-        let metas = &mut self.metas;
         let new_tasks = update.new_tasks.into_iter().filter_map(|mut task| {
             if task.id.is_none() {
                 tracing::warn!(?task, "skipping task with no id");
@@ -233,67 +168,32 @@ impl State {
         }
     }
 
-    pub(crate) fn details_ref(&self) -> DetailsRef {
-        self.current_task_details.clone()
-    }
+    pub(crate) fn retain_active(&mut self, now: SystemTime, retain_for: Duration) {
+        self.tasks.retain(|_, task| {
+            let task = task.borrow();
 
-    pub(crate) fn update_task_details(&mut self, update: proto::tasks::TaskDetails) {
-        if let Some(id) = update.task_id {
-            let details = Details {
-                task_id: id.id,
-                poll_times_histogram: update.poll_times_histogram.and_then(|data| {
-                    hdrhistogram::serialization::Deserializer::new()
-                        .deserialize(&mut Cursor::new(&data))
-                        .ok()
-                }),
-                last_updated_at: update.now.map(|now| now.try_into().unwrap()),
-            };
-
-            *self.current_task_details.borrow_mut() = Some(details);
-        }
-    }
-
-    pub(crate) fn unset_task_details(&mut self) {
-        *self.current_task_details.borrow_mut() = None;
-    }
-
-    pub(crate) fn retain_active(&mut self) {
-        // Don't clean up stopped tasks while the console is paused.
-        if self.is_paused() {
-            return;
-        }
-
-        if let (Some(now), Some(retain_for)) = (self.last_updated_at, self.retain_for) {
-            self.tasks.retain(|_, task| {
-                let task = task.borrow();
-
-                task.stats
-                    .dropped_at
-                    .map(|d| {
-                        let dropped_for = now.duration_since(d).unwrap();
-                        retain_for > dropped_for
-                    })
-                    .unwrap_or(true)
-            })
-        }
-    }
-
-    // temporality methods
-
-    pub(crate) fn pause(&mut self) {
-        self.temporality = Temporality::Paused;
-    }
-
-    pub(crate) fn resume(&mut self) {
-        self.temporality = Temporality::Live;
-    }
-
-    pub(crate) fn is_paused(&self) -> bool {
-        matches!(self.temporality, Temporality::Paused)
+            task.stats
+                .dropped_at
+                .map(|d| {
+                    let dropped_for = now.duration_since(d).unwrap();
+                    retain_for > dropped_for
+                })
+                .unwrap_or(true)
+        })
     }
 
     pub(crate) fn warnings(&self) -> impl Iterator<Item = &Linter<Task>> {
         self.linters.iter().filter(|linter| linter.count() > 0)
+    }
+}
+
+impl Details {
+    pub(crate) fn task_id(&self) -> u64 {
+        self.task_id
+    }
+
+    pub(crate) fn poll_times_histogram(&self) -> Option<&Histogram<u64>> {
+        self.poll_times_histogram.as_ref()
     }
 }
 
@@ -430,17 +330,7 @@ impl Task {
     }
 }
 
-impl Details {
-    pub(crate) fn task_id(&self) -> u64 {
-        self.task_id
-    }
-
-    pub(crate) fn poll_times_histogram(&self) -> Option<&Histogram<u64>> {
-        self.poll_times_histogram.as_ref()
-    }
-}
-
-impl From<proto::tasks::Stats> for Stats {
+impl From<proto::tasks::Stats> for TaskStats {
     fn from(pb: proto::tasks::Stats) -> Self {
         fn pb_duration(dur: prost_types::Duration) -> Duration {
             let secs =
@@ -480,34 +370,6 @@ impl From<proto::tasks::Stats> for Stats {
     }
 }
 
-impl Metadata {
-    fn from_proto(pb: proto::Metadata, id: u64) -> Self {
-        Self {
-            field_names: pb.field_names.into_iter().map(|n| n.into()).collect(),
-            target: pb.target.into(),
-            id,
-        }
-    }
-}
-
-impl From<proto::field::Value> for FieldValue {
-    fn from(pb: proto::field::Value) -> Self {
-        match pb {
-            proto::field::Value::BoolVal(v) => Self::Bool(v),
-            proto::field::Value::StrVal(v) => Self::Str(v),
-            proto::field::Value::I64Val(v) => Self::I64(v),
-            proto::field::Value::U64Val(v) => Self::U64(v),
-            proto::field::Value::DebugVal(v) => Self::Debug(v),
-        }
-    }
-}
-
-impl Default for Temporality {
-    fn default() -> Self {
-        Self::Live
-    }
-}
-
 impl Default for SortBy {
     fn default() -> Self {
         Self::Total
@@ -542,6 +404,12 @@ impl SortBy {
     }
 }
 
+impl view::SortBy for SortBy {
+    fn as_column(&self) -> usize {
+        *self as usize
+    }
+}
+
 impl TryFrom<usize> for SortBy {
     type Error = ();
     fn try_from(idx: usize) -> Result<Self, Self::Error> {
@@ -555,179 +423,6 @@ impl TryFrom<usize> for SortBy {
             idx if idx == Self::Idle as usize => Ok(Self::Idle),
             idx if idx == Self::Polls as usize => Ok(Self::Polls),
             _ => Err(()),
-        }
-    }
-}
-
-// === impl Field ===
-
-impl Field {
-    const SPAWN_LOCATION: &'static str = "spawn.location";
-    const NAME: &'static str = "task.name";
-
-    /// Converts a wire-format `Field` into an internal `Field` representation,
-    /// using the provided `Metadata` for the task span that the field came
-    /// from.
-    ///
-    /// If the field is invalid or it has a string value which is empty, this
-    /// returns `None`.
-    fn from_proto(
-        proto::Field {
-            name,
-            metadata_id,
-            value,
-        }: proto::Field,
-        meta: &Metadata,
-    ) -> Option<Self> {
-        use proto::field::Name;
-        let name: Arc<str> = match name? {
-            Name::StrName(n) => n.into(),
-            Name::NameIdx(idx) => {
-                let meta_id = metadata_id.map(|m| m.id);
-                if meta_id != Some(meta.id) {
-                    tracing::warn!(
-                        task.meta_id = meta.id,
-                        field.meta.id = ?meta_id,
-                        field.name_index = idx,
-                        ?meta,
-                        "skipping malformed field name (metadata id mismatch)"
-                    );
-                    debug_assert_eq!(
-                        meta_id,
-                        Some(meta.id),
-                        "malformed field name: metadata ID mismatch! (name idx={}; metadata={:#?})",
-                        idx,
-                        meta,
-                    );
-                    return None;
-                }
-                match meta.field_names.get(idx as usize).cloned() {
-                    Some(name) => name,
-                    None => {
-                        tracing::warn!(
-                            task.meta_id = meta.id,
-                            field.meta.id = ?meta_id,
-                            field.name_index = idx,
-                            ?meta,
-                            "missing field name for index"
-                        );
-                        return None;
-                    }
-                }
-            }
-        };
-
-        debug_assert!(
-            value.is_some(),
-            "missing field value for field `{:?}` (metadata={:#?})",
-            name,
-            meta,
-        );
-        let mut value = FieldValue::from(value?)
-            // if the value is an empty string, just skip it.
-            .ensure_nonempty()?;
-
-        if &*name == Field::SPAWN_LOCATION {
-            value = value.truncate_registry_path();
-        }
-
-        Some(Self { name, value })
-    }
-
-    fn make_formatted(styles: &view::Styles, fields: &mut Vec<Field>) -> Vec<Vec<Span<'static>>> {
-        use std::cmp::Ordering;
-
-        let key_style = styles.fg(Color::LightBlue).add_modifier(Modifier::BOLD);
-        let delim_style = styles.fg(Color::LightBlue).add_modifier(Modifier::DIM);
-        let val_style = styles.fg(Color::Yellow);
-
-        fields.sort_unstable_by(|left, right| {
-            if &*left.name == Field::NAME {
-                return Ordering::Less;
-            }
-
-            if &*right.name == Field::NAME {
-                return Ordering::Greater;
-            }
-
-            if &*left.name == Field::SPAWN_LOCATION {
-                return Ordering::Greater;
-            }
-
-            if &*right.name == Field::SPAWN_LOCATION {
-                return Ordering::Less;
-            }
-
-            left.name.cmp(&right.name)
-        });
-
-        let mut formatted = Vec::with_capacity(fields.len());
-        let mut fields = fields.iter();
-        if let Some(field) = fields.next() {
-            formatted.push(vec![
-                Span::styled(field.name.to_string(), key_style),
-                Span::styled("=", delim_style),
-                Span::styled(format!("{} ", field.value), val_style),
-            ]);
-            for field in fields {
-                formatted.push(vec![
-                    // Span::styled(", ", delim_style),
-                    Span::styled(field.name.to_string(), key_style),
-                    Span::styled("=", delim_style),
-                    Span::styled(format!("{} ", field.value), val_style),
-                ])
-            }
-        }
-        formatted
-    }
-}
-
-// === impl FieldValue ===
-
-impl fmt::Display for FieldValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FieldValue::Bool(v) => fmt::Display::fmt(v, f)?,
-            FieldValue::Str(v) => fmt::Display::fmt(v, f)?,
-            FieldValue::U64(v) => fmt::Display::fmt(v, f)?,
-            FieldValue::Debug(v) => fmt::Display::fmt(v, f)?,
-            FieldValue::I64(v) => fmt::Display::fmt(v, f)?,
-        }
-
-        Ok(())
-    }
-}
-
-impl FieldValue {
-    /// Truncates paths including `.cargo/registry`.
-    fn truncate_registry_path(self) -> Self {
-        use once_cell::sync::OnceCell;
-        use regex::Regex;
-        use std::borrow::Cow;
-
-        static REGEX: OnceCell<Regex> = OnceCell::new();
-        let regex = REGEX.get_or_init(|| {
-            Regex::new(r#".*/\.cargo/registry/src/[^/]*/"#).expect("failed to compile regex")
-        });
-
-        let s = match self {
-            FieldValue::Str(s) | FieldValue::Debug(s) => s,
-            f => return f,
-        };
-
-        let s = match regex.replace(&s, "<cargo>/") {
-            Cow::Owned(s) => s,
-            // String was not modified, return the original.
-            Cow::Borrowed(_) => s,
-        };
-        FieldValue::Debug(s)
-    }
-
-    /// If `self` is an empty string, returns `None`. Otherwise, returns `Some(self)`.
-    fn ensure_nonempty(self) -> Option<Self> {
-        match self {
-            FieldValue::Debug(s) | FieldValue::Str(s) if s.is_empty() => None,
-            val => Some(val),
         }
     }
 }

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -146,10 +146,7 @@ impl View {
 
 impl ViewState {
     pub(crate) fn is_tasks_view(&self) -> bool {
-        if let Self::TasksList = self {
-            return true;
-        }
-        false
+        matches!(self, Self::TasksList)
     }
 }
 

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -1,4 +1,5 @@
-use crate::{input, tasks::State};
+use crate::view::{table::TableListState, tasks::TasksTable};
+use crate::{input, state::State};
 use std::{borrow::Cow, cmp};
 use tui::{
     layout,
@@ -8,9 +9,18 @@ use tui::{
 
 mod mini_histogram;
 mod styles;
+mod table;
 mod task;
 mod tasks;
 pub(crate) use self::styles::{Palette, Styles};
+pub(crate) use self::table::SortBy;
+
+const DUR_LEN: usize = 10;
+// This data is only updated every second, so it doesn't make a ton of
+// sense to have a lot of precision in timestamps (and this makes sure
+// there's room for the unit!)
+const DUR_PRECISION: usize = 4;
+const TABLE_HIGHLIGHT_SYMBOL: &str = ">> ";
 
 pub struct View {
     /// The tasks list is stored separately from the currently selected state,
@@ -20,12 +30,12 @@ pub struct View {
     /// details view), we want to leave the task list's state the way we left it
     /// --- e.g., if the user previously selected a particular sorting, we want
     /// it to remain sorted that way when we return to it.
-    list: tasks::List,
+    tasks_list: TableListState<TasksTable>,
     state: ViewState,
     pub(crate) styles: Styles,
 }
 
-enum ViewState {
+pub(crate) enum ViewState {
     /// The table list of all tasks.
     TasksList,
     /// Inspecting a single task instance.
@@ -61,12 +71,12 @@ impl View {
     pub fn new(styles: Styles) -> Self {
         Self {
             state: ViewState::TasksList,
-            list: tasks::List::default(),
+            tasks_list: TableListState::<TasksTable>::default(),
             styles,
         }
     }
 
-    pub(crate) fn update_input(&mut self, event: input::Event, tasks: &State) -> UpdateKind {
+    pub(crate) fn update_input(&mut self, event: input::Event, state: &State) -> UpdateKind {
         use ViewState::*;
         let mut update_kind = UpdateKind::Other;
         match self.state {
@@ -75,15 +85,17 @@ impl View {
                 // mutate the currently selected view.
                 match event {
                     key!(Enter) => {
-                        if let Some(task) = self.list.selected_task().upgrade() {
+                        if let Some(task) = self.tasks_list.selected_item().upgrade() {
                             update_kind = UpdateKind::SelectTask(task.borrow().id());
-                            self.state =
-                                TaskInstance(self::task::TaskView::new(task, tasks.details_ref()));
+                            self.state = TaskInstance(self::task::TaskView::new(
+                                task,
+                                state.task_details_ref(),
+                            ));
                         }
                     }
                     _ => {
                         // otherwise pass on to view
-                        self.list.update_input(event);
+                        self.tasks_list.update_input(event);
                     }
                 }
             }
@@ -109,21 +121,35 @@ impl View {
         &mut self,
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
-        tasks: &mut crate::tasks::State,
+        state: &mut State,
     ) {
+        let styles = &self.styles;
         match self.state {
             ViewState::TasksList => {
-                self.list.render(&self.styles, frame, area, tasks);
+                self.tasks_list.render(styles, frame, area, state);
             }
             ViewState::TaskInstance(ref mut view) => {
-                let now = tasks
+                let now = state
                     .last_updated_at()
                     .expect("task view implies we've received an update");
                 view.render(&self.styles, frame, area, now);
             }
         }
 
-        tasks.retain_active();
+        state.retain_active();
+    }
+
+    pub(crate) fn current_view(&self) -> &ViewState {
+        &self.state
+    }
+}
+
+impl ViewState {
+    pub(crate) fn is_tasks_view(&self) -> bool {
+        if let Self::TasksList = self {
+            return true;
+        }
+        false
     }
 }
 

--- a/console/src/view/table.rs
+++ b/console/src/view/table.rs
@@ -1,0 +1,189 @@
+use crate::{
+    input, state,
+    view::{self, bold},
+};
+use std::convert::TryFrom;
+use tui::{
+    layout,
+    text::{self, Span, Spans, Text},
+    widgets::TableState,
+};
+
+use std::cell::RefCell;
+use std::rc::Weak;
+
+pub(crate) trait TableList {
+    type Row;
+    type Sort: SortBy + TryFrom<usize>;
+    const HEADER: &'static [&'static str];
+
+    fn render<B: tui::backend::Backend>(
+        state: &mut TableListState<Self>,
+        styles: &view::Styles,
+        frame: &mut tui::terminal::Frame<B>,
+        area: layout::Rect,
+        state: &mut state::State,
+    ) where
+        Self: Sized;
+}
+
+pub(crate) trait SortBy {
+    fn as_column(&self) -> usize;
+}
+
+pub(crate) struct TableListState<T: TableList> {
+    pub(crate) sorted_items: Vec<Weak<RefCell<T::Row>>>,
+    pub(crate) sort_by: T::Sort,
+    pub(crate) selected_column: usize,
+    pub(crate) sort_descending: bool,
+    pub(crate) table_state: TableState,
+}
+
+impl<T: TableList> TableListState<T> {
+    pub(in crate::view) fn len(&self) -> usize {
+        self.sorted_items.len()
+    }
+
+    pub(in crate::view) fn update_input(&mut self, event: input::Event) {
+        // Clippy likes to remind us that we could use an `if let` here, since
+        // the match only has one arm...but this is a `match` because I
+        // anticipate adding more cases later...
+        #[allow(clippy::single_match)]
+        match event {
+            input::Event::Key(event) => self.key_input(event),
+            _ => {
+                // do nothing for now
+                // TODO(eliza): mouse input would be cool...
+            }
+        }
+    }
+
+    pub(in crate::view) fn key_input(&mut self, input::KeyEvent { code, .. }: input::KeyEvent) {
+        use input::KeyCode::*;
+        let header_len = T::HEADER.len();
+        match code {
+            Left => {
+                if self.selected_column == 0 {
+                    self.selected_column = header_len - 1;
+                } else {
+                    self.selected_column -= 1;
+                }
+            }
+            Right => {
+                if self.selected_column == header_len - 1 {
+                    self.selected_column = 0;
+                } else {
+                    self.selected_column += 1;
+                }
+            }
+            Char('i') => self.sort_descending = !self.sort_descending,
+            Down => self.scroll_next(),
+            Up => self.scroll_prev(),
+            _ => {} // do nothing for now...
+        }
+        if let Ok(sort_by) = T::Sort::try_from(self.selected_column) {
+            self.sort_by = sort_by;
+        }
+    }
+
+    pub(in crate::view) fn scroll_with(
+        &mut self,
+        f: impl Fn(&Vec<Weak<RefCell<T::Row>>>, usize) -> usize,
+    ) {
+        // If the list of sorted items is empty, don't try to scroll...
+        if self.sorted_items.is_empty() {
+            self.table_state.select(None);
+            return;
+        }
+
+        // Increment the currently selected row, or if no row is selected, start
+        // at the first row.
+        let i = self.table_state.selected().unwrap_or(0);
+        let i = f(&self.sorted_items, i);
+        self.table_state.select(Some(i));
+    }
+
+    pub(in crate::view) fn scroll_next(&mut self) {
+        self.scroll_with(|resources, i| {
+            if i >= resources.len() - 1 {
+                // If the last itsm is currently selected, wrap around to the
+                // first item.
+                0
+            } else {
+                // Otherwise, increase the selected index by 1.
+                i + 1
+            }
+        });
+    }
+
+    pub(in crate::view) fn scroll_prev(&mut self) {
+        self.scroll_with(|resources, i| {
+            if i == 0 {
+                // If the first item is currently selected, wrap around to the
+                // last item.
+                resources.len() - 1
+            } else {
+                // Otherwise, decrease the selected item by 1.
+                i - 1
+            }
+        })
+    }
+
+    pub(in crate::view) fn selected_item(&self) -> Weak<RefCell<T::Row>> {
+        self.table_state
+            .selected()
+            .map(|i| {
+                let selected = if self.sort_descending {
+                    i
+                } else {
+                    self.sorted_items.len() - i - 1
+                };
+                self.sorted_items[selected].clone()
+            })
+            .unwrap_or_default()
+    }
+
+    pub(in crate::view) fn render<B: tui::backend::Backend>(
+        &mut self,
+        styles: &view::Styles,
+        frame: &mut tui::terminal::Frame<B>,
+        area: layout::Rect,
+        state: &mut state::State,
+    ) {
+        T::render(self, styles, frame, area, state)
+    }
+}
+
+pub(in crate::view) fn controls(styles: &view::Styles) -> Text {
+    tui::text::Text::from(Spans::from(vec![
+        Span::raw("controls: "),
+        bold(styles.if_utf8("\u{2190}\u{2192}", "left, right")),
+        text::Span::raw(" = select column (sort), "),
+        bold(styles.if_utf8("\u{2191}\u{2193}", "up, down")),
+        text::Span::raw(" = scroll, "),
+        bold(styles.if_utf8("\u{21B5}", "enter")),
+        text::Span::raw(" = view details, "),
+        bold("i"),
+        text::Span::raw(" = invert sort (highest/lowest), "),
+        bold("q"),
+        text::Span::raw(" = quit"),
+    ]))
+}
+
+impl<T> Default for TableListState<T>
+where
+    T: TableList,
+    T::Sort: Default,
+{
+    fn default() -> Self {
+        let sort_by = T::Sort::default();
+        let selected_column = sort_by.as_column();
+        Self {
+            sorted_items: Default::default(),
+            sort_by,
+            table_state: Default::default(),
+            selected_column,
+            sort_descending: false,
+        }
+    }
+}

--- a/console/src/view/task.rs
+++ b/console/src/view/task.rs
@@ -1,6 +1,9 @@
 use crate::{
     input,
-    tasks::{Details, DetailsRef, Task},
+    state::{
+        tasks::{Details, Task},
+        DetailsRef,
+    },
     util::Percentage,
     view::{
         self, bold,

--- a/console/src/warnings.rs
+++ b/console/src/warnings.rs
@@ -1,4 +1,4 @@
-use crate::tasks::Task;
+use crate::state::tasks::Task;
 use std::{fmt::Debug, rc::Rc};
 
 /// A warning for a particular type of monitored entity (e.g. task or resource).


### PR DESCRIPTION
This change factors out the table logic from the tasks view in order
to make it reusable for future features (e.g. resources view).

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>