### PR TITLE
docs: document minimum Tokio versions

### DIFF
--- a/console-subscriber/README.md
+++ b/console-subscriber/README.md
@@ -114,7 +114,7 @@ Other instrumentation is added in later Tokio releases:
   as `Mutex`es, `RwLock`s, `Semaphore`s, `oneshot` channels, `mpsc` channels, et
   cetera. 
      
-[Tokio v1.0.0]:
+[Tokio v1.0.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.0.0
 [Tokio v1.7.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.7.0
 [Tokio v1.12.0]:https://github.com/tokio-rs/tokio/releases/tag/tokio-1.12.0
 [`Runtime::block_on`]: https://docs.rs/tokio/1/tokio/runtime/struct.Runtime.html#method.block_on

--- a/console-subscriber/README.md
+++ b/console-subscriber/README.md
@@ -87,7 +87,43 @@ runtime][Tokio] is considered *experimental*. In order to use
   [here](https://doc.rust-lang.org/cargo/reference/config.html).
 
   Missing this configuration file during compilation will cause tokio-console to not work, and alternating
-  between building with and without this configuration file included will cause full rebuilds of your project.
+  between building with and without this configuration file included will cause
+  full rebuilds of your project.
+  
+#### Required Tokio Versions
+
+Because instrumentation for different aspects of the runtime is being added to
+Tokio over time, the latest Tokio release is generally *recommended* to access all of
+the console's functionality. However, it should generally be compatible with
+earlier Tokio versions, although some information may not be available. A
+minimum version of [Tokio v1.0.0] or later is required to use the console's
+task instrumentation. 
+
+Other instrumentation is added in later Tokio releases:
+
+* [Tokio v1.7.0] or later is required to record task waker instrumentation (such
+  as waker counts, clones, drops, et cetera).
+
+* [Tokio v1.12.0] or later is required to record tasks created by the
+  [`Runtime::block_on`] and [`Handle::block_on`] methods.
+
+* [Tokio v1.13.0] or later is required to track [`tokio::time`] resources, such
+  as `sleep` and `Interval`.
+
+* [Tokio v1.15.0] or later is required to track [`tokio::sync`] resources, such
+  as `Mutex`es, `RwLock`s, `Semaphore`s, `oneshot` channels, `mpsc` channels, et
+  cetera. 
+     
+[Tokio v1.0.0]:
+[Tokio v1.7.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.7.0
+[Tokio v1.12.0]:https://github.com/tokio-rs/tokio/releases/tag/tokio-1.12.0
+[`Runtime::block_on`]: https://docs.rs/tokio/1/tokio/runtime/struct.Runtime.html#method.block_on
+[`Handle::block_on`]: https://docs.rs/tokio/1/tokio/runtime/struct.Handle.html#method.block_on
+[Tokio v1.13.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.13.0
+[`tokio::time`]: https://docs.rs/tokio/1/tokio/time/index.html
+[Tokio v1.15.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.13.0
+[`tokio::sync`]: https://docs.rs/tokio/1/tokio/sync/index.html
+
 ### Adding the Console Subscriber
 
 If the runtime emits compatible `tracing` events, enabling the console is as

--- a/tokio-console/README.md
+++ b/tokio-console/README.md
@@ -64,7 +64,7 @@ use the [Tokio] runtime, this means that:
   See [the `console-subscriber` documentation][versions] for details.
  
 [`tracing`]: https://crates.io/crates/tracing
-[unstable features]: https://docs.rs/console-subscriber/0.1/console_subscriber/#enabling-tokio-instrumentation
+[unstable]: https://docs.rs/console-subscriber/0.1/console_subscriber/#enabling-tokio-instrumentation
 [versions]: https://docs.rs/console-subscriber/0.1/console_subscriber/#required-tokio-versions
 
 ### Using the Console

--- a/tokio-console/README.md
+++ b/tokio-console/README.md
@@ -44,9 +44,30 @@ application that provides an interactive debugging interface.
 [subscriber]: https://crates.io/crates/console-subscriber
 ## Getting Started
 
-To use the console CLI to debug an asynchronous application, the application
-must first be instrumented to record `tokio-console` telemetry. The easiest way
-to do this is [using the `console-subscriber` crate][subscriber].
+To use the console to monitor and debug a program, it must be instrumented to
+emit the data the console consumes. Then, the `tokio-console` CLI application
+can be used to connect to the application and monitor its operation.
+### Instrumenting the Application
+
+Before the console can connect to an application, it must first be instrumented
+to record `tokio-console` telemetry. The easiest way  to do this is [using the
+`console-subscriber` crate][subscriber].
+
+`console-subscriber` requires that the application's async runtime (or runtimes)
+emit [`tracing`] data in a format that the console can record. For programs that
+use the [Tokio] runtime, this means that:
+
+- Tokio's [unstable features][unstable] must be enabled. See [the `console-subscriber`
+  documentation][unstable] for details.
+- A [compatible Tokio version][versions] must be used. Tokio v1.0 or greater is required
+  to use the console, and some features are only available in later versions.
+  See [the `console-subscriber` documentation][versions] for details.
+ 
+[`tracing`]: https://crates.io/crates/tracing
+[unstable features]: https://docs.rs/console-subscriber/0.1/console_subscriber/#enabling-tokio-instrumentation
+[versions]: https://docs.rs/console-subscriber/0.1/console_subscriber/#required-tokio-versions
+
+### Using the Console
 
 Once the application is instrumented, install the console CLI using
 


### PR DESCRIPTION
This branch adds documentation to the `console-subscriber` _and_
`tokio-console` READMEs and RustDoc explaining the minimum Tokio
versions required by the console. Since instrumentation for different
aspects of the runtime has been added over time, this isn't as simple as
"the console requires version x.y.z or later"; instead, we provide a
list of which console features require which Tokio versions. The console
should be capable of at least limited operation with any Tokio version
>= 1.0, but some data will not be available (such as wakers, resource
>instrumentation, etc).

Closes #281