### PR TITLE
add information on where to put .cargo/config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,15 @@ notes:
   ```shell
   $ RUSTFLAGS="--cfg tokio_unstable" cargo build
   ```
-  or add the following to your `.cargo/config` file:
+  or add the following to your `.cargo/config.toml` file:
   ```toml
   [build]
   rustflags = ["--cfg", "tokio_unstable"]
   ```
+
+  For more information on the appropriate location of your `.cargo/config.toml` file,
+  especially when using workspaces, see the
+  [console-subscriber readme](console-subscriber/README.md#enabling-tokio-instrumentation).
 * the `tokio` and `runtime` [`tracing` targets] must be enabled at the [`TRACE`
   level].
 

--- a/console-subscriber/README.md
+++ b/console-subscriber/README.md
@@ -71,11 +71,23 @@ runtime][Tokio] is considered *experimental*. In order to use
   ```shell
   $ RUSTFLAGS="--cfg tokio_unstable" cargo build
   ```
-  or, by adding the following to the `.cargo/config` file in a Cargo workspace:
+  or, by adding the following to the `.cargo/config.toml` file in a Cargo workspace:
   ```toml
   [build]
   rustflags = ["--cfg", "tokio_unstable"]
   ```
+  If you're using a workspace, you should put the `.cargo/config.toml` file in the root of your workspace.
+  Otherwise, put the `.cargo/config.toml` file in the root directory of your crate.
+  
+  Putting `.cargo/config.toml` files below the workspace or crate root directory may lead to tools like
+  Rust-Analyzer or VSCode not using your `.cargo/config.toml` since they invoke cargo from
+  the workspace or crate root and cargo only looks for the `.cargo` directory in the current & parent directories.
+  Cargo ignores configurations in child directories.
+  More information about where cargo looks for configuration files can be found
+  [here](https://doc.rust-lang.org/cargo/reference/config.html).
+
+  Missing this configuration file during compilation will cause tokio-console to not work, and alternating
+  between building with and without this configuration file included will cause full rebuilds of your project.
 ### Adding the Console Subscriber
 
 If the runtime emits compatible `tracing` events, enabling the console is as


### PR DESCRIPTION
I ran into an issue where putting my .cargo/config.toml with the tokio_unstable rustflag in the sub-project of my workspace where I needed to use tokio-console led to full rebuilds on every cargo build invocation.

This was caused by rust-analyzer invoking its cargo commands in the workspace root independent of the directory where the editor (e.g. nvim) is launched from. This led to rust-analyzer not to use the cargo config, while my manual cargo build invocations did use the config, hence requiring full rebuilds on every run.

This documentation informs new users of this pitfall.

If this documentation is found to be a little on the long side, I can try to move part of this warning into the cargo documentation, which I'm linking to anyways.