### PR TITLE
feat(console): feature-flag `tracing-journald` dependency

### DIFF
--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -35,7 +35,7 @@ futures = "0.3"
 tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
-tracing-journald = "0.2"
+tracing-journald = { version = "0.2", optional = true }
 prost-types = "0.9"
 crossterm = { version = "0.20", features = ["event-stream"] }
 color-eyre = { version = "0.5", features = ["issue-url"] }


### PR DESCRIPTION
`tracing-journald` depends on relatively recent libc APIs that may not
be available on all Linux distros (see #248). Journald support is
primarily used for internal debugging of the `tokio-console` API, so
many users may not need journald support, even if they are on a
compatible Linux distro. Therefore, this commit makes it an
off-by-default optional dependency, so that it can be enabled only when
needed.