### PR TITLE
fix(console): increase default event buffer capacity a bit

### DIFF
--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -336,7 +336,7 @@ impl ConsoleLayer {
     /// events being dropped more frequently.
     ///
     /// See also [`Builder::event_buffer_capacity`].
-    pub const DEFAULT_EVENT_BUFFER_CAPACITY: usize = 1024 * 10;
+    pub const DEFAULT_EVENT_BUFFER_CAPACITY: usize = 1024 * 100;
     /// Default maximum capacity for th echannel of events sent from a
     /// [`Server`] to each subscribed client.
     ///


### PR DESCRIPTION
It seems like a number of people using the console with real life
applications are running into issues related to the console's event
buffer being at capacity (e.g. #230, #234, etc). This commit bumps up
the default capacity a bit as a quick fix.

In the future, I think we should probably do things to avoid reaching
the event buffer capacity as often --- I think we can change the
aggregator/layer design a bit to avoid creating as many events. But, for
now, this should hopefully give people a better default configuration.