### PR TITLE
refac: move ID rewriting to `console`

### DIFF
--- a/console-api/src/common.rs
+++ b/console-api/src/common.rs
@@ -221,3 +221,9 @@ impl From<Id> for u64 {
 }
 
 impl Copy for Id {}
+
+impl From<tracing_core::span::Id> for Id {
+    fn from(id: tracing_core::span::Id) -> Self {
+        Id { id: id.into_u64() }
+    }
+}


### PR DESCRIPTION
Currently, `console-subscriber` contains a bunch of machinery for
rewriting non-sequential `span::Id`s from `tracing` to sequential IDs
(see #75). Upon thinking about this for a bit, I don't actually
understand why this has to be done on the instrumentation-side. This
seems like extra work that's currently done in the instrumented
application, when it really doesn't have to be.

Instead, the client should be responsible for rewriting `tracing` IDs to
pretty, sequential user-facing IDs. This would have a few advantages:
- it moves some work out of the application, which is always good
- if data is being emitted through an implementation other than
  `console-subscriber`, we will *still* get nicely ordered ids
- this also makes some of the stuff i'm working on in #238 easier

This branch removes ID rewriting from `console-subscriber`, and adds it
to the `console` CLI's `state` module.

Closes #240