### PR TITLE
api: prepare to release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "prost",
  "prost-types",

--- a/console-api/CHANGELOG.md
+++ b/console-api/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="0.1.2"></a>
+## 0.1.2 (2022-02-04)
+
+#### Bug Fixes
+
+
+* fix accidental exhaustive matching on `metadata::Kind` (#271)
+  ([d9aafaa0](d9aafaa0), closes [#270](270))
+
 <a name="0.1.1"></a>
 ## 0.1.1 (2022-01-18)
 

--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console-api"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 edition = "2021"
 rust-version = "1.56.0"


### PR DESCRIPTION
<a name="0.1.2"></a>
## 0.1.2 (2022-02-04)

#### Bug Fixes

* fix accidental exhaustive matching on `metadata::Kind` (#271)
  ([d9aafaa0](d9aafaa0), closes [#270](270))