### PR TITLE
api: prepare to release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "prost",
  "prost-types",

--- a/console-api/CHANGELOG.md
+++ b/console-api/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="0.1.1"></a>
+## 0.1.1 (2022-01-18)
+
+#### Features
+
+- add `From<tracing_core::span::Id>` for `Id` (#244) ([095b1ef](095b1ef))
+
 <a name="0.1.0"></a>
 ## 0.1.0 (2021-12-16)
 

--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console-api"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 edition = "2021"
 rust-version = "1.56.0"


### PR DESCRIPTION
<a name="0.1.1"></a>
## 0.1.1 (2022-01-18)

#### Features

- add `From<tracing_core::span::Id>` for `Id` (#244) ([095b1ef](095b1ef))

