### PR TITLE
fix(console): fix mangled help text for `--retain-for`

### DIFF
--- a/console/src/config.rs
+++ b/console/src/config.rs
@@ -32,23 +32,33 @@ pub struct Config {
     pub(crate) view_options: ViewOptions,
 
     /// How long to continue displaying completed tasks and dropped resources
-    /// after they have been closed. Accepted values are:
+    /// after they have been closed.
     ///
-    /// - Durations, parsed as a combination of time spans (such as `5days 2min 2s`).
+    /// This accepts either a duration, parsed as a combination of time spans
+    /// (such as `5days 2min 2s`), or `none` to disable removing completed tasks
+    /// and dropped resources.
     ///
-    ///   Each time span is an integer number followed by a suffix. Supported suffixes are:
+    /// Each time span is an integer number followed by a suffix. Supported suffixes are:
     ///
-    ///   * `nsec`, `ns` -- nanoseconds
-    ///   * `usec`, `us` -- microseconds
-    ///   * `msec`, `ms` -- milliseconds
-    ///   * `seconds`, `second`, `sec`, `s`
-    ///   * `minutes`, `minute`, `min`, `m`
-    ///   * `hours`, `hour`, `hr`, `h`
-    ///   * `days`, `day`, `d`
-    ///   * `weeks`, `week`, `w`
-    ///   * `months`, `month`, `M` -- defined as 30.44 days
-    ///   * `years`, `year`, `y` -- defined as 365.25 days
-    /// - `none` to disable removing completed task spans
+    /// * `nsec`, `ns` -- nanoseconds
+    ///
+    /// * `usec`, `us` -- microseconds
+    ///
+    /// * `msec`, `ms` -- milliseconds
+    ///
+    /// * `seconds`, `second`, `sec`, `s`
+    ///
+    /// * `minutes`, `minute`, `min`, `m`
+    ///
+    /// * `hours`, `hour`, `hr`, `h`
+    ///
+    /// * `days`, `day`, `d`
+    ///
+    /// * `weeks`, `week`, `w`
+    ///
+    /// * `months`, `month`, `M` -- defined as 30.44 days
+    ///
+    /// * `years`, `year`, `y` -- defined as 365.25 days
     #[clap(long = "retain-for", default_value = "6s")]
     retain_for: RetainFor,
 }


### PR DESCRIPTION
Currently, the RustDoc comment for the `--retain-for` command-line
argument contains a bulleted list. This is valid Markdown and is
accepted by RustDoc. However, when `clap`'s derive macro uses the doc
comment to generate help text for the argument, it doesn't handle the
bulleted list nicely. Currently, the help text looks like this, which
is...extremely not great:

```
--retain-for <RETAIN_FOR>
    How long to continue displaying completed tasks and dropped resources after they have
    been closed.

    This accepts either a duration, parsed as a combination of time spans (such as `5days
    2min 2s`), or `none` to disable removing completed tasks and dropped resources.

    Each time span is an integer number followed by a suffix. Supported suffixes are:

    * `nsec`, `ns` -- nanoseconds * `usec`, `us` -- microseconds * `msec`, `ms` --
    milliseconds * `seconds`, `second`, `sec`, `s` * `minutes`, `minute`, `min`, `m` *
    `hours`, `hour`, `hr`, `h` * `days`, `day`, `d` * `weeks`, `week`, `w` * `months`,
    `month`, `M` -- defined as 30.44 days * `years`, `year`, `y` -- defined as 365.25 days
    [default: 6s]
```

This branch changes the doc comment a bit so that the help text formats
a bit better in the terminal. Now, it looks like this:

```
--retain-for <RETAIN_FOR>
    How long to continue displaying completed tasks and dropped resources after they have
    been closed.

    This accepts either a duration, parsed as a combination of time spans (such as `5days
    2min 2s`), or `none` to disable removing completed tasks and dropped resources.

    Each time span is an integer number followed by a suffix. Supported suffixes are:

    * `nsec`, `ns` -- nanoseconds

    * `usec`, `us` -- microseconds

    * `msec`, `ms` -- milliseconds

    * `seconds`, `second`, `sec`, `s`

    * `minutes`, `minute`, `min`, `m`

    * `hours`, `hour`, `hr`, `h`

    * `days`, `day`, `d`

    * `weeks`, `week`, `w`

    * `months`, `month`, `M` -- defined as 30.44 days

    * `years`, `year`, `y` -- defined as 365.25 days [default: 6s]
```

Adding extra whitespace between each bullet point is necessary to stop
clap from screwing up the list