### PR TITLE
fix(subscriber): only send *new* tasks/resources/etc over the event channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ name = "console-subscriber"
 version = "0.1.0"
 dependencies = [
  "console-api",
+ "crossbeam-channel",
  "futures",
  "hdrhistogram",
  "humantime",
@@ -243,6 +244,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
 ]
 
 [[package]]

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -40,12 +40,15 @@ tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["fmt", "registry"] }
 futures = { version = "0.3", default-features = false }
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 # The parking_lot dependency is renamed, because we want our `parking_lot`
 # feature to also enable `tracing-subscriber`'s parking_lot feature flag.
 parking_lot_crate = { package = "parking_lot", version = "0.11", optional = true }
 humantime = "2.1.0"
+
+# Required for recording:
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+crossbeam-channel = "0.5"
 
 [dev-dependencies]
 tokio = { version = "^1.7", features = ["full", "rt-multi-thread"] }

--- a/console-subscriber/src/aggregator/id_data.rs
+++ b/console-subscriber/src/aggregator/id_data.rs
@@ -1,13 +1,11 @@
-use super::{shrink::ShrinkMap, DroppedAt, Id, ToProto};
+use super::{shrink::ShrinkMap, Id, ToProto};
+use crate::stats::{DroppedAt, Unsent};
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 use std::time::{Duration, SystemTime};
 
 pub(crate) struct IdData<T> {
-    data: ShrinkMap<Id, (T, bool)>,
+    data: ShrinkMap<Id, T>,
 }
