### PR TITLE
subscriber: prepare to release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "console-api",
  "crossbeam-channel",

--- a/console-subscriber/CHANGELOG.md
+++ b/console-subscriber/CHANGELOG.md
@@ -1,4 +1,18 @@
-<a name="0.1.0"></a>
+<a name="0.1.1"></a>
+## 0.1.1 (2022-01-18)
+
+
+#### Bug Fixes
+
+*  only send *new* tasks/resources/etc over the event channel (#238) ([fdc77e28](fdc77e28))
+*  increased default event buffer capacity (#235) ([0cf0aee](0cf0aee))
+*  use saturating arithmetic for attribute updates (#234) ([fe82e170](fe82e170))
+
+#### Changes
+
+*  moved ID rewriting from `console-subscriber` to the client (#244) ([095b1ef](095b1ef))
+
 ## 0.1.0 (2021-12-16)
+
 
 - Initial release! &#x1f389;

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console-subscriber"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 edition = "2021"
 rust-version = "1.56.0"
@@ -33,7 +33,7 @@ parking_lot = ["parking_lot_crate", "tracing-subscriber/parking_lot"]
 tokio = { version = "^1.15", features = ["sync", "time", "macros", "tracing"] }
 tokio-stream = "0.1"
 thread_local = "1.1.3"
-console-api = { version = "0.1.0", path = "../console-api", features = ["transport"] }
+console-api = { version = "0.1.1", path = "../console-api", features = ["transport"] }
 tonic = { version = "0.6", features = ["transport"] }
 tracing-core = "0.1.18"
 tracing = "0.1.26"


### PR DESCRIPTION
<a name="0.1.1"></a>
## 0.1.1 (2022-01-18)

#### Bug Fixes

*  only send *new* tasks/resources/etc over the event channel (#238) ([fdc77e28](fdc77e28))
*  increased default event buffer capacity (#235) ([0cf0aee](0cf0aee))
*  use saturating arithmetic for attribute updates (#234) ([fe82e170](fe82e170))

#### Changes

*  moved ID rewriting from `console-subscriber` to the client (#244) ([095b1ef](095b1ef))