### PR TITLE
docs: post-release readme fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@
 [![Build Status][actions-badge]][actions-url]
 [![Discord chat][discord-badge]][discord-url]
 
-⚠️ **extremely serious warning:** this is _pre-alpha_ software undergoing active
-development! currently, the wire format has _no stability guarantees_ &mdash;
-the crates in this repository are not guaranteed to be interoperable except
-within the same Git revision. when these crates are published to crates.io, the
-wire format will follow semver, but currently, anything could happen!
-
 [Chat][discord-url] | [API Documentation (`main` branch)][main-docs]
 
 [main-docs]: https://tokio-console.netlify.app

--- a/console-api/README.md
+++ b/console-api/README.md
@@ -56,6 +56,14 @@ may be useful for anyone implementing other software that also consumes the
 [`console-subscriber`]: https://crates.io/crates/console-subscriber
 [protobuf]: https://developers.google.com/protocol-buffers
 
+### Stability
+
+&#x26A0;&#xfe0f; The protobuf wire format is not currently considered totally
+stable. While we will try to avoid unnecessary protobuf-incompatible changes,
+protobuf compatibility is only guaranteed within SemVer-compatible releases of
+this crate. For example, the protobuf as of `console-api` v0.2.5 may not be
+backwards-compatible with `console-api` v0.1.12.
+
 ### Crate Feature Flags
 
 This crate provides the following feature flags:
@@ -64,7 +72,7 @@ This crate provides the following feature flags:
   module] (disabled by default)
 
 [Tonic]: https://crates.io/crates/tonic
-[`transport`]: https://docs.rs/tonic/latest/tonic/transport/index.html
+[`transport` module]: https://docs.rs/tonic/latest/tonic/transport/index.html
 
 ## Getting Help
 

--- a/console/README.md
+++ b/console/README.md
@@ -31,10 +31,11 @@ applications, which collects and displays in-depth diagnostic data on the
 asynchronous tasks, resources, and operations in an application. The console
 system consists of two primary components:
 
-* _instrumentation_, embedded in the application, which collects data from the
-  async runtime and exposes it over the console's [wire format]
-* _consumers_, which connect to the instrumented application, recieve telemetry
-  data, and display it to the user
+* &#x1f4e1;&#xfe0f; _instrumentation_, embedded in the application, which
+  collects data from the async runtime and exposes it over the console's wire
+  format
+* &#x1f6f0;&#xfe0f; _consumers_, which connect to the instrumented application,
+  recieve telemetry data, and display it to the user
 
 This crate is the primary consumer of `tokio-console` telemetry, a command-line
 application that provides an interactive debugging interface.


### PR DESCRIPTION
I removed the big, scary "this is pre-alpha software" warning from the
main GitHub readme, and I've added a new, less scary stability note
specifically about protobuf stability in the `console-api` README.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>