### PR TITLE
chore: update to Rust 2021

### DIFF
--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "console-api"
 version = "0.1.0"
-edition = "2018"
 license = "MIT"
+edition = "2021"
+rust-version = "1.56.0"
 
 [features]
 # Generate code that is compatible with Tonic's `transport` module.

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "console-subscriber"
 version = "0.1.0"
-edition = "2018"
 license = "MIT"
+edition = "2021"
+rust-version = "1.56.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "tokio-console"
 version = "0.1.0"
-edition = "2018"
 license = "MIT"
 repository = "https://github.com/tokio-rs/console"
+edition = "2021"
+rust-version = "1.56.0"
 
 [dependencies]
 atty = "0.2"


### PR DESCRIPTION
Depends on #199

This branch updates everything to the 2021 edition. There's nothing we
*need* from the latest edition, and none of the current code is invalid
in Rust 2021...but we may as well stay on top of it!