-
-pub(crate) struct Updating<'a, T>(&'a mut (T, bool));
 
 pub(crate) enum Include {
     All,
@@ -19,31 +17,19 @@ pub(crate) enum Include {
 impl<T> Default for IdData<T> {
     fn default() -> Self {
         IdData {
-            data: ShrinkMap::<Id, (T, bool)>::new(),
+            data: ShrinkMap::<Id, T>::new(),
         }
     }
 }
 
-impl<T> IdData<T> {
-    pub(crate) fn update_or_default(&mut self, id: Id) -> Updating<'_, T>
-    where
-        T: Default,
-    {
-        Updating(self.data.entry(id).or_default())
-    }
-
-    pub(crate) fn update(&mut self, id: &Id) -> Option<Updating<'_, T>> {
-        self.data.get_mut(id).map(Updating)
-    }
-
+impl<T: Unsent> IdData<T> {
     pub(crate) fn insert(&mut self, id: Id, data: T) {
-        self.data.insert(id, (data, true));
+        self.data.insert(id, data);
     }
 
     pub(crate) fn since_last_update(&mut self) -> impl Iterator<Item = (&Id, &mut T)> {
-        self.data.iter_mut().filter_map(|(id, (data, dirty))| {
-            if *dirty {
-                *dirty = false;
+        self.data.iter_mut().filter_map(|(id, data)| {
+            if data.take_unsent() {
                 Some((id, data))
             } else {
                 None
@@ -52,11 +38,11 @@ impl<T> IdData<T> {
     }
 
     pub(crate) fn all(&self) -> impl Iterator<Item = (&Id, &T)> {
-        self.data.iter().map(|(id, (data, _))| (id, data))
+        self.data.iter()
     }
 
     pub(crate) fn get(&self, id: &Id) -> Option<&T> {
-        self.data.get(id).map(|(data, _)| data)
+        self.data.get(id)
     }
 
     pub(crate) fn as_proto(&mut self, include: Include) -> HashMap<u64, T::Output>
@@ -75,7 +61,7 @@ impl<T> IdData<T> {
         }
     }
 
-    pub(crate) fn drop_closed<R: DroppedAt>(
+    pub(crate) fn drop_closed<R: DroppedAt + Unsent>(
         &mut self,
         stats: &mut IdData<R>,
         now: SystemTime,
@@ -92,18 +78,19 @@ impl<T> IdData<T> {
         // drop closed entities
         tracing::trace!(?retention, has_watchers, "dropping closed");
 
-        stats.data.retain_and_shrink(|id, (stats, dirty)| {
+        stats.data.retain_and_shrink(|id, stats| {
             if let Some(dropped_at) = stats.dropped_at() {
                 let dropped_for = now.duration_since(dropped_at).unwrap_or_default();
+                let dirty = stats.is_unsent();
                 let should_drop =
                         // if there are any clients watching, retain all dirty tasks regardless of age
-                        (*dirty && has_watchers)
+                        (dirty && has_watchers)
                         || dropped_for > retention;
                 tracing::trace!(
                     stats.id = ?id,
                     stats.dropped_at = ?dropped_at,
                     stats.dropped_for = ?dropped_for,
-                    stats.dirty = *dirty,
+                    stats.dirty = dirty,
                     should_drop,
                 );
                 return !should_drop;
@@ -114,27 +101,6 @@ impl<T> IdData<T> {
 
         // drop closed entities which no longer have stats.
         self.data
-            .retain_and_shrink(|id, (_, _)| stats.data.contains_key(id));
-    }
-}
-
-// === impl Updating ===
-
-impl<'a, T> Deref for Updating<'a, T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0 .0
-    }
-}
-
-impl<'a, T> DerefMut for Updating<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0 .0
-    }
-}
-
-impl<'a, T> Drop for Updating<'a, T> {
-    fn drop(&mut self) {
-        self.0 .1 = true;
+            .retain_and_shrink(|id, _| stats.data.contains_key(id));
     }
 }

--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -469,22 +469,17 @@ impl Aggregator {
                 task_id,
                 is_ready,
             } => {
-                // TODO(eliza): put back
+                let poll_op = proto::resources::PollOp {
+                    metadata: Some(metadata.into()),
+                    resource_id: Some(resource_id.into()),
+                    name: op_name,
+                    task_id: Some(task_id.into()),
+                    async_op_id: Some(async_op_id.into()),
+                    is_ready,
+                };
 
-                // let mut async_op_stats = self.async_op_stats.update_or_default(async_op_id.clone());
-                // async_op_stats.task_id.get_or_insert(task_id.clone());
-
-                // let poll_op = proto::resources::PollOp {
-                //     metadata: Some(metadata.into()),
-                //     resource_id: Some(resource_id.into()),
-                //     name: op_name,
-                //     task_id: Some(task_id.into()),
-                //     async_op_id: Some(async_op_id.into()),
-                //     is_ready,
-                // };
-
-                // self.all_poll_ops.push(poll_op.clone());
-                // self.new_poll_ops.push(poll_op);
+                self.all_poll_ops.push(poll_op.clone());
+                self.new_poll_ops.push(poll_op);
             }
 
             Event::AsyncResourceOp {

--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -423,7 +423,7 @@ impl Aggregator {
                     id.clone(),
                     Task {
                         id: id.clone(),
-                        is_dirty: AtomicBool::new(false),
+                        is_dirty: AtomicBool::new(true),
                         metadata,
                         fields,
                         location,
@@ -448,7 +448,7 @@ impl Aggregator {
                     id.clone(),
                     Resource {
                         id: id.clone(),
-                        is_dirty: AtomicBool::new(false),
+                        is_dirty: AtomicBool::new(true),
                         parent_id,
                         kind,
                         metadata,
@@ -494,7 +494,7 @@ impl Aggregator {
                     id.clone(),
                     AsyncOp {
                         id: id.clone(),
-                        is_dirty: AtomicBool::new(false),
+                        is_dirty: AtomicBool::new(true),
                         resource_id,
                         metadata,
                         source,

--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -21,11 +21,6 @@ use std::{
 };
 use tracing_core::{span::Id, Metadata};
 
-use hdrhistogram::{
-    serialization::{Serializer, V2SerializeError, V2Serializer},
-    Histogram,
-};
-
 mod id_data;
 mod shrink;
 use self::id_data::{IdData, Include};
@@ -329,8 +324,7 @@ impl Aggregator {
                 && subscription.update(&proto::tasks::TaskDetails {
                     task_id: Some(id.clone().into()),
                     now: Some(now.into()),
-                    poll_times_histogram: None, // TODO(eliza): put back
-                                                // poll_times_histogram: serialize_histogram(&stats.poll_times_histogram).ok(),
+                    poll_times_histogram: stats.serialize_histogram(),
                 })
             {
                 self.details_watchers
@@ -718,13 +712,6 @@ impl From<AttributeUpdate> for Attribute {
             unit: upd.unit,
         }
     }
-}
-
-fn serialize_histogram(histogram: &Histogram<u64>) -> Result<Vec<u8>, V2SerializeError> {
-    let mut serializer = V2Serializer::new();
-    let mut buf = Vec::new();
-    serializer.serialize(histogram, &mut buf)?;
-    Ok(buf)
 }
 
 fn update_attribute(attribute: &mut Attribute, update: &AttributeUpdate) {

--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -393,9 +393,7 @@ impl Aggregator {
                 let details = proto::tasks::TaskDetails {
                     task_id: Some(id.clone().into()),
                     now: Some(now.into()),
-                    // poll_times_histogram: serialize_histogram(&task_stats.poll_times_histogram)
-                    //     .ok(),
-                    poll_times_histogram: None, // TODO(eliza): put back
+                    poll_times_histogram: task_stats.serialize_histogram(),
                 };
                 watchers.retain(|watch| watch.update(&details));
                 !watchers.is_empty()

--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -93,9 +93,6 @@ pub(crate) struct Aggregator {
     /// This is emptied on every state update.
     new_poll_ops: Vec<proto::resources::PollOp>,
 
-    /// A sink to record all events to a file.
-    recorder: Option<Recorder>,
-
     /// The time "state" of the aggregator, such as paused or live.
     temporality: Temporality,
 }
@@ -168,10 +165,6 @@ impl Aggregator {
             async_op_stats: IdData::default(),
             all_poll_ops: Default::default(),
             new_poll_ops: Default::default(),
-            recorder: builder
-                .recording_path
-                .as_ref()
-                .map(|path| Recorder::new(path).expect("creating recorder")),
             temporality: Temporality::Live,
         }
     }
@@ -232,10 +225,6 @@ impl Aggregator {
             while let Some(event) = self.events.recv().now_or_never() {
                 match event {
                     Some(event) => {
-                        // always be recording...
-                        if let Some(ref recorder) = self.recorder {
-                            recorder.record(&event);
-                        }
                         self.update_state(event);
                         drained = true;
                     }

--- a/console-subscriber/src/attribute.rs
+++ b/console-subscriber/src/attribute.rs
@@ -1,14 +1,32 @@
 use console_api as proto;
 use std::collections::HashMap;
+use tracing::span::Id;
 
 #[derive(Debug, Default)]
 pub(crate) struct Attributes {
     attributes: HashMap<FieldKey, proto::Attribute>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct Update {
+    pub(crate) field: proto::Field,
+    pub(crate) op: Option<UpdateOp>,
+    pub(crate) unit: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum UpdateOp {
+    Add,
+    Override,
+    Sub,
+}
+
+/// Represents a key for a `proto::field::Name`. Because the
+/// proto::field::Name might not be unique we also include the
+/// resource id in this key
 #[derive(Debug, Hash, PartialEq, Eq)]
-pub(crate) struct FieldKey {
-    update_id: u64,
+struct FieldKey {
+    update_id: Id,
     field_name: proto::field::Name,
 }
 
@@ -17,5 +35,82 @@ pub(crate) struct FieldKey {
 impl Attributes {
     pub(crate) fn values(&self) -> impl Iterator<Item = &proto::Attribute> {
         self.attributes.values()
+    }
+
+    pub(crate) fn update(&mut self, id: &Id, update: &Update) {
+        let field_name = match update.field.name.as_ref() {
+            Some(name) => name.clone(),
+            None => {
+                tracing::warn!(?update.field, "field missing name, skipping...");
+                return;
+            }
+        };
+        let update_id = id.clone();
+        let key = FieldKey {
+            update_id,
+            field_name,
+        };
+
+        self.attributes
+            .entry(key)
+            .and_modify(|attr| update_attribute(attr, &update))
+            .or_insert_with(|| update.clone().into());
+    }
+}
+
+fn update_attribute(attribute: &mut proto::Attribute, update: &Update) {
+    use proto::field::Value::*;
+    let attribute_val = attribute.field.as_mut().and_then(|a| a.value.as_mut());
+    let update_val = update.field.value.clone();
+    let update_name = update.field.name.clone();
+    match (attribute_val, update_val) {
+        (Some(BoolVal(v)), Some(BoolVal(upd))) => *v = upd,
+
+        (Some(StrVal(v)), Some(StrVal(upd))) => *v = upd,
+
+        (Some(DebugVal(v)), Some(DebugVal(upd))) => *v = upd,
+
+        (Some(U64Val(v)), Some(U64Val(upd))) => match update.op {
+            Some(UpdateOp::Add) => *v = v.saturating_add(upd),
+
+            Some(UpdateOp::Sub) => *v = v.saturating_sub(upd),
+
+            Some(UpdateOp::Override) => *v = upd,
+
+            None => tracing::warn!(
+                "numeric attribute update {:?} needs to have an op field",
+                update_name
+            ),
+        },
+
+        (Some(I64Val(v)), Some(I64Val(upd))) => match update.op {
+            Some(UpdateOp::Add) => *v = v.saturating_add(upd),
+
+            Some(UpdateOp::Sub) => *v = v.saturating_sub(upd),
+
+            Some(UpdateOp::Override) => *v = upd,
+
+            None => tracing::warn!(
+                "numeric attribute update {:?} needs to have an op field",
+                update_name
+            ),
+        },
+
+        (val, update) => {
+            tracing::warn!(
+                "attribute {:?} cannot be updated by update {:?}",
+                val,
+                update
+            );
+        }
+    }
+}
+
+impl From<Update> for proto::Attribute {
+    fn from(upd: Update) -> Self {
+        proto::Attribute {
+            field: Some(upd.field),
+            unit: upd.unit,
+        }
     }
 }

--- a/console-subscriber/src/attribute.rs
+++ b/console-subscriber/src/attribute.rs
@@ -53,7 +53,7 @@ impl Attributes {
 
         self.attributes
             .entry(key)
-            .and_modify(|attr| update_attribute(attr, &update))
+            .and_modify(|attr| update_attribute(attr, update))
             .or_insert_with(|| update.clone().into());
     }
 }

--- a/console-subscriber/src/attribute.rs
+++ b/console-subscriber/src/attribute.rs
@@ -1,0 +1,21 @@
+use console_api as proto;
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub(crate) struct Attributes {
+    attributes: HashMap<FieldKey, proto::Attribute>,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+pub(crate) struct FieldKey {
+    update_id: u64,
+    field_name: proto::field::Name,
+}
+
+// === impl Attributes ===
+
+impl Attributes {
+    pub(crate) fn values(&self) -> impl Iterator<Item = &proto::Attribute> {
+        self.attributes.values()
+    }
+}

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -27,6 +27,7 @@ mod builder;
 mod callsites;
 mod record;
 mod stack;
+mod stats;
 pub(crate) mod sync;
 mod visitors;
 

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -20,7 +20,11 @@ use tracing_core::{
     subscriber::{self, NoSubscriber, Subscriber},
     Metadata,
 };
-use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+use tracing_subscriber::{
+    layer::Context,
+    registry::{LookupSpan, SpanRef},
+    Layer,
+};
 
 mod aggregator;
 mod attribute;
@@ -171,35 +175,16 @@ enum Event {
         fields: Vec<proto::Field>,
         location: Option<proto::Location>,
     },
-    Enter {
-        id: span::Id,
-        parent_id: Option<span::Id>,
-        at: SystemTime,
-    },
-    Exit {
-        id: span::Id,
-        parent_id: Option<span::Id>,
-        at: SystemTime,
-    },
-    Close {
-        id: span::Id,
-        at: SystemTime,
-    },
-    Waker {
-        id: span::Id,
-        op: WakeOp,
-        at: SystemTime,
-    },
     Resource {
         id: span::Id,
         parent_id: Option<span::Id>,
         metadata: &'static Metadata<'static>,
-        at: SystemTime,
         concrete_type: String,
         kind: resource::Kind,
         location: Option<proto::Location>,
         is_internal: bool,
         inherit_child_attrs: bool,
+        stats: Arc<stats::ResourceStats>,
     },
     PollOp {
         metadata: &'static Metadata<'static>,
@@ -219,9 +204,10 @@ enum Event {
         parent_id: Option<span::Id>,
         resource_id: span::Id,
         metadata: &'static Metadata<'static>,
-        at: SystemTime,
         source: String,
         inherit_child_attrs: bool,
+
+        stats: Arc<stats::AsyncOpStats>,
     },
 }
 
@@ -431,19 +417,28 @@ impl ConsoleLayer {
             .cloned()
     }
 
-    fn send(&self, dropped: &AtomicUsize, event: Event) -> bool {
+    fn send_metadata(&self, dropped: &AtomicUsize, event: Event) -> bool {
+        self.send_stats(dropped, move || (event, ())).is_some()
+    }
+
+    fn send_stats<S>(
+        &self,
+        dropped: &AtomicUsize,
+        mk_event: impl FnOnce() -> (Event, S),
+    ) -> Option<S> {
         use mpsc::error::TrySendError;
 
         // Return whether or not we actually sent the event.
         let sent = match self.tx.try_reserve() {
             Ok(permit) => {
+                let (event, stats) = mk_event();
                 permit.send(event);
-                true
+                Some(stats)
             }
             Err(TrySendError::Closed(_)) => {
                 // we should warn here eventually, but nop for now because we
                 // can't trigger tracing events...
-                false
+                None
             }
             Err(TrySendError::Full(_)) => {
                 // this shouldn't happen, since we trigger a flush when
@@ -451,7 +446,7 @@ impl ConsoleLayer {
                 // time is very high, maybe the aggregator task hasn't been
                 // polled yet. so... eek?!
                 dropped.fetch_add(1, Ordering::Release);
-                false
+                None
             }
         };
 
@@ -505,28 +500,35 @@ where
             (_, _) => &self.shared.dropped_tasks,
         };
 
-        self.send(dropped, Event::Metadata(meta));
+        self.send_metadata(dropped, Event::Metadata(meta));
         subscriber::Interest::always()
     }
 
     fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
         let metadata = attrs.metadata();
-        let sent = if self.is_spawn(metadata) {
+        if self.is_spawn(metadata) {
             let at = SystemTime::now();
             let mut task_visitor = TaskVisitor::new(metadata.into());
             attrs.record(&mut task_visitor);
             let (fields, location) = task_visitor.result();
-            self.send(
-                &self.shared.dropped_tasks,
-                Event::Spawn {
+            if let Some(stats) = self.send_stats(&self.shared.dropped_tasks, move || {
+                let stats = Arc::new(stats::TaskStats::new(at));
+                let event = Event::Spawn {
                     id: id.clone(),
-                    at,
+                    stats: stats.clone(),
                     metadata,
                     fields,
                     location,
-                },
-            )
-        } else if self.is_resource(metadata) {
+                };
+                (event, stats)
+            }) {
+                ctx.span(id).expect("if `on_new_span` was called, the span must exist; this is a `tracing` bug!").extensions_mut().insert(stats);
+            }
+            return;
+        }
+
+        if self.is_resource(metadata) {
+            let at = SystemTime::now();
             let mut resource_visitor = ResourceVisitor::default();
             attrs.record(&mut resource_visitor);
             if let Some(result) = resource_visitor.result() {
@@ -537,33 +539,35 @@ where
                     is_internal,
                     inherit_child_attrs,
                 } = result;
-                let at = SystemTime::now();
                 let parent_id = self.current_spans.get().and_then(|stack| {
                     self.first_entered(&stack.borrow(), |id| self.is_id_resource(id, &ctx))
                 });
-                self.send(
-                    &self.shared.dropped_resources,
-                    Event::Resource {
+                if let Some(stats) = self.send_stats(&self.shared.dropped_resources, move || {
+                    let stats = Arc::new(stats::ResourceStats::new(at));
+                    let event = Event::Resource {
                         id: id.clone(),
                         parent_id,
                         metadata,
-                        at,
                         concrete_type,
                         kind,
                         location,
                         is_internal,
                         inherit_child_attrs,
-                    },
-                )
-            } else {
-                // else unknown resource span format
-                false
+                        stats: stats.clone(),
+                    };
+                    (event, stats)
+                }) {
+                    ctx.span(id).expect("if `on_new_span` was called, the span must exist; this is a `tracing` bug!").extensions_mut().insert(stats);
+                }
             }
-        } else if self.is_async_op(metadata) {
+            return;
+        }
+
+        if self.is_async_op(metadata) {
+            let at = SystemTime::now();
             let mut async_op_visitor = AsyncOpVisitor::default();
             attrs.record(&mut async_op_visitor);
             if let Some((source, inherit_child_attrs)) = async_op_visitor.result() {
-                let at = SystemTime::now();
                 let resource_id = self.current_spans.get().and_then(|stack| {
                     self.first_entered(&stack.borrow(), |id| self.is_id_resource(id, &ctx))
                 });
@@ -573,40 +577,24 @@ where
                 });
 
                 if let Some(resource_id) = resource_id {
-                    self.send(
-                        &self.shared.dropped_async_ops,
-                        Event::AsyncResourceOp {
-                            id: id.clone(),
-                            parent_id,
-                            resource_id,
-                            at,
-                            metadata,
-                            source,
-                            inherit_child_attrs,
-                        },
-                    )
-                } else {
-                    false
+                    if let Some(stats) =
+                        self.send_stats(&self.shared.dropped_async_ops, move || {
+                            let stats = Arc::new(stats::AsyncOpStats::new(at));
+                            let event = Event::AsyncResourceOp {
+                                id: id.clone(),
+                                parent_id,
+                                resource_id,
+                                metadata,
+                                source,
+                                inherit_child_attrs,
+                                stats: stats.clone(),
+                            };
+                            (event, stats)
+                        })
+                    {
+                        ctx.span(id).expect("if `on_new_span` was called, the span must exist; this is a `tracing` bug!").extensions_mut().insert(stats);
+                    }
                 }
-            } else {
-                // else async op span needs to have a source field
-                false
-            }
-        } else {
-            false
-        };
-
-        // If we were able to record the span, add a marker extension indicating
-        // that it's tracked by the console.
-        if sent {
-            if let Some(span) = ctx.span(id) {
-                span.extensions_mut().insert(Tracked {});
-            } else {
-                debug_assert!(
-                    false,
-                    "span should exist if `on_new_span` was called for its ID ({:?})",
-                    id
-                );
             }
         }
     }
@@ -617,171 +605,192 @@ where
             let at = SystemTime::now();
             let mut visitor = WakerVisitor::default();
             event.record(&mut visitor);
+            // XXX (eliza): ew...
             if let Some((id, mut op)) = visitor.result() {
-                if op.is_wake() {
-                    // Are we currently inside the task's span? If so, the task
-                    // has woken itself.
-                    let self_wake = self
-                        .current_spans
-                        .get()
-                        .map(|spans| spans.borrow().iter().any(|span| span == &id))
-                        .unwrap_or(false);
-                    op = op.self_wake(self_wake);
-                }
-                self.send(&self.shared.dropped_tasks, Event::Waker { id, op, at });
-            }
-            // else unknown waker event... what to do? can't trace it from here...
-            return;
-        }
+                if let Some(span) = ctx.span(&id) {
+                    let exts = span.extensions();
+                    if let Some(stats) = exts.get::<stats::TaskStats>() {
+                        if op.is_wake() {
+                            // Are we currently inside the task's span? If so, the task
+                            // has woken itself.
 
-        if self.poll_op_callsites.contains(metadata) {
-            let resource_id = self.current_spans.get().and_then(|stack| {
-                self.first_entered(&stack.borrow(), |id| self.is_id_resource(id, &ctx))
-            });
-            // poll op event should have a resource span parent
-            if let Some(resource_id) = resource_id {
-                let mut poll_op_visitor = PollOpVisitor::default();
-                event.record(&mut poll_op_visitor);
-                if let Some((op_name, is_ready)) = poll_op_visitor.result() {
-                    let task_and_async_op_ids = self.current_spans.get().and_then(|stack| {
-                        let stack = stack.borrow();
-                        let task_id =
-                            self.first_entered(&stack, |id| self.is_id_spawned(id, &ctx))?;
-                        let async_op_id =
-                            self.first_entered(&stack, |id| self.is_id_async_op(id, &ctx))?;
-                        Some((task_id, async_op_id))
-                    });
+                            let self_wake = self
+                                .current_spans
+                                .get()
+                                .map(|spans| spans.borrow().iter().any(|span| span == &id))
+                                .unwrap_or(false);
+                            op = op.self_wake(self_wake);
+                        }
 
-                    // poll op event should be emitted in the context of an async op and task spans
-                    if let Some((task_id, async_op_id)) = task_and_async_op_ids {
-                        self.send(
-                            &self.shared.dropped_async_ops,
-                            Event::PollOp {
-                                metadata,
-                                op_name,
-                                resource_id,
-                                async_op_id,
-                                task_id,
-                                is_ready,
-                            },
-                        );
+                        stats.record_wake_op(op, at);
                     }
                 }
             }
             return;
         }
 
-        if self.resource_state_update_callsites.contains(metadata) {
-            // state update event should have a resource span parent
-            let resource_id = self.current_spans.get().and_then(|stack| {
-                self.first_entered(&stack.borrow(), |id| self.is_id_resource(id, &ctx))
-            });
+        if self.poll_op_callsites.contains(metadata) {
+            // let resource_id = self.current_spans.get().and_then(|stack| {
+            //     self.first_entered(&stack.borrow(), |id| self.is_id_resource(id, &ctx))
+            // });
+            // // poll op event should have a resource span parent
+            // if let Some(resource_id) = resource_id {
+            //     let mut poll_op_visitor = PollOpVisitor::default();
+            //     event.record(&mut poll_op_visitor);
+            //     if let Some((op_name, is_ready)) = poll_op_visitor.result() {
+            //         let task_and_async_op_ids = self.current_spans.get().and_then(|stack| {
+            //             let stack = stack.borrow();
+            //             let task_id =
+            //                 self.first_entered(&stack, |id| self.is_id_spawned(id, &ctx))?;
+            //             let async_op_id =
+            //                 self.first_entered(&stack, |id| self.is_id_async_op(id, &ctx))?;
+            //             Some((task_id, async_op_id))
+            //         });
 
-            if let Some(resource_id) = resource_id {
-                let meta_id = event.metadata().into();
-                let mut state_update_visitor = StateUpdateVisitor::new(meta_id);
-                event.record(&mut state_update_visitor);
-                if let Some(update) = state_update_visitor.result() {
-                    self.send(
-                        &self.shared.dropped_resources,
-                        Event::StateUpdate {
-                            update_id: resource_id,
-                            update_type: UpdateType::Resource,
-                            update,
-                        },
-                    );
-                }
-            }
-            return;
+            //         // poll op event should be emitted in the context of an async op and task spans
+            //         if let Some((task_id, async_op_id)) = task_and_async_op_ids {
+            //             self.send(
+            //                 &self.shared.dropped_async_ops,
+            //                 Event::PollOp {
+            //                     metadata,
+            //                     op_name,
+            //                     resource_id,
+            //                     async_op_id,
+            //                     task_id,
+            //                     is_ready,
+            //                 },
+            //             );
+            //         }
+            //     }
+            // }
+            // return;
+
+            // TODO(eliza)
         }
 
-        if self.async_op_state_update_callsites.contains(metadata) {
-            let async_op_id = self.current_spans.get().and_then(|stack| {
-                self.first_entered(&stack.borrow(), |id| self.is_id_async_op(id, &ctx))
-            });
-            if let Some(async_op_id) = async_op_id {
-                let meta_id = event.metadata().into();
-                let mut state_update_visitor = StateUpdateVisitor::new(meta_id);
-                event.record(&mut state_update_visitor);
-                if let Some(update) = state_update_visitor.result() {
-                    self.send(
-                        &self.shared.dropped_async_ops,
-                        Event::StateUpdate {
-                            update_id: async_op_id,
-                            update_type: UpdateType::AsyncOp,
-                            update,
-                        },
-                    );
-                }
-            }
-        }
+        // if self.resource_state_update_callsites.contains(metadata) {
+        //     // state update event should have a resource span parent
+        //     let resource_id = self.current_spans.get().and_then(|stack| {
+        //         self.first_entered(&stack.borrow(), |id| self.is_id_resource(id, &ctx))
+        //     });
+
+        //     if let Some(resource_id) = resource_id {
+        //         let meta_id = event.metadata().into();
+        //         let mut state_update_visitor = StateUpdateVisitor::new(meta_id);
+        //         event.record(&mut state_update_visitor);
+        //         if let Some(update) = state_update_visitor.result() {
+        //             self.send(
+        //                 &self.shared.dropped_resources,
+        //                 Event::StateUpdate {
+        //                     update_id: resource_id,
+        //                     update_type: UpdateType::Resource,
+        //                     update,
+        //                 },
+        //             );
+        //         }
+        //     }
+        //     return;
+        // }
+
+        // if self.async_op_state_update_callsites.contains(metadata) {
+        //     let async_op_id = self.current_spans.get().and_then(|stack| {
+        //         self.first_entered(&stack.borrow(), |id| self.is_id_async_op(id, &ctx))
+        //     });
+        //     if let Some(async_op_id) = async_op_id {
+        //         let meta_id = event.metadata().into();
+        //         let mut state_update_visitor = StateUpdateVisitor::new(meta_id);
+        //         event.record(&mut state_update_visitor);
+        //         if let Some(update) = state_update_visitor.result() {
+        //             self.send(
+        //                 &self.shared.dropped_async_ops,
+        //                 Event::StateUpdate {
+        //                     update_id: async_op_id,
+        //                     update_type: UpdateType::AsyncOp,
+        //                     update,
+        //                 },
+        //             );
+        //         }
+        //     }
+        // }
     }
 
     fn on_enter(&self, id: &span::Id, cx: Context<'_, S>) {
-        if !self.is_id_tracked(id, &cx) {
-            return;
+        fn update<S: Subscriber + for<'a> LookupSpan<'a>>(
+            span: SpanRef<S>,
+            at: Option<SystemTime>,
+        ) -> Option<SystemTime> {
+            let exts = span.extensions();
+            if let Some(stats) = exts.get::<stats::TaskStats>() {
+                let at = at.unwrap_or_else(SystemTime::now);
+                stats.start_poll(at);
+                Some(at)
+            } else if let Some(stats) = exts.get::<stats::AsyncOpStats>() {
+                let at = at.unwrap_or_else(SystemTime::now);
+                stats.start_poll(at);
+                Some(at)
+            } else {
+                None
+            }
         }
-        let _default = dispatcher::set_default(&self.no_dispatch);
-        let parent_id = cx.span(id).and_then(|s| s.parent().map(|p| p.id()));
-        let sent = self.send(
-            &self.shared.dropped_tasks,
-            Event::Enter {
-                at: SystemTime::now(),
-                id: id.clone(),
-                parent_id,
-            },
-        );
 
-        // if we were able to record the send successfully, track entering the
-        // span. if not, ignore the enter, to avoid inconsistent data.
-        if sent {
-            self.current_spans
-                .get_or_default()
-                .borrow_mut()
-                .push(id.clone());
+        if let Some(span) = cx.span(id) {
+            let now = SystemTime::now();
+            if let Some(at) = update(span, None) {
+                if let Some(parent) = span.parent() {
+                    update(parent, Some(at));
+                }
+                self.current_spans
+                    .get_or_default()
+                    .borrow_mut()
+                    .push(id.clone());
+            }
         }
     }
 
     fn on_exit(&self, id: &span::Id, cx: Context<'_, S>) {
-        if !self.is_id_tracked(id, &cx) {
-            return;
-        }
-
-        let _default = dispatcher::set_default(&self.no_dispatch);
-        if let Some(spans) = self.current_spans.get() {
-            if !spans.borrow_mut().pop(id) {
-                // we did not actually pop the span --- entering it may not have
-                // been successfully recorded. in this case, ignore the exit,
-                // since the aggregator was never informed of the entry.
-                return;
+        fn update<S: Subscriber + for<'a> LookupSpan<'a>>(
+            span: SpanRef<S>,
+            at: Option<SystemTime>,
+        ) -> Option<SystemTime> {
+            let exts = span.extensions();
+            if let Some(stats) = exts.get::<stats::TaskStats>() {
+                let at = at.unwrap_or_else(SystemTime::now);
+                stats.end_poll(at);
+                Some(at)
+            } else if let Some(stats) = exts.get::<stats::AsyncOpStats>() {
+                let at = at.unwrap_or_else(SystemTime::now);
+                stats.end_poll(at);
+                Some(at)
+            } else {
+                None
             }
         }
 
-        let parent_id = cx.span(id).and_then(|s| s.parent().map(|p| p.id()));
-
-        self.send(
-            &self.shared.dropped_tasks,
-            Event::Exit {
-                id: id.clone(),
-                parent_id,
-                at: SystemTime::now(),
-            },
-        );
+        if let Some(span) = cx.span(id) {
+            let now = SystemTime::now();
+            if let Some(at) = update(span, None) {
+                if let Some(parent) = span.parent() {
+                    update(parent, Some(at));
+                }
+                self.current_spans
+                    .get_or_default()
+                    .borrow_mut()
+                    .push(id.clone());
+            }
+        }
     }
 
     fn on_close(&self, id: span::Id, cx: Context<'_, S>) {
-        if !self.is_id_tracked(&id, &cx) {
-            return;
+        if let Some(span) = cx.span(&id) {
+            let exts = span.extensions();
+            if let Some(stats) = exts.get::<stats::TaskStats>() {
+                stats.drop_task(SystemTime::now());
+            } else if let Some(stats) = exts.get::<stats::AsyncOpStats>() {
+                stats.drop_async_op(SystemTime::now());
+            } else if let Some(stats) = exts.get::<stats::ResourceStats>() {
+                stats.drop_resource(SystemTime::now());
+            }
         }
-
-        let _default = dispatcher::set_default(&self.no_dispatch);
-        self.send(
-            &self.shared.dropped_tasks,
-            Event::Close {
-                at: SystemTime::now(),
-                id,
-            },
-        );
     }
 }
 

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -130,6 +130,11 @@ pub struct Server {
     client_buffer: usize,
 }
 
+pub(crate) trait ToProto {
+    type Output;
+    fn to_proto(&self) -> Self::Output;
+}
+
 /// State shared between the `ConsoleLayer` and the `Aggregator` task.
 #[derive(Debug, Default)]
 struct Shared {
@@ -609,7 +614,7 @@ where
             if let Some((id, mut op)) = visitor.result() {
                 if let Some(span) = ctx.span(&id) {
                     let exts = span.extensions();
-                    if let Some(stats) = exts.get::<stats::TaskStats>() {
+                    if let Some(stats) = exts.get::<Arc<stats::TaskStats>>() {
                         if op.is_wake() {
                             // Are we currently inside the task's span? If so, the task
                             // has woken itself.
@@ -716,15 +721,15 @@ where
 
     fn on_enter(&self, id: &span::Id, cx: Context<'_, S>) {
         fn update<S: Subscriber + for<'a> LookupSpan<'a>>(
-            span: SpanRef<S>,
+            span: &SpanRef<S>,
             at: Option<SystemTime>,
         ) -> Option<SystemTime> {
             let exts = span.extensions();
-            if let Some(stats) = exts.get::<stats::TaskStats>() {
+            if let Some(stats) = exts.get::<Arc<stats::TaskStats>>() {
                 let at = at.unwrap_or_else(SystemTime::now);
                 stats.start_poll(at);
                 Some(at)
-            } else if let Some(stats) = exts.get::<stats::AsyncOpStats>() {
+            } else if let Some(stats) = exts.get::<Arc<stats::AsyncOpStats>>() {
                 let at = at.unwrap_or_else(SystemTime::now);
                 stats.start_poll(at);
                 Some(at)
@@ -734,10 +739,9 @@ where
         }
 
         if let Some(span) = cx.span(id) {
-            let now = SystemTime::now();
-            if let Some(at) = update(span, None) {
+            if let Some(now) = update(&span, None) {
                 if let Some(parent) = span.parent() {
-                    update(parent, Some(at));
+                    update(&parent, Some(now));
                 }
                 self.current_spans
                     .get_or_default()
@@ -749,15 +753,15 @@ where
 
     fn on_exit(&self, id: &span::Id, cx: Context<'_, S>) {
         fn update<S: Subscriber + for<'a> LookupSpan<'a>>(
-            span: SpanRef<S>,
+            span: &SpanRef<S>,
             at: Option<SystemTime>,
         ) -> Option<SystemTime> {
             let exts = span.extensions();
-            if let Some(stats) = exts.get::<stats::TaskStats>() {
+            if let Some(stats) = exts.get::<Arc<stats::TaskStats>>() {
                 let at = at.unwrap_or_else(SystemTime::now);
                 stats.end_poll(at);
                 Some(at)
-            } else if let Some(stats) = exts.get::<stats::AsyncOpStats>() {
+            } else if let Some(stats) = exts.get::<Arc<stats::AsyncOpStats>>() {
                 let at = at.unwrap_or_else(SystemTime::now);
                 stats.end_poll(at);
                 Some(at)
@@ -767,10 +771,9 @@ where
         }
 
         if let Some(span) = cx.span(id) {
-            let now = SystemTime::now();
-            if let Some(at) = update(span, None) {
+            if let Some(now) = update(&span, None) {
                 if let Some(parent) = span.parent() {
-                    update(parent, Some(at));
+                    update(&parent, Some(now));
                 }
                 self.current_spans
                     .get_or_default()
@@ -783,11 +786,11 @@ where
     fn on_close(&self, id: span::Id, cx: Context<'_, S>) {
         if let Some(span) = cx.span(&id) {
             let exts = span.extensions();
-            if let Some(stats) = exts.get::<stats::TaskStats>() {
+            if let Some(stats) = exts.get::<Arc<stats::TaskStats>>() {
                 stats.drop_task(SystemTime::now());
-            } else if let Some(stats) = exts.get::<stats::AsyncOpStats>() {
+            } else if let Some(stats) = exts.get::<Arc<stats::AsyncOpStats>>() {
                 stats.drop_async_op(SystemTime::now());
-            } else if let Some(stats) = exts.get::<stats::ResourceStats>() {
+            } else if let Some(stats) = exts.get::<Arc<stats::ResourceStats>>() {
                 stats.drop_resource(SystemTime::now());
             }
         }

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -468,22 +468,16 @@ impl ConsoleLayer {
             None => return,
         };
 
-        stats.update_attribute(&id, &update);
+        stats.update_attribute(id, &update);
 
-        if let Some(parent) = stats
-            .parent_id
-            .as_ref()
-            .and_then(|parent| ctx.span(&parent))
-        {
+        if let Some(parent) = stats.parent_id.as_ref().and_then(|parent| ctx.span(parent)) {
             let exts = parent.extensions();
             if let Some(stats) = get_stats(&exts) {
                 if stats.inherit_child_attributes {
-                    stats.update_attribute(&id, &update);
+                    stats.update_attribute(id, &update);
                 }
             }
         }
-
-        return;
     }
 }
 
@@ -726,7 +720,7 @@ where
             if let Some(id) = resource_id {
                 self.state_update(&id, event, &ctx, |exts| {
                     exts.get::<Arc<stats::ResourceStats>>()
-                        .map(|arc| <Arc<stats::ResourceStats> as std::ops::Deref>::deref(arc))
+                        .map(<Arc<stats::ResourceStats> as std::ops::Deref>::deref)
                 });
             }
 
@@ -743,8 +737,6 @@ where
                     Some(&async_op.stats)
                 });
             }
-
-            return;
         }
     }
 

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -166,7 +166,7 @@ enum Event {
     Spawn {
         id: span::Id,
         metadata: &'static Metadata<'static>,
-        at: SystemTime,
+        stats: Arc<stats::TaskStats>,
         fields: Vec<proto::Field>,
         location: Option<proto::Location>,
     },

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -23,6 +23,7 @@ use tracing_core::{
 use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
 mod aggregator;
+mod attribute;
 mod builder;
 mod callsites;
 mod record;

--- a/console-subscriber/src/record.rs
+++ b/console-subscriber/src/record.rs
@@ -1,16 +1,10 @@
+use console_api as proto;
+use crossbeam_channel::{Receiver, Sender};
 use serde::{
     ser::{SerializeSeq, SerializeStruct},
     Serialize,
 };
-use std::{
-    fs::File,
-    io,
-    path::Path,
-    sync::{Arc, Mutex},
-    time::SystemTime,
-};
-
-use console_api as proto;
+use std::{fs::File, io, path::Path, time::SystemTime};
 
 /// This marks the currently understood version of the recording format. This
 /// should be increased whenever the format has a breaking change that we
@@ -21,23 +15,9 @@ use console_api as proto;
 const DATA_FORMAT_VERSION: u8 = 1;
 
 pub(crate) struct Recorder {
-    buf: Arc<Mutex<RecordBuf>>,
-
-    worker: std::thread::JoinHandle<()>,
-}
-
-struct Io {
-    buf: Arc<Mutex<RecordBuf>>,
-    file: File,
-}
-
-struct RecordBuf {
-    /// The current buffer to serialize events into.
-    bytes: Vec<u8>,
-    /// The "next" buffer that should be used when the IO thread takes the
-    /// current buffer. After flushing, the IO thread will put the buffer
-    /// back in this slot, so the allocation can be reused.
-    next: Vec<u8>,
+    tx: Sender<Event>,
+    // TODO(eliza): terminate and flush when dropping...
+    _worker: std::thread::JoinHandle<()>,
 }
 
 #[derive(Serialize)]
@@ -46,11 +26,11 @@ struct Header {
 }
 
 #[derive(Serialize)]
-enum Event<'a> {
+pub(crate) enum Event {
     Spawn {
         id: u64,
         at: SystemTime,
-        fields: SerializeFields<'a>,
+        fields: SerializeFields,
     },
     Enter {
         id: u64,
@@ -71,123 +51,73 @@ enum Event<'a> {
     },
 }
 
-struct SerializeFields<'a>(&'a [proto::Field]);
+pub(crate) struct SerializeFields(pub(crate) Vec<proto::Field>);
 
 struct SerializeField<'a>(&'a proto::Field);
 
 impl Recorder {
     pub(crate) fn new(path: &Path) -> io::Result<Self> {
-        let buf = Arc::new(Mutex::new(RecordBuf::new()));
-        let buf2 = buf.clone();
         let file = std::fs::File::create(path)?;
-
-        let worker = std::thread::Builder::new()
+        let (tx, rx) = crossbeam_channel::bounded(4096);
+        let _worker = std::thread::Builder::new()
             .name("console/subscriber/recorder/io".into())
-            .spawn(move || {
-                record_io(Io { buf: buf2, file });
+            .spawn(move || match record_io(file, rx) {
+                Err(e) => eprintln!("event recorder failed: {}", e),
+                Ok(()) => {}
             })?;
 
-        let recorder = Recorder { buf, worker };
-
-        recorder.write(&Header {
-            v: DATA_FORMAT_VERSION,
-        });
+        let recorder = Recorder { tx, _worker };
 
         Ok(recorder)
     }
 
-    pub(crate) fn record(&self, event: &crate::Event) {
-        let event = match event {
-            crate::Event::Spawn {
-                id, fields, stats, ..
-            } => Event::Spawn {
-                id: id.into_u64(),
-                at: stats.created_at,
-                fields: SerializeFields(fields),
-            },
-            // TODO(eliza): this more or less bricks recording, lol...put this back.
-            // crate::Event::Enter { id, at, .. } => Event::Enter {
-            //     id: id.into_u64(),
-            //     at: *at,
-            // },
-            // crate::Event::Exit { id, at, .. } => Event::Exit {
-            //     id: id.into_u64(),
-            //     at: *at,
-            // },
-            // crate::Event::Close { id, at } => Event::Close {
-            //     id: id.into_u64(),
-            //     at: *at,
-            // },
-            // crate::Event::Waker { id, op, at } => Event::Waker {
-            //     id: id.into_u64(),
-            //     at: *at,
-            //     op: *op,
-            // },
-            _ => return,
-        };
-
-        self.write(&event);
-    }
-
-    fn write<T: Serialize>(&self, val: &T) {
-        let mut buf = self.buf.lock().unwrap();
-        serde_json::to_writer(&mut buf.bytes, val).expect("json");
-        buf.bytes.push(b'\n');
-        drop(buf);
-        self.worker.thread().unpark();
-    }
-}
-
-impl RecordBuf {
-    fn new() -> Self {
-        Self {
-            bytes: Vec::new(),
-            next: Vec::new(),
-        }
-    }
-
-    /// Takes the existing bytes to be written, and resets self so that
-    /// it may continue to buffer events.
-    fn take(&mut self) -> Vec<u8> {
-        let next = std::mem::take(&mut self.next);
-        std::mem::replace(&mut self.bytes, next)
-    }
-
-    fn put(&mut self, mut next: Vec<u8>) {
-        debug_assert_eq!(self.next.capacity(), 0);
-        next.clear();
-        self.next = next;
-    }
-}
-
-fn record_io(mut dst: Io) {
-    use std::io::Write;
-
-    loop {
-        std::thread::park();
-
-        // Only lock the mutex to take the bytes out. The file write could
-        // take a relatively long time, and we don't want to be blocking
-        // the serialization end holding this lock.
-        let bytes = dst.buf.lock().unwrap().take();
-        match dst.file.write_all(&bytes) {
-            Ok(()) => {
-                dst.buf.lock().unwrap().put(bytes);
-            }
-            Err(_e) => {
-                // TODO: what to do if file error?
-            }
+    pub(crate) fn record(&self, event: Event) {
+        if self.tx.send(event).is_err() {
+            eprintln!("event recorder thread has terminated!");
         }
     }
 }
 
-impl serde::Serialize for SerializeFields<'_> {
+fn record_io(file: File, rx: Receiver<Event>) -> io::Result<()> {
+    use std::io::{BufWriter, Write};
+
+    fn write<T: Serialize>(mut file: &mut BufWriter<File>, val: &T) -> io::Result<()> {
+        serde_json::to_writer(&mut file, val)?;
+        file.write_all(b"\n")
+    }
+
+    let mut file = BufWriter::new(file);
+    write(
+        &mut file,
+        &Header {
+            v: DATA_FORMAT_VERSION,
+        },
+    )?;
+
+    // wait to recieve an event...
+    while let Ok(event) = rx.recv() {
+        // TODO: what to do if file error?
+        write(&mut file, &event)?;
+
+        // drain any additional events that are ready now
+        while let Ok(event) = rx.try_recv() {
+            write(&mut file, &event)?;
+        }
+
+        file.flush()?;
+    }
+
+    tracing::debug!("event stream ended; flushing file");
+    file.flush()
+}
+
+impl serde::Serialize for SerializeFields {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for element in self.0 {
+        for element in &self.0 {
             seq.serialize_element(&SerializeField(element))?;
         }
         seq.end()

--- a/console-subscriber/src/record.rs
+++ b/console-subscriber/src/record.rs
@@ -98,28 +98,31 @@ impl Recorder {
 
     pub(crate) fn record(&self, event: &crate::Event) {
         let event = match event {
-            crate::Event::Spawn { id, at, fields, .. } => Event::Spawn {
+            crate::Event::Spawn {
+                id, fields, stats, ..
+            } => Event::Spawn {
                 id: id.into_u64(),
-                at: *at,
+                at: stats.created_at,
                 fields: SerializeFields(fields),
             },
-            crate::Event::Enter { id, at, .. } => Event::Enter {
-                id: id.into_u64(),
-                at: *at,
-            },
-            crate::Event::Exit { id, at, .. } => Event::Exit {
-                id: id.into_u64(),
-                at: *at,
-            },
-            crate::Event::Close { id, at } => Event::Close {
-                id: id.into_u64(),
-                at: *at,
-            },
-            crate::Event::Waker { id, op, at } => Event::Waker {
-                id: id.into_u64(),
-                at: *at,
-                op: *op,
-            },
+            // TODO(eliza): this more or less bricks recording, lol...put this back.
+            // crate::Event::Enter { id, at, .. } => Event::Enter {
+            //     id: id.into_u64(),
+            //     at: *at,
+            // },
+            // crate::Event::Exit { id, at, .. } => Event::Exit {
+            //     id: id.into_u64(),
+            //     at: *at,
+            // },
+            // crate::Event::Close { id, at } => Event::Close {
+            //     id: id.into_u64(),
+            //     at: *at,
+            // },
+            // crate::Event::Waker { id, op, at } => Event::Waker {
+            //     id: id.into_u64(),
+            //     at: *at,
+            //     op: *op,
+            // },
             _ => return,
         };
 

--- a/console-subscriber/src/stats.rs
+++ b/console-subscriber/src/stats.rs
@@ -59,19 +59,6 @@ impl<T: ToProto> ToProto for Arc<T> {
         T::to_proto(self)
     }
 }
-
-// pub(crate) trait Stats: ToProto {
-//     fn dropped_at(&self) -> Option<SystemTime>;
-
-//     fn to_proto_if_unsent(&self) -> Option<<Self as ToProto>::Output> {
-//         if self.take_unsent() {
-//             Some(self.to_proto)
-//         } else {
-//             None
-//         }
-//     }
-// }
-
 #[derive(Debug)]
 pub(crate) struct TaskStats {
     is_dirty: AtomicBool,

--- a/console-subscriber/src/stats.rs
+++ b/console-subscriber/src/stats.rs
@@ -1,0 +1,108 @@
+use crate::sync::Mutex;
+use hdrhistogram::Histogram;
+use std::cmp;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::*};
+use std::time::{Duration, SystemTime};
+
+pub(crate) struct TaskStats {
+    dirty: AtomicBool,
+    // task stats
+    created_at: SystemTime,
+    timestamps: Mutex<TaskTimestamps>,
+
+    // waker stats
+    wakes: AtomicUsize,
+    waker_clones: AtomicUsize,
+    waker_drops: AtomicUsize,
+    self_wakes: AtomicUsize,
+
+    poll_times_histogram: Histogram<u64>,
+    poll_stats: PollStats,
+}
+
+#[derive(Default)]
+struct TaskTimestamps {
+    dropped_at: Option<SystemTime>,
+    last_wake: Option<SystemTime>,
+}
+
+#[derive(Default)]
+pub(crate) struct PollStats {
+    /// The number of polls in progress
+    current_polls: AtomicUsize,
+    /// The total number of polls
+    polls: AtomicUsize,
+    busy_time_ns: AtomicUsize,
+    timestamps: Mutex<PollTimestamps>,
+}
+
+#[derive(Default)]
+struct PollTimestamps {
+    first_poll: Option<SystemTime>,
+    last_poll_started: Option<SystemTime>,
+    last_poll_ended: Option<SystemTime>,
+    histogram: Option<Histogram<u64>>,
+}
+
+impl TaskStats {
+    pub(crate) fn clone_waker(&self) {
+        self.waker_clones.fetch_add(1, Release);
+        let _ = self.dirty.compare_exchange(false, true, AcqRel, Acquire);
+    }
+
+    pub(crate) fn drop_waker(&self) {
+        self.waker_drops.fetch_add(1, Release);
+        let _ = self.dirty.compare_exchange(false, true, AcqRel, Acquire);
+    }
+
+    pub(crate) fn wake(&self, at: SystemTime, self_wake: bool) {
+        let mut timestamps = self.timestamps.lock();
+        timestamps.last_wake = cmp::max(timestamps.last_wake, Some(at));
+        self.wakes.fetch_add(1, Release);
+        if self_wake {
+            self.wakes.fetch_add(1, Release);
+        }
+
+        let _ = self.dirty.compare_exchange(false, true, AcqRel, Acquire);
+    }
+}
+
+impl PollStats {
+    pub(crate) fn start_poll(&self, at: SystemTime) {
+        if self.current_polls.fetch_add(1, AcqRel) == 0 {
+            // We are starting the first poll
+            let mut timestamps = self.timestamps.lock();
+            if timestamps.first_poll.is_none() {
+                timestamps.first_poll = Some(at);
+            }
+
+            timestamps.last_poll_started = Some(at);
+
+            self.polls.fetch_add(1, Release);
+        }
+    }
+
+    pub(crate) fn end_poll(&self, at: SystemTime) {
+        if self.current_polls.fetch_sub(1, AcqRel) == 1 {
+            // We are ending the last current poll
+            let mut timestamps = self.timestamps.lock();
+            let last_poll_started = timestamps.last_poll_started;
+            debug_assert!(last_poll_started.is_some(), "must have started a poll before ending a poll; this is a `console-subscriber` bug!");
+            timestamps.last_poll_ended = Some(at);
+            let elapsed = last_poll_started.and_then(|started| at.duration_since(started).ok());
+            debug_assert!(elapsed.is_some(), "the current poll must have started before it ended; this is a `console-subscriber` bug!");
+            if let Some(elapsed) = elapsed {
+                let elapsed_ns = elapsed.as_nanos().try_into().unwrap_or(u64::MAX);
+
+                // if we have a poll time histogram, add the timestamp
+                if let Some(ref mut histogram) = timestamps.histogram {
+                    histogram
+                        .record(elapsed_ns)
+                        .expect("failed to record histogram for some kind of reason");
+                }
+
+                self.busy_time_ns.fetch_add(elapsed_ns as usize, Release);
+            }
+        }
+    }
+}

--- a/console-subscriber/src/stats.rs
+++ b/console-subscriber/src/stats.rs
@@ -4,6 +4,29 @@ use std::cmp;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::*};
 use std::time::{Duration, SystemTime};
 
+use console_api as proto;
+
+pub(crate) trait ToProto {
+    type Output;
+    fn to_proto(&self) -> Self::Output;
+}
+
+/// A type which records whether it has unsent updates.
+///
+/// If something implementing this trait has been changed since the last time
+/// data was sent to a client, it will indicate that it is "dirty". If it has
+/// not been changed, it does not have to be included in the current update.
+pub(crate) trait Unsent {
+    /// Returns `true` if this type has unsent updates, and if it does, clears
+    /// the flag indicating there are unsent updates.
+    ///
+    /// This is called when filtering which stats need to be included in the
+    /// current update. If this returns `true`, it will be included, so it
+    /// becomes no longer dirty.
+    fn take_unsent(&self) -> bool;
+}
+
+#[derive(Debug)]
 pub(crate) struct TaskStats {
     dirty: AtomicBool,
     // task stats
@@ -16,35 +39,65 @@ pub(crate) struct TaskStats {
     waker_drops: AtomicUsize,
     self_wakes: AtomicUsize,
 
-    poll_times_histogram: Histogram<u64>,
     poll_stats: PollStats,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct TaskTimestamps {
     dropped_at: Option<SystemTime>,
     last_wake: Option<SystemTime>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
+struct AsyncOpStats {
+    created_at: SystemTime,
+    dropped_at: Option<SystemTime>,
+    task_id: Option<Id>,
+    poll_stats: PollStats,
+    attributes: HashMap<FieldKey, Attribute>,
+}
+
+#[derive(Debug, Default)]
 pub(crate) struct PollStats {
     /// The number of polls in progress
     current_polls: AtomicUsize,
     /// The total number of polls
     polls: AtomicUsize,
-    busy_time_ns: AtomicUsize,
     timestamps: Mutex<PollTimestamps>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct PollTimestamps {
     first_poll: Option<SystemTime>,
     last_poll_started: Option<SystemTime>,
     last_poll_ended: Option<SystemTime>,
+    busy_time: Duration,
     histogram: Option<Histogram<u64>>,
 }
 
 impl TaskStats {
+    pub(crate) fn new(created_at: SystemTime) -> Self {
+        // significant figures should be in the [0-5] range and memory usage
+        // grows exponentially with higher a sigfig
+        let poll_times_histogram = Histogram::<u64>::new(2).unwrap();
+        Self {
+            dirty: AtomicBool::new(true),
+            created_at,
+            timestamps: Mutex::new(TaskTimestamps::default()),
+            poll_stats: PollStats {
+                timestamps: Mutex::new(PollTimestamps {
+                    histogram: Some(poll_times_histogram),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            wakes: AtomicUsize::new(0),
+            waker_clones: AtomicUsize::new(0),
+            waker_drops: AtomicUsize::new(0),
+            self_wakes: AtomicUsize::new(0),
+        }
+    }
+
     pub(crate) fn clone_waker(&self) {
         self.waker_clones.fetch_add(1, Release);
         let _ = self.dirty.compare_exchange(false, true, AcqRel, Acquire);
@@ -66,6 +119,36 @@ impl TaskStats {
         let _ = self.dirty.compare_exchange(false, true, AcqRel, Acquire);
     }
 }
+
+impl ToProto for TaskStats {
+    type Output = proto::tasks::Stats;
+
+    fn to_proto(&self) -> Self::Output {
+        let poll_stats = Some(self.poll_stats.to_proto());
+        let timestamps = self.timestamps.lock();
+        proto::tasks::Stats {
+            poll_stats,
+            created_at: Some(self.created_at.into()),
+            dropped_at: timestamps.dropped_at.map(Into::into),
+            wakes: self.wakes.load(Acquire) as u64,
+            waker_clones: self.waker_clones.load(Acquire) as u64,
+            self_wakes: self.self_wakes.load(Acquire) as u64,
+            waker_drops: self.waker_drops.load(Acquire) as u64,
+            last_wake: timestamps.last_wake.map(Into::into),
+        }
+    }
+}
+
+impl Unsent for TaskStats {
+    #[inline]
+    fn take_unsent(&self) -> bool {
+        self.dirty
+            .compare_exchange(true, false, AcqRel, Acquire)
+            .is_ok()
+    }
+}
+
+// === impl PollStats ===
 
 impl PollStats {
     pub(crate) fn start_poll(&self, at: SystemTime) {
@@ -92,17 +175,31 @@ impl PollStats {
             let elapsed = last_poll_started.and_then(|started| at.duration_since(started).ok());
             debug_assert!(elapsed.is_some(), "the current poll must have started before it ended; this is a `console-subscriber` bug!");
             if let Some(elapsed) = elapsed {
-                let elapsed_ns = elapsed.as_nanos().try_into().unwrap_or(u64::MAX);
-
                 // if we have a poll time histogram, add the timestamp
                 if let Some(ref mut histogram) = timestamps.histogram {
+                    let elapsed_ns = elapsed.as_nanos().try_into().unwrap_or(u64::MAX);
                     histogram
                         .record(elapsed_ns)
                         .expect("failed to record histogram for some kind of reason");
                 }
 
-                self.busy_time_ns.fetch_add(elapsed_ns as usize, Release);
+                timestamps.busy_time += elapsed;
             }
+        }
+    }
+}
+
+impl ToProto for PollStats {
+    type Output = proto::PollStats;
+
+    fn to_proto(&self) -> Self::Output {
+        let timestamps = self.timestamps.lock();
+        proto::PollStats {
+            polls: self.polls.load(Acquire) as u64,
+            first_poll: timestamps.first_poll.map(Into::into),
+            last_poll_started: timestamps.last_poll_started.map(Into::into),
+            last_poll_ended: timestamps.last_poll_ended.map(Into::into),
+            busy_time: Some(timestamps.busy_time.into()),
         }
     }
 }

--- a/console-subscriber/src/stats.rs
+++ b/console-subscriber/src/stats.rs
@@ -202,10 +202,6 @@ impl TaskStats {
         self.make_dirty();
     }
 
-    pub(crate) fn since_last_poll(&self, now: SystemTime) -> Option<Duration> {
-        self.poll_stats.since_last_poll(now)
-    }
-
     pub(crate) fn drop_task(&self, dropped_at: SystemTime) {
         if self.is_dropped.swap(true, AcqRel) {
             // The task was already dropped.
@@ -304,6 +300,7 @@ impl AsyncOpStats {
         self.task_id.store(id.into_u64(), Release);
         self.make_dirty();
     }
+
     pub(crate) fn drop_async_op(&self, dropped_at: SystemTime) {
         self.stats.drop_resource(dropped_at)
     }
@@ -316,10 +313,6 @@ impl AsyncOpStats {
     pub(crate) fn end_poll(&self, at: SystemTime) {
         self.poll_stats.end_poll(at);
         self.make_dirty();
-    }
-
-    pub(crate) fn since_last_poll(&self, now: SystemTime) -> Option<Duration> {
-        self.poll_stats.since_last_poll(now)
     }
 
     #[inline]
@@ -482,13 +475,6 @@ impl PollStats {
                 timestamps.busy_time += elapsed;
             }
         }
-    }
-
-    fn since_last_poll(&self, timestamp: SystemTime) -> Option<Duration> {
-        self.timestamps
-            .lock()
-            .last_poll_started
-            .map(|lps| timestamp.duration_since(lps).unwrap())
     }
 }
 

--- a/console-subscriber/src/sync.rs
+++ b/console-subscriber/src/sync.rs
@@ -22,7 +22,7 @@ mod std_impl {
     }
 
     impl<T: ?Sized> Mutex<T> {
-        pub(crate) fn read(&self) -> MutexGuard<'_, T> {
+        pub(crate) fn lock(&self) -> MutexGuard<'_, T> {
             self.0.lock().unwrap_or_else(PoisonError::into_inner)
         }
     }

--- a/console-subscriber/src/sync.rs
+++ b/console-subscriber/src/sync.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code, unused_imports)]
 
 #[cfg(feature = "parking_lot")]
-pub(crate) use parking_lot_crate::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub(crate) use parking_lot_crate::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[cfg(not(feature = "parking_lot"))]
 pub(crate) use self::std_impl::*;
@@ -10,7 +10,22 @@ pub(crate) use self::std_impl::*;
 #[cfg(not(feature = "parking_lot"))]
 mod std_impl {
     use std::sync::{self, PoisonError, TryLockError};
-    pub use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+    pub use std::sync::{MutexGuard, RwLockReadGuard, RwLockWriteGuard};
+
+    #[derive(Debug, Default)]
+    pub(crate) struct Mutex<T: ?Sized>(sync::Mutex<T>);
+
+    impl<T> Mutex<T> {
+        pub(crate) fn new(data: T) -> Self {
+            Self(sync::Mutex::new(data))
+        }
+    }
+
+    impl<T: ?Sized> Mutex<T> {
+        pub(crate) fn read(&self) -> MutexGuard<'_, T> {
+            self.0.lock().unwrap_or_else(PoisonError::into_inner)
+        }
+    }
 
     #[derive(Debug, Default)]
     pub(crate) struct RwLock<T: ?Sized>(sync::RwLock<T>);

--- a/console-subscriber/src/visitors.rs
+++ b/console-subscriber/src/visitors.rs
@@ -2,7 +2,7 @@
 //! fields from tracing metadata and producing the parts
 //! needed to construct `Event` instances.
 
-use super::{AttributeUpdate, AttributeUpdateOp, WakeOp};
+use super::{attribute, WakeOp};
 use console_api as proto;
 use proto::resources::resource;
 use tracing_core::{
@@ -162,7 +162,7 @@ pub(crate) struct StateUpdateVisitor {
     meta_id: proto::MetaId,
     field: Option<proto::Field>,
     unit: Option<String>,
-    op: Option<AttributeUpdateOp>,
+    op: Option<attribute::UpdateOp>,
 }
 
 impl ResourceVisitor {
@@ -456,8 +456,8 @@ impl StateUpdateVisitor {
         }
     }
 
-    pub(crate) fn result(self) -> Option<AttributeUpdate> {
-        Some(AttributeUpdate {
+    pub(crate) fn result(self) -> Option<attribute::Update> {
+        Some(attribute::Update {
             field: self.field?,
             op: self.op,
             unit: self.unit,
@@ -517,9 +517,9 @@ impl Visit for StateUpdateVisitor {
     fn record_str(&mut self, field: &field::Field, value: &str) {
         if field.name().ends_with(Self::STATE_OP_SUFFIX) {
             match value {
-                Self::OP_ADD => self.op = Some(AttributeUpdateOp::Add),
-                Self::OP_SUB => self.op = Some(AttributeUpdateOp::Sub),
-                Self::OP_OVERRIDE => self.op = Some(AttributeUpdateOp::Override),
+                Self::OP_ADD => self.op = Some(attribute::UpdateOp::Add),
+                Self::OP_SUB => self.op = Some(attribute::UpdateOp::Sub),
+                Self::OP_OVERRIDE => self.op = Some(attribute::UpdateOp::Override),
                 _ => {}
             };
         } else if field.name().ends_with(Self::STATE_UNIT_SUFFIX) {


### PR DESCRIPTION
## Motivation

Currently, there are some rather bad issues that occur when the event
buffer is at capacity and events are dropped.

Completely *losing* data due to buffer capacity is relatively okay: if
we set a bound on how much memory the console can use, and we don't
record new things that occur when we've reached that limit, this is
correct and acceptable behavior. However, the current design can result
in *incorrect* data when events are lost due to the buffer being at
capacity.

This is because we currently record things like starting to poll a
task/resource, ending a poll, dropping a task/resource/async op, and
waker operations, as individual events in the buffer. This means that we
can have a situation where the creation of a task was recorded, because
there was buffer capacity at the time, but then when the task ended, the
buffer was full, so we never recorded its termination. That results in
the tasks appearing to run forever and never terminate --- see issue
#230. Similarly, if we record the beginning of a poll, but drop the
end-of-poll event because we're at capacity, this means we will
(incorrectly) record a poll that goes on forever, which is obviously
incorrect. I think this may also be the cause of the false positives
with the lost waker lint (#149), if we record a waker drop but missed a
waker clone that previously occurred.

The change in #212 fixed one category of issue that occurs due to event
buffer capacity --- when a task, resource, or async op's _creation_
event is dropped due to buffer capacity, we skip any subsequent events
related to that task/resource/op. However, this doesn't fix issues where
the subsequent events are the ones that are dropped.

## Solution

This branch proposes a solution to this whole category of event buffer
capacity related issues. Unfortunately, this requires rewriting a *lot*
of `console-subscriber`'s internals.

In the new approach, we now _only_ send events over the channel when
creating a new task, resource, or async op. Those events now contain an
`Arc` holding the stats for that entity. Another clone of the `Arc` is
stored in the `tracing_subscriber::Registry`'s [span extensions] for the
span corresponding to that entity. When the `ConsoleLayer` records
subsequent events for a particular entity, such as starting/ending a
poll, it looks up the span by ID, and updates the stats type stored in
its extensions. The aggregator stores its clone of the `Arc` in a map of
entities, just like it does currently, but no longer handles actually
updating the stats; just building wire format updates from any tracked
entities whose data was updated by the layer.

This should fix all issues where dropping something due to event buffer
capacity results in incorrect data. Once we have successfully recorded
the *creation* of a task, resource, or async op, any subsequent updates
to its stats are *guaranteed* to be reliable. If the channel is at
capacity and we fail to record a new resource/task/op, we never create a
stats extension for it, and we won't record anything for it at all.
Otherwise, it will always have correct data recorded.

When possible, the stats in the `Arc`ed stats are updated atomically. In
some cases, this isn't easily possible, and some fields of the stats
types are stored in a mutex. In particualr, this is required for storing
timestamps. I don't really love that, but these mutices should be
contented very infrequently. Stats aren't marked as having unset updates
until after the stats inside the mutices have been updated, so the
aggregator will not try to lock the mutex if the layer is currently
updating it; instead, it will simply be included in the next update once
the layer is no longer touching it. Mutices here will only be contended
when multiple threads are updating a task's stats at the same time,
which should occur very rarely...and in most cases, they *still* won't
have to contend a mutex, since access to most of the mutices are guarded
by an atomic variable for e.g. determining which thread actually was the
last to complete a concurrent poll. The biggest performance downside of
the mutices is probably not actually contention, but the additional heap
allocation required when using `std::sync::Mutex`. However, since we
have conditional `parking_lot` support, parking_lot can be used to avoid
requiring additional allocations.

In the future, it's probably possible to make more of this atomic by
converting timestamps into integers and storing them in atomic
variables. I haven't done this yet because both the protobuf timestamps
and `std::time` timestamps are larger than a single 64-bit number and it
might take a little extra work to ensure we can nicely fit them in an
`AtomicUsize`...but we can probably do that later.

[span extensions]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/registry/struct.SpanRef.html#method.extensions