### PR TITLE
feat(subscriber): count dropped events due to buffer cap

### DIFF
--- a/console-api/proto/async_ops.proto
+++ b/console-api/proto/async_ops.proto
@@ -19,6 +19,17 @@ message AsyncOpUpdate {
     repeated AsyncOp new_async_ops = 1;
     // Any async op stats that have changed since the last update.
     map<uint64, Stats> stats_update = 2;
+    // A count of how many async op events (e.g. polls, creation, etc) were not
+    // recorded because the application's event buffer was at capacity.
+    //
+    // If everything is working normally, this should be 0. If it is greater
+    // than 0, that may indicate that some data is missing from this update, and
+    // it may be necessary to increase the number of events buffered by the
+    // application to ensure that data loss is avoided.
+    //
+    // If the application's instrumentation ensures reliable delivery of events,
+    // this will always be 0.
+    uint64 dropped_events = 3;
 }
 
 // An async operation.

--- a/console-api/proto/resources.proto
+++ b/console-api/proto/resources.proto
@@ -23,6 +23,18 @@ message ResourceUpdate {
 
     // A list of all new poll ops that have been invoked on resources since the last update.
     repeated PollOp new_poll_ops = 3;
+
+    // A count of how many resource events (e.g. polls, creation, etc) were not
+    // recorded because the application's event buffer was at capacity.
+    //
+    // If everything is working normally, this should be 0. If it is greater
+    // than 0, that may indicate that some data is missing from this update, and
+    // it may be necessary to increase the number of events buffered by the
+    // application to ensure that data loss is avoided.
+    //
+    // If the application's instrumentation ensures reliable delivery of events,
+    // this will always be 0.
+    uint64 dropped_events = 4;
 }
 
 // Static data recorded when a new resource is created.

--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -26,6 +26,17 @@ message TaskUpdate {
     // *is* included in this map, the corresponding value represents a complete
     // snapshot of that task's stats at in the current time window.
     map<uint64, Stats> stats_update = 3;
+    // A count of how many task events (e.g. polls, spawns, etc) were not
+    // recorded because the application's event buffer was at capacity.
+    //
+    // If everything is working normally, this should be 0. If it is greater
+    // than 0, that may indicate that some data is missing from this update, and
+    // it may be necessary to increase the number of events buffered by the
+    // application to ensure that data loss is avoided.
+    //
+    // If the application's instrumentation ensures reliable delivery of events,
+    // this will always be 0.
+    uint64 dropped_events = 4;
 }
 
 // A task details update


### PR DESCRIPTION
See also #209

Currently, we don't really have any way of surfacing potential data loss
due to the event buffer capacity limit --- so, if events are dropped,
the user may not be *aware* that they're seeing an incomplete picture of
their application. It would be better if we had a way to surface this in
the UI.

This branch adds support for counting the number of dropped events in
the `ConsoleLayer`. This data is now included in the `ResourceUpdate`,
`TaskUpdate`, and `AsyncOpUpdate` messages, respectively. We track a
separate counter for dropped events of each type, to make it easier to
determine what data may be missing.

The console UI doesn't currently *display* these counts; that can be
added in a separate PR. We may want to use the warnings interface for
displaying this information?