### PR TITLE
pref(console): drop un-referenced interned strings

### DIFF
--- a/console/src/state/mod.rs
+++ b/console/src/state/mod.rs
@@ -148,6 +148,10 @@ impl State {
             self.tasks_state.retain_active(now, retain_for);
             self.resources_state.retain_active(now, retain_for);
         }
+
+        // After dropping idle tasks & resources, prune any interned strings
+        // that are no longer referenced.
+        self.strings.retain_referenced();
     }
 
     pub(crate) fn task_details_ref(&self) -> DetailsRef {


### PR DESCRIPTION
Follow-up from #158.

This should keep us from gradually using more and more memory if we
intern a bunch of strings that are only used by one or two tasks.

It will also periodically shrink the hashmap itself, so that we don't
allocate a bunch of hashmap capacity we never use again.

My initial thought was that we would do this using `Weak` references,
but it turns out it's actually much simpler if we just `retain` only
the `Rc`s with `strong_count` > 1.

We will only try to drop strings if we dropped any task or resource
data, to avoid iterating over the hash map in `retain` when we know
that no ref counts will have changed. This required changing the
`retain_active` methods for tasks and resources to return `bool`s
indicating whether anything was dropped.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>