### PR TITLE
Fix histogram display

### DIFF
--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -215,7 +215,7 @@ impl State {
     pub(crate) fn update_task_details(&mut self, update: proto::tasks::TaskDetails) {
         if let Some(id) = update.task_id {
             let details = Details {
-                task_id: id.id,
+                span_id: id.id,
                 poll_times_histogram: update.poll_times_histogram.and_then(|data| {
                     hdrhistogram::serialization::Deserializer::new()
                         .deserialize(&mut Cursor::new(&data))

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -26,7 +26,7 @@ pub(crate) struct TasksState {
 
 #[derive(Debug, Default)]
 pub(crate) struct Details {
-    pub(crate) task_id: u64,
+    pub(crate) span_id: u64,
     pub(crate) poll_times_histogram: Option<Histogram<u64>>,
 }
 
@@ -223,8 +223,8 @@ impl TasksState {
 }
 
 impl Details {
-    pub(crate) fn task_id(&self) -> u64 {
-        self.task_id
+    pub(crate) fn span_id(&self) -> u64 {
+        self.span_id
     }
 
     pub(crate) fn poll_times_histogram(&self) -> Option<&Histogram<u64>> {

--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -52,7 +52,7 @@ impl TaskView {
         let details_ref = self.details.borrow();
         let details = details_ref
             .as_ref()
-            .filter(|details| details.task_id() == task.id());
+            .filter(|details| details.span_id() == task.span_id());
 
         let warnings: Vec<_> = task
             .warnings()


### PR DESCRIPTION
Task `Details` are tracked by the remote's `span::Id` while the
`Task::id()` is the friendly id.

The comparison in the view is changed to use the remote span ids and the
field in `Details` is renamed to match.

Fixes: #262