### PR TITLE
chore: make Rust 1.56.0 the console's msrv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ env:
   #
   # Some of our dependencies require `edition = "2021"` which is only supported
   # on 1.56.0+.
-  MIN_RUST: 1.56.0
+  minrust: 1.56.0
 
 jobs:
   check:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,11 @@ env:
   RUSTUP_MAX_RETRIES: 10
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
+  # Make Rust 1.56.0 the minimum supported Rust version.
+  #
+  # Some of our dependencies require `edition = "2021"` which is only supported
+  # on 1.56.0+.
+  MIN_RUST: 1.56.0
 
 jobs:
   check:
@@ -44,7 +49,7 @@ jobs:
         with:
           command: check
 
-  test:
+  test_os:
     name: Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -60,6 +65,32 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  test_versions:
+    name: Tests on ${{ matrix.rust }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - nightly
+          - ${{ env.minrust }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
           override: true
       - uses: Swatinem/rust-cache@v1
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,24 +73,18 @@ jobs:
         with:
           command: test
 
-  test_versions:
-    name: Tests on ${{ matrix.rust }}
+  test_msrv:
+    name: Tests on MSRV
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          - nightly
-          - ${{ env.minrust }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install MSRV toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ env.minrust }}
           override: true
       - uses: Swatinem/rust-cache@v1
 

--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "console-api"
 version = "0.1.0"
 edition = "2018"
 license = "MIT"
+rust-version = "1.56.0"
 
 [features]
 # Generate code that is compatible with Tonic's `transport` module.

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -3,6 +3,7 @@ name = "console-subscriber"
 version = "0.1.0"
 edition = "2018"
 license = "MIT"
+rust-version = "1.56.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/tokio-rs/console"
+rust-version = "1.56.0"
 
 [dependencies]
 atty = "0.2"


### PR DESCRIPTION
Some of our dependencies (e.g. `tonic`) require 1.56.0 for
`edition = "2021"`, so it's the minimum Rust version we can currently
support.

This branch adds a MSRV test job on CI. In addition, it adds
`rust-version = "1.56.0"` metadata to Cargo.toml files.