### PR TITLE
Update console for clap 3.0.0-rc.4.

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/tokio-rs/console"
 [dependencies]
 atty = "0.2"
 console-api = { path = "../console-api", features = ["transport"] }
-clap = "3.0.0-beta.5"
+clap = { version = "3.0.0-beta.5", features = ["cargo", "derive", "env"] }
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.6", features = ["transport"] }
 futures = "0.3"


### PR DESCRIPTION
This enables the `clap` features that will be necessary for one to use clap 3 release candidate 4.

~~Since these features were not part of the earlier beta releases, it also *does* the upgrade to `clap` release candidate 4.~~
 * Update: wait, I think they were there. Let me try decoupling that change.
 * Update 2: Done.

Now one *should* be able to painlessly upgrade to clap 3.0.0-rc.4, but I have not wed us to that change here. This way, any changes injected by this PR should be solely due to the change to the `features` setting, and not extraneous differences between beta.5 and rc.4.

Fix #191 