### PR TITLE
subscriber: prepare to release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "console-api",
  "crossbeam-channel",

--- a/console-subscriber/CHANGELOG.md
+++ b/console-subscriber/CHANGELOG.md
@@ -1,3 +1,23 @@
+<a name="0.1.2"></a>
+## 0.1.2 (2022-01-18)
+
+
+#### Bug Fixes
+
+*  update console-api dependencies to require 0.1.2 (#274) ([b95f683f](b95f683f))
+
+
+<a name="0.1.1"></a>
+## 0.1.1 (2022-01-18)
+
+
+#### Bug Fixes
+
+*  only send *new* tasks/resources/etc over the event channel (#238) ([fdc77e28](fdc77e28))
+*  increased default event buffer capacity (#235) ([0cf0aee](0cf0aee))
+*  use saturating arithmetic for attribute updates (#234) ([fe82e170](fe82e170))
+
+
 <a name="0.1.1"></a>
 ## 0.1.1 (2022-01-18)
 

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console-subscriber"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 edition = "2021"
 rust-version = "1.56.0"


### PR DESCRIPTION
<a name="0.1.2"></a>
## 0.1.2 (2022-01-18)

#### Bug Fixes

*  update console-api dependencies to require 0.1.2 (#274) ([b95f683f](b95f683f))