### PR TITLE
fix(subscriber): fix potential spurious flush notifications

### DIFF
--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -222,7 +222,7 @@ impl TasksLayer {
 
         // Conservatively, start to trigger a flush when half the channel is full.
         // This tries to reduce the chance of losing events to a full channel.
-        let flush_under_capacity = config.event_buffer_capacity / 4;
+        let flush_under_capacity = config.event_buffer_capacity / 2;
 
         let server = Server {
             aggregator: Some(aggregator),
@@ -248,7 +248,7 @@ impl TasksLayer {
 }
 
 impl TasksLayer {
-    pub const DEFAULT_EVENT_BUFFER_CAPACITY: usize = 1024 * 100;
+    pub const DEFAULT_EVENT_BUFFER_CAPACITY: usize = 1024 * 10;
     pub const DEFAULT_CLIENT_BUFFER_CAPACITY: usize = 1024 * 4;
     pub const DEFAULT_PUBLISH_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -406,7 +406,6 @@ where
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
         let metadata = event.metadata();
         if self.waker_callsites.contains(event.metadata()) {
-            tracing::debug!(?event, "waker op event");
             let at = SystemTime::now();
             let mut visitor = WakerVisitor::default();
             event.record(&mut visitor);
@@ -425,7 +424,6 @@ where
             }
             // else unknown waker event... what to do? can't trace it from here...
         } else if self.poll_op_callsites.contains(event.metadata()) {
-            tracing::debug!(?event, "poll op event");
             match ctx.event_span(event) {
                 Some(resource_span) if self.is_resource(resource_span.metadata()) => {
                     let mut poll_op_visitor = PollOpVisitor::default();
@@ -465,7 +463,6 @@ where
                 ),
             }
         } else if self.state_update_callsites.contains(event.metadata()) {
-            tracing::debug!(?event, "state update");
             match ctx.event_span(event) {
                 Some(resource_span) if self.is_resource(resource_span.metadata()) => {
                     let meta_id = event.metadata().into();


### PR DESCRIPTION
Currently, there is a potential issue with the flush notification
channel. An `AtomicBool` is used to determine whether a flush
notification should be sent, so that only one thread will trigger a
flush when approaching the flush capacity. However, the `AtomicBool` is
cleared by the aggregator task _as soon as_ it's woken by the flush
notification. This seems to potentially cause a situation where several
notifications are sent while the channel capacity is below the flush
limit, because the flag is cleared as soon as the aggregator task is
_woken_, and before it has the time to actually drain the channel. This
seems to result in many notifications being queued, causing the
aggregator task to loop a bunch of times.

This branch fixes this by changing the aggregator task to only clear the
flag when it has drained all queued events, hopefully reducing needless
notifications. This appears to partially resolve #177, although there
appears to also be an issue where console *updates* seem to become
increasingly delayed over time.