### PR TITLE
console: prepare to release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-console"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "atty",
  "clap",

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-console"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 repository = "https://github.com/tokio-rs/console"
 edition = "2021"
@@ -27,7 +27,7 @@ keywords = [
 
 [dependencies]
 atty = "0.2"
-console-api = { version = "0.1.0", path = "../console-api", features = ["transport"] }
+console-api = { version = "0.1.1", path = "../console-api", features = ["transport"] }
 clap = { version = "3", features = ["cargo", "derive", "env"] }
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.6", features = ["transport"] }


### PR DESCRIPTION
<a name=""></a>
##  (2022-01-18)

#### Features

*  feature-flag `tracing-journald` dependency (#250) ([24f25dbd](24f25dbd))
*  add vi style keybinds for tables (#223) ([1845c998](1845c998))

#### Bug Fixes

*  fix task lookup in async ops view (#257) ([9a50b630](9a50b630))
*  don't make details requests with rewritten IDs (#251) ([4ec26a8d](4ec26a8d))
*  fix build error with journald enabled ([a931b7ec](a931b7ec))
*  increase default event buffer capacity a bit (#235) ([0cf0aee3](0cf0aee3))
*  wrap controls line when the terminal is too narrow (#231) ([ef415072](ef415072))
*  don't enable crossterm mouse capture (#222) ([e020d66c](e020d66c), closes [#167](167))