### PR TITLE
Remove `authors` fields from `Cargo.toml`s

### DIFF
--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "console-api"
 version = "0.1.0"
-authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 [features]
 # Generate code that is compatible with Tonic's `transport` module.

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "console-subscriber"
 version = "0.1.0"
-authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tokio-console"
 version = "0.1.0"
-authors = ["Eliza Weisman <eliza@buoyant.io>", "David Barsky <me@davidbarsky.com>"]
 edition = "2018"
 repository = "https://github.com/tokio-rs/console"
 


### PR DESCRIPTION
The `authors` field has been [effectively soft-deprecated](https://github.com/rust-lang/rust/issues/83227), as it is no longer required, shown on crates.io or docs.rs, and crates created with `cargo new` no longer automatically create the `authors` field. Keeping or removing the field is of course a matter of taste, but I thought that, since it doesn’t have any effect anymore, it might be easier to just remove it instead of updating it over time as contributors come and go.