### PR TITLE
Add license to Cargo.toml

### DIFF
--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -2,6 +2,8 @@
 name = "console-api"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+
 [features]
 # Generate code that is compatible with Tonic's `transport` module.
 transport = ["tonic-build/transport", "tonic/transport"]

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -2,6 +2,7 @@
 name = "console-subscriber"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tokio-console"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
 repository = "https://github.com/tokio-rs/console"
 
 [dependencies]


### PR DESCRIPTION
Thanks for these awesome crates!

Reading at your main LICENSE file, it looks you're using the MIT license, so I'm including them in your Cargo.toml files (using your crates would otherwise break the scanning of licenses that I'm using in my CI pipelines at home :D )