### PR TITLE
console: fix task lookup in async ops view

### DIFF
--- a/console/src/state/async_ops.rs
+++ b/console/src/state/async_ops.rs
@@ -119,6 +119,9 @@ impl AsyncOpsState {
         self.async_ops.values().map(Rc::downgrade)
     }
 
+    // Clippy warns us that having too many arguments is bad style. In this case, however
+    // it does not make much sense to group any of them.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn update_async_ops(
         &mut self,
         styles: &view::Styles,

--- a/console/src/state/async_ops.rs
+++ b/console/src/state/async_ops.rs
@@ -126,6 +126,7 @@ impl AsyncOpsState {
         metas: &HashMap<u64, Metadata>,
         update: proto::async_ops::AsyncOpUpdate,
         resource_ids: &mut Ids,
+        task_ids: &mut Ids,
         visibility: Visibility,
     ) {
         let mut stats_update = update.stats_update;
@@ -155,8 +156,13 @@ impl AsyncOpsState {
             };
 
             let span_id = async_op.id?.id;
-            let stats =
-                AsyncOpStats::from_proto(stats_update.remove(&span_id)?, meta, styles, strings);
+            let stats = AsyncOpStats::from_proto(
+                stats_update.remove(&span_id)?,
+                meta,
+                styles,
+                strings,
+                task_ids,
+            );
 
             let num = self.ids.id_for(span_id);
             let resource_id = resource_ids.id_for(async_op.resource_id?.id);
@@ -187,7 +193,8 @@ impl AsyncOpsState {
             if let Some(async_op) = self.async_ops.get_mut(&num) {
                 let mut async_op = async_op.borrow_mut();
                 if let Some(meta) = metas.get(&async_op.meta_id) {
-                    async_op.stats = AsyncOpStats::from_proto(stats, meta, styles, strings);
+                    async_op.stats =
+                        AsyncOpStats::from_proto(stats, meta, styles, strings, task_ids);
                 }
             }
         }
@@ -275,6 +282,7 @@ impl AsyncOpStats {
         meta: &Metadata,
         styles: &view::Styles,
         strings: &mut intern::Strings,
+        task_ids: &mut Ids,
     ) -> Self {
         let mut pb = pb;
 
@@ -304,7 +312,7 @@ impl AsyncOpStats {
         let busy = poll_stats.busy_time.map(pb_duration).unwrap_or_default();
         let idle = total.map(|total| total - busy);
         let formatted_attributes = Attribute::make_formatted(styles, &mut attributes);
-        let task_id = pb.task_id.map(|id| id.id);
+        let task_id = pb.task_id.map(|id| task_ids.id_for(id.id));
         let task_id_str = strings.string(
             task_id
                 .as_ref()

--- a/console/src/state/mod.rs
+++ b/console/src/state/mod.rs
@@ -166,6 +166,7 @@ impl State {
                 &self.metas,
                 async_ops_update,
                 &mut self.resources_state.ids,
+                &mut self.tasks_state.ids,
                 visibility,
             )
         }


### PR DESCRIPTION
#244 moved rewriting of ids to the console. We have however forgot to look up
the pretty ID when trying to figure out which task is running a particular async op.
The result of that was that we were displaying the raw ID for the task and we were
not able to properly resolve the name of the task if specified.


Before: 
<img width="838" alt="Screenshot 2022-01-09 at 19 52 27" src="https://user-images.githubusercontent.com/4391506/148694237-1d9b995c-a99a-42d8-865d-2af638524582.png">

After: 
<img width="861" alt="Screenshot 2022-01-09 at 19 53 24" src="https://user-images.githubusercontent.com/4391506/148694247-9af70d61-6b8b-4bca-bdcb-63c1a0a334f9.png">



Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>