### PR TITLE
Reword comment on the tracing_core::metadata::Kind match

### DIFF
--- a/console-api/src/common.rs
+++ b/console-api/src/common.rs
@@ -17,16 +17,16 @@ impl From<tracing_core::Level> for metadata::Level {
 
 impl From<tracing_core::metadata::Kind> for metadata::Kind {
     fn from(kind: tracing_core::metadata::Kind) -> Self {
-        // /!\ Note that this is intentionally *not* an exhaustive match. the
-        // `metadata::Kind` struct in `tracing_core` is not intended to be
-        // exhaustively matched, but compiler changes made past versions of it
-        // capable of being matched exhaustively, which was never intended.
+        // /!\ Note that this is intentionally *not* implemented using match.
+        // The `metadata::Kind` struct in `tracing_core` was written not
+        // intending to allow exhaustive matches, but accidentally did.
         //
-        // Therefore, we cannot write a match with both variants without a
-        // wildcard arm. However, on versions of `tracing_core` where the
-        // compiler believes the type to be exhaustive, a wildcard arm will
-        // result in a warning. Thus, we must write this rather tortured-looking
-        // `if` statement, to get non-exhaustive matching behavior.
+        // Therefore, we shouldn't be able to write a match against both
+        // variants without a wildcard arm. However, on versions of
+        // `tracing_core` where the type was exhaustively matchable, a wildcard
+        // arm will result in a warning. Thus we must write this rather
+        // tortured-looking `if` statement to get non-exhaustive matching
+        // behavior.
         if kind == tracing_core::metadata::Kind::SPAN {
             metadata::Kind::Span
         } else {


### PR DESCRIPTION
I don't think it's accurate that a compiler change made this exhaustively matchable when it wasn't before. All versions of rustc since 1.0.0 have allowed exhaustively matching on that kind of data structure from outside of the defining crate.