### PR TITLE
chore(console): use `Location` for tasks and resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,7 +1338,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "tokio"
 version = "1.11.0"
-source = "git+https://github.com/zaharidichev/tokio?branch=zd/instrument-sleep#b1c8f3e73109f8b158da4aa9762162e09d08bb87"
+source = "git+https://github.com/zaharidichev/tokio?branch=zd/instrument-sleep#02a41078e2f14848536f9f4da29352a8823613d9"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "1.3.0"
-source = "git+https://github.com/zaharidichev/tokio?branch=zd/instrument-sleep#b1c8f3e73109f8b158da4aa9762162e09d08bb87"
+source = "git+https://github.com/zaharidichev/tokio?branch=zd/instrument-sleep#02a41078e2f14848536f9f4da29352a8823613d9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/console-api/proto/resources.proto
+++ b/console-api/proto/resources.proto
@@ -40,7 +40,7 @@ message Resource {
     // The kind of resource (e.g timer, mutex)
     Kind kind = 4;
     // The location in code where the resource was created.
-    common.Location location = 4;
+    common.Location location = 5;
 
     message Kind {
         oneof kind {

--- a/console-api/proto/resources.proto
+++ b/console-api/proto/resources.proto
@@ -37,8 +37,10 @@ message Resource {
     common.MetaId metadata = 2;
     // The resources's concrete rust type.
     string concrete_type = 3;
+    // The location in code where the resource was created.
+    common.Location location = 4;
     // The kind of resource (e.g timer, mutex)
-    Kind kind = 4;
+    Kind kind = 5;
 
     message Kind {
         oneof kind {

--- a/console-api/proto/resources.proto
+++ b/console-api/proto/resources.proto
@@ -37,10 +37,10 @@ message Resource {
     common.MetaId metadata = 2;
     // The resources's concrete rust type.
     string concrete_type = 3;
+    // The kind of resource (e.g timer, mutex)
+    Kind kind = 4;
     // The location in code where the resource was created.
     common.Location location = 4;
-    // The kind of resource (e.g timer, mutex)
-    Kind kind = 5;
 
     message Kind {
         oneof kind {

--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -73,6 +73,8 @@ message Task {
     // These IDs may correspond to `tracing` spans which are *not* tasks, if
     // additional trace data is being collected.
     repeated common.SpanId parents = 5;
+    // The location in code where the task was spawned.
+    common.Location location = 6;
 
     enum Kind {
         SPAWN = 0;

--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -772,7 +772,13 @@ impl Aggregator {
             } => {
                 let resource_id = self.ids.id_for(resource_id);
                 if let Some(mut stats) = self.resource_stats.update(&resource_id) {
-                    let field_name = update.field.name.clone().expect("field misses name");
+                    let field_name = match update.field.name.clone() {
+                        Some(name) => name,
+                        None => {
+                            tracing::warn!(?update.field, "field missing name, skipping...");
+                            return;
+                        }
+                    };
                     let upd_key = FieldKey {
                         resource_id,
                         field_name,

--- a/console-subscriber/src/visitors.rs
+++ b/console-subscriber/src/visitors.rs
@@ -44,9 +44,10 @@ pub(crate) struct FieldVisitor {
 }
 
 /// Used to extract the fields needed to construct
-/// an Event::Spawn from the metadata of a tracing span
+/// an `Event::Spawn` from the metadata of a tracing span
 /// that has the following shape:
 ///
+/// ```
 /// tracing::trace_span!(
 ///     target: "tokio::task",
 ///     "runtime.spawn",
@@ -56,10 +57,14 @@ pub(crate) struct FieldVisitor {
 ///     loc.line = 555,
 ///     loc.col = 5,
 /// );
+/// ```
 ///
-/// Fields:
-/// concrete_type - indicates the concrete rust type for this resource
-/// kind - indicates the type of resource (i.e. timer, sync, io )
+/// # Fields
+///
+/// This visitor has special behavior for `loc.line`, `loc.file`, and `loc.col`
+/// fields, which are interpreted as a Rust source code location where the task
+/// was spawned, if they are present. Other fields are recorded as arbitrary
+/// key-value pairs.
 pub(crate) struct TaskVisitor {
     field_visitor: FieldVisitor,
     line: Option<u32>,

--- a/console-subscriber/src/visitors.rs
+++ b/console-subscriber/src/visitors.rs
@@ -10,6 +10,10 @@ use tracing_core::{
     span,
 };
 
+const LOCATION_FILE: &str = "loc.file";
+const LOCATION_LINE: &str = "loc.line";
+const LOCATION_COLUMN: &str = "loc.col";
+
 /// Used to extract the fields needed to construct
 /// an Event::Resource from the metadata of a tracing span
 /// that has the following shape:
@@ -27,6 +31,9 @@ use tracing_core::{
 pub(crate) struct ResourceVisitor {
     concrete_type: Option<String>,
     kind: Option<resource::Kind>,
+    line: Option<u32>,
+    file: Option<String>,
+    column: Option<u32>,
 }
 
 /// Used to extract all fields from the metadata
@@ -34,6 +41,30 @@ pub(crate) struct ResourceVisitor {
 pub(crate) struct FieldVisitor {
     fields: Vec<proto::Field>,
     meta_id: proto::MetaId,
+}
+
+/// Used to extract the fields needed to construct
+/// an Event::Spawn from the metadata of a tracing span
+/// that has the following shape:
+///
+/// tracing::trace_span!(
+///     target: "tokio::task",
+///     "runtime.spawn",
+///     kind = "local",
+///     task.name = "some_name",
+///     loc.file = "some_file.rs"
+///     loc.line = 555,
+///     loc.col = 5,
+/// );
+///
+/// Fields:
+/// concrete_type - indicates the concrete rust type for this resource
+/// kind - indicates the type of resource (i.e. timer, sync, io )
+pub(crate) struct TaskVisitor {
+    field_visitor: FieldVisitor,
+    line: Option<u32>,
+    file: Option<String>,
+    column: Option<u32>,
 }
 
 /// Used to extract the fields needed to construct
@@ -119,8 +150,22 @@ impl ResourceVisitor {
     const RES_KIND_FIELD_NAME: &'static str = "kind";
     const RES_KIND_TIMER: &'static str = "timer";
 
-    pub(crate) fn result(self) -> Option<(String, resource::Kind)> {
-        self.concrete_type.zip(self.kind)
+    pub(crate) fn result(self) -> Option<(String, resource::Kind, Option<proto::Location>)> {
+        let concrete_type = self.concrete_type?;
+        let kind = self.kind?;
+
+        let location = if self.file.is_some() && self.line.is_some() && self.column.is_some() {
+            Some(proto::Location {
+                file: self.file,
+                line: self.line,
+                column: self.column,
+                ..Default::default()
+            })
+        } else {
+            None
+        };
+
+        Some((concrete_type, kind, location))
     }
 }
 
@@ -139,6 +184,15 @@ impl Visit for ResourceVisitor {
                 });
                 self.kind = Some(resource::Kind { kind });
             }
+            LOCATION_FILE => self.file = Some(value.to_string()),
+            _ => {}
+        }
+    }
+
+    fn record_u64(&mut self, field: &tracing_core::Field, value: u64) {
+        match field.name() {
+            LOCATION_LINE => self.line = Some(value as u32),
+            LOCATION_COLUMN => self.column = Some(value as u32),
             _ => {}
         }
     }
@@ -153,6 +207,63 @@ impl FieldVisitor {
     }
     pub(crate) fn result(self) -> Vec<proto::Field> {
         self.fields
+    }
+}
+
+impl TaskVisitor {
+    pub(crate) fn new(meta_id: proto::MetaId) -> Self {
+        TaskVisitor {
+            field_visitor: FieldVisitor::new(meta_id),
+            line: None,
+            file: None,
+            column: None,
+        }
+    }
+
+    pub(crate) fn result(self) -> (Vec<proto::Field>, Option<proto::Location>) {
+        let fields = self.field_visitor.result();
+        let location = if self.file.is_some() && self.line.is_some() && self.column.is_some() {
+            Some(proto::Location {
+                file: self.file,
+                line: self.line,
+                column: self.column,
+                ..Default::default()
+            })
+        } else {
+            None
+        };
+
+        (fields, location)
+    }
+}
+
+impl Visit for TaskVisitor {
+    fn record_debug(&mut self, field: &field::Field, value: &dyn std::fmt::Debug) {
+        self.field_visitor.record_debug(field, value);
+    }
+
+    fn record_i64(&mut self, field: &tracing_core::Field, value: i64) {
+        self.field_visitor.record_i64(field, value);
+    }
+
+    fn record_u64(&mut self, field: &tracing_core::Field, value: u64) {
+        match field.name() {
+            LOCATION_LINE => self.line = Some(value as u32),
+            LOCATION_COLUMN => self.column = Some(value as u32),
+            _ => self.field_visitor.record_u64(field, value),
+        }
+    }
+
+    fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
+        self.field_visitor.record_bool(field, value);
+    }
+
+    fn record_str(&mut self, field: &tracing_core::Field, value: &str) {
+        if field.name() == LOCATION_FILE {
+            self.file = Some(value.to_string());
+        } else {
+            self.field_visitor.record_str(field, value);
+        }
     }
 }
 

--- a/console-subscriber/src/visitors.rs
+++ b/console-subscriber/src/visitors.rs
@@ -53,7 +53,7 @@ pub(crate) struct FieldVisitor {
 ///     "runtime.spawn",
 ///     kind = "local",
 ///     task.name = "some_name",
-///     loc.file = "some_file.rs"
+///     loc.file = "some_file.rs",
 ///     loc.line = 555,
 ///     loc.col = 5,
 /// );


### PR DESCRIPTION
This pr modifies the proto schema and the subscriber crate to
allow us to capture the spawn location of a task and the instantiation
location of a resource into a `Location` proto message rather than
a field. Note that the special treatment given to the `spawn.location`
filed, found on tasks has not been touched in order not to break 
apps that use tokio versions, not emitting this data as structured
fields.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>