### PR TITLE
fix: console-api dependencies to require 0.1.2

### DIFF
--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -33,7 +33,7 @@ parking_lot = ["parking_lot_crate", "tracing-subscriber/parking_lot"]
 tokio = { version = "^1.15", features = ["sync", "time", "macros", "tracing"] }
 tokio-stream = "0.1"
 thread_local = "1.1.3"
-console-api = { version = "0.1.1", path = "../console-api", features = ["transport"] }
+console-api = { version = "0.1.2", path = "../console-api", features = ["transport"] }
 tonic = { version = "0.6", features = ["transport"] }
 tracing-core = "0.1.18"
 tracing = "0.1.26"

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -27,7 +27,7 @@ keywords = [
 
 [dependencies]
 atty = "0.2"
-console-api = { version = "0.1.1", path = "../console-api", features = ["transport"] }
+console-api = { version = "0.1.2", path = "../console-api", features = ["transport"] }
 clap = { version = "3", features = ["cargo", "derive", "env"] }
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.6", features = ["transport"] }


### PR DESCRIPTION
This should ensure we don't see any compilation errors.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>