### PR TITLE
perf(console): quick and dirty string interning

### DIFF
--- a/console/src/intern.rs
+++ b/console/src/intern.rs
@@ -1,0 +1,106 @@
+use std::{
+    borrow::{Borrow, Cow},
+    collections::HashSet,
+    fmt,
+    hash::Hash,
+    ops::Deref,
+    rc::Rc,
+};
+
+/// A (painfully simple) string interner.
+///
+/// A nicer implementation is almost certainly possible. However, this one is
+/// simple and doesn't involve any unsafe code. We could almost certainly
+/// replace it with something faster if it becomes a bottleneck.
+#[derive(Debug, Default)]
+pub(crate) struct Strings {
+    strings: HashSet<InternedStr>,
+}
+
+#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct InternedStr(Rc<String>);
+
+impl Strings {
+    // NOTE(elzia): currently, we never need to use this, but we can always
+    // uncomment it if we do...
+
+    // pub(crate) fn string_ref<Q>(&mut self, string: &Q) -> InternedStr
+    // where
+    //     InternedStr: Borrow<Q>,
+    //     Q: Hash + Eq + ToOwned<Owned = String>,
+    // {
+    //     if let Some(s) = self.strings.get(string) {
+    //         return s.clone();
+    //     }
+
+    //     self.insert(string.to_owned())
+    // }
+
+    pub(crate) fn string(&mut self, string: String) -> InternedStr {
+        if let Some(s) = self.strings.get(&string) {
+            return s.clone();
+        }
+
+        self.insert(string)
+    }
+
+    fn insert(&mut self, string: String) -> InternedStr {
+        let string = InternedStr(Rc::new(string));
+        self.strings.insert(string.clone());
+        string
+    }
+}
+
+// === impl InternedStr ===
+
+impl Deref for InternedStr {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl AsRef<str> for InternedStr {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl fmt::Display for InternedStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.0.deref(), f)
+    }
+}
+
+impl Borrow<str> for InternedStr {
+    fn borrow(&self) -> &str {
+        self.0.deref()
+    }
+}
+
+impl Borrow<String> for InternedStr {
+    fn borrow(&self) -> &String {
+        self.0.deref()
+    }
+}
+
+impl<'a> From<&'a InternedStr> for Cow<'a, str> {
+    fn from(istr: &'a InternedStr) -> Self {
+        Cow::Borrowed(istr)
+    }
+}
+
+impl fmt::Debug for InternedStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let include_refs = f.alternate();
+        let mut tuple = f.debug_tuple("InternedStr");
+        tuple.field(&self.0);
+        if include_refs {
+            tuple.field(&Rc::strong_count(&self.0));
+        }
+        tuple.finish()
+    }
+}

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -17,6 +17,7 @@ use crate::view::UpdateKind;
 mod config;
 mod conn;
 mod input;
+mod intern;
 mod state;
 mod term;
 mod util;

--- a/console/src/state/mod.rs
+++ b/console/src/state/mod.rs
@@ -129,8 +129,13 @@ impl State {
             } else {
                 Visibility::Hide
             };
-            self.resources_state
-                .update_resources(styles, resources_update, &self.metas, visibility)
+            self.resources_state.update_resources(
+                styles,
+                &mut self.strings,
+                &self.metas,
+                resources_update,
+                visibility,
+            )
         }
     }
 

--- a/console/src/state/resources.rs
+++ b/console/src/state/resources.rs
@@ -7,7 +7,6 @@ use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
     rc::{Rc, Weak},
-    sync::Arc,
     time::{Duration, SystemTime},
 };
 use tui::{


### PR DESCRIPTION
While reviewing PR #145, I [noticed] that when we sort the task and
resource lists by the `name` field, we clone the actual strings for each
task/resource's name while sorting. This seems...sad, but it's
unfortunately necessary because the task/resource data is behind a
`RefCell`, and the refcell guard can't return a borrowed string that
outlives it. We should make these cheap to clone, such as by `Arc`ing
them.

The other thing I noticed was that there are likely to be a large number
of repeated strings that are recieved in data from the application, such
as targets and field names. Since these string values are coming from
the app rather than defined in the console, we can't easily replace them
with string _constants_...but we can intern them, so that we don't have
to store a ton of copies of the string "tokio::task" (for example), or a
given task name that's spawned a bunch of times. This branch adds a
_very_ simplistic string interning system based on a `HashSet` of `Rc`s,
which should reduce the console's memory footprint a bit (and possibly
make things like sorting and rendering the UI a bit faster?).

This is, of course, not the most optimal string interner implementation,
but we can always replace it with [something faster][1] later --- this
seemed good for now, since it's simple, easy to understand, and 100%
safe.

Running the console with the demo app for about ten seconds results in
us interning the following strings (note the counts, which show how many
times that string would have been duplicated):

<details>

<summary>Debug output</summary>

```rust
Strings {
    strings: {
        InternedStr(
            "duration.op",
            3,
        ),
        InternedStr(
            "tokio::time::driver::sleep",
            4,
        ),
        InternedStr(
            "runtime::resource::state_update",
            3,
        ),
        InternedStr(
            "spawn.location",
            13,
        ),
        InternedStr(
            "task1",
            2,
        ),
        InternedStr(
            "concrete_type",
            2,
        ),
        InternedStr(
            "task2",
            2,
        ),
        InternedStr(
            "op_name",
            4,
        ),
        InternedStr(
            "loc.line",
            2,
        ),
        InternedStr(
            "runtime::resource::poll_op",
            4,
        ),
        InternedStr(
            "is_ready",
            4,
        ),
        InternedStr(
            "wait",
            6,
        ),
        InternedStr(
            "console::serve",
            2,
        ),
        InternedStr(
            "source",
            3,
        ),
        InternedStr(
            "kind",
            14,
        ),
        InternedStr(
            "tokio::task",
            13,
        ),
        InternedStr(
            "loc.file",
            2,
        ),
        InternedStr(
            "duration.unit",
            3,
        ),
        InternedStr(
            "console::aggregate",
            2,
        ),
        InternedStr(
            "task.name",
            2,
        ),
        InternedStr(
            "loc.col",
            2,
        ),
        InternedStr(
            "duration",
            3,
        ),
    },
}
```

</details>

I imagine in a real program, there would be significantly more duplicate
strings eliminated, especially if we run the console for longer than 10
seconds. :)

[noticed]: https://github.com/tokio-rs/console/pull/145/files#r713207224
[1]: https://matklad.github.io/2020/03/22/fast-simple-rust-interner.html