### PR TITLE
chore: add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,10 @@
+# These are supported funding model platforms
+
+github:
+  # To support development of the console and other Tokio projects,
+  # you can donate to the Tokio organization!
+  - tokio-rs
+  # Eliza is willing to offer hands-on support --- including help
+  # with issues involving proprietary software --- in her free time,
+  # in exchange for a donation.
+  - hawkw


### PR DESCRIPTION
This commit adds a FUNDING.yml so that people who want to support
console development can sponsor the Tokio GitHub org. In addition, I
also added my own GitHub Sponsors account, as I'm willing to perform
certain services (such as help debugging issues with proprietary code)
in exchange for sponsorship. I hope it wasn't presumptuous to add my
personal account to the sponsorship settings for a Tokio project, let me
know if that's not okay! :)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>