### PR TITLE
chore(console): fix homepage URL in cargo metadata

### DIFF
--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust-version = "1.56.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>",]
 readme = "README.md"
-homepage = "https://github.com/tokio-rs/console/blob/main/console"
+homepage = "https://github.com/tokio-rs/console/tree/main/tokio-console" 
 description = """
 The Tokio console: a debugger for async Rust.
 """


### PR DESCRIPTION
The `tokio-console` crate's `homepage` URL was incorrect after the crate
was moved from a directory named `console` to one named `tokio-console`,
which results in a 404 error when following the "homepage" link on
crates.io.

This commit fixes that.

Fixes #280