### PR TITLE
docs: fix broken links in READMEs and subscriber doc comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,4 +248,4 @@ cargo run --example $name
 [build]: https://tokio-console.netlify.app/console_subscriber/fn.build.html
 [init]: https://tokio-console.netlify.app/console_subscriber/fn.init.html
 [`EnvFilter`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html
-[`Targets`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.Targets.html
+[`Targets`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html

--- a/console-subscriber/README.md
+++ b/console-subscriber/README.md
@@ -128,9 +128,9 @@ tracing_subscriber::registry()
 [`tracing`]: https://crates.io/crates/tracing
 [`tracing-subscriber`]: https://crates.io/crates/tracing-subscriber
 [`Layer`]:https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/layer/index.html
-[default]: https://docs.rs/tracing/latest/0.1/dispatcher/index.html#setting-the-default-subscriber
-[env]: https://docs.rs/console-subscriber/0.1/console-subscriber/struct.builder#method.with_default_env
-[builder]: https://docs.rs/console-subscriber/0.1/console-subscriber/struct.builder
+[default]: https://docs.rs/tracing/latest/tracing/#in-executables
+[env]: https://docs.rs/console-subscriber/latest/console_subscriber/struct.Builder.html#method.with_default_env
+[builder]: https://docs.rs/console-subscriber/latest/console_subscriber/struct.Builder.html
 [`tokio-console`]: https://github.com/tokio-rs/console
 [Tokio]: https://tokio.rs
 

--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -270,7 +270,7 @@ impl Builder {
     /// additional [`Layer`]s to be added.
     ///
     /// [subscriber]: https://docs.rs/tracing/latest/tracing/subscriber/trait.Subscriber.html
-    /// [filter]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.Targets.html
+    /// [filter]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html
     /// [`Layer`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
     /// [`Server`]: crate::Server
     ///
@@ -444,7 +444,7 @@ pub fn init() {
 /// # use tracing_subscriber::prelude::*;
 /// # tracing_subscriber::registry().with(layer).init(); // to suppress must_use warnings
 /// ```
-/// [filter]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.Targets.html
+/// [filter]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html
 /// [`Layer`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
 /// [`Server`]: crate::Server
 ///


### PR DESCRIPTION
Documentation about setting the default subscriber in tracing and the
builder interface for console-subscriber moved, resulting in a few
broken links. Updates those links to their current locations.