### PR TITLE
fix(console): don't make details requests with rewritten IDs

### DIFF
--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -81,6 +81,7 @@ async fn main() -> color_eyre::Result<()> {
                 let _ = update_tx.send(update_kind);
                 match update_kind {
                     UpdateKind::SelectTask(task_id) => {
+                        tracing::info!(task_id, "starting details watch");
                         match conn.watch_details(task_id).await {
                             Ok(stream) => {
                                 tokio::spawn(watch_details_stream(task_id, stream, update_rx.clone(), details_tx.clone()));

--- a/console/src/view/mod.rs
+++ b/console/src/view/mod.rs
@@ -103,7 +103,7 @@ impl View {
                 match event {
                     key!(Enter) => {
                         if let Some(task) = self.tasks_list.selected_item().upgrade() {
-                            update_kind = UpdateKind::SelectTask(task.borrow().id());
+                            update_kind = UpdateKind::SelectTask(task.borrow().span_id());
                             self.state = TaskInstance(self::task::TaskView::new(
                                 task,
                                 state.task_details_ref(),
@@ -123,7 +123,7 @@ impl View {
                 match event {
                     key!(Enter) => {
                         if let Some(res) = self.resources_list.selected_item().upgrade() {
-                            update_kind = UpdateKind::SelectResource(res.borrow().id());
+                            update_kind = UpdateKind::SelectResource(res.borrow().span_id());
                             self.state = ResourceInstance(self::resource::ResourceView::new(res));
                         }
                     }


### PR DESCRIPTION
PR #244 moved the rewriting of `tracing` span IDs to sequential
low-number IDs from the `console-subscriber` crate to the console CLI.
However, this introduced a bug with task details, because that PR didn't
change the part of the console that makes `watch_details` RPCs to use
the `tracing` span ID recieved from the remote --- it continued to use
the `Task` and `Resource` structs' `id` fields. These are now different
from the `tracing` ID recieved from the remote, because they're
rewritten in the console CLI. This means that `watch_details` RPCs would
generally recieve an error, or (in the off-chance that a rewritten ID
collides with a low-numbered `tracing` ID) the details for anoter task
or resource.

This branch fixes the bug by changing the `Task` and `Resource` structs
to store both the span ID received from the remote _and_ the rewritten
pretty ID. This way, when we make `watch_details` RPC calls, we do it
with the span ID we received from the remote process.

I also changed some naming to make the distinction between rewritten IDs
and span IDs clearer.