### PR TITLE
chore(nix): include `RUST_SRC_PATH` in nix-shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -5,15 +5,12 @@ let
 
   env = buildEnv {
     name = "console-env";
-    paths = [ ]
-      ++ lib.optional stdenv.isDarwin libiconv
-      ++ tokio-console.buildInputs
-      ++ tokio-console.nativeBuildInputs;
+    paths = [ ] ++ lib.optional stdenv.isDarwin libiconv
+      ++ tokio-console.buildInputs ++ tokio-console.nativeBuildInputs;
   };
-in
-mkShell {
+in mkShell {
   buildInputs = [ env ];
-
+  RUST_SRC_PATH = "${rust.packages.stable.rustPlatform.rustLibSrc}";
   CARGO_TERM_COLOR = "always";
   RUST_BACKTRACE = "full";
 }


### PR DESCRIPTION
This fixes rust-analyzer not being able to find the source path after
merging #220.

cc @jrobsonchase 