### PR TITLE
chore(subscriber): prepare to release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "console-api",
  "crossbeam-channel",

--- a/console-subscriber/CHANGELOG.md
+++ b/console-subscriber/CHANGELOG.md
@@ -1,3 +1,19 @@
+<a name="0.1.3"></a>
+## 0.1.3  (2022-02-18)
+
+
+#### Features
+
+*  add `Builder::filter_env_var` builder parameter (#276) ([dbdb1494](dbdb1494), closes [#206](206))
+
+#### Bug Fixes
+
+*  record timestamps for updates last (#289) ([703f1aa4](703f1aa4), closes [#266](266))
+*  use monotonic `Instant`s for all timestamps (#288) ([abc08300](abc08300), closes [#286](286))
+*  bail rather than panic when encountering clock skew (#287) ([24db8c60](24db8c60), closes [#286](286))
+*  fix compilation on targets without 64-bit atomics (#282) ([5590fdbc](5590fdbc), closes [#279](279))
+
+  
 <a name="0.1.2"></a>
 ## 0.1.2 (2022-01-18)
 

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console-subscriber"
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT"
 edition = "2021"
 rust-version = "1.56.0"


### PR DESCRIPTION
#### Features

*  add `Builder::filter_env_var` builder parameter (#276)
   ([dbdb1494](dbdb1494), closes [#206](206))

#### Bug Fixes

*  record timestamps for updates last (#289) ([703f1aa4](703f1aa4),
   closes [#266](266))
*  use monotonic `Instant`s for all timestamps (#288)
   ([abc08300](abc08300), closes [#286](286))
*  bail rather than panic when encountering clock skew (#287)
   ([24db8c60](24db8c60), closes [#286](286))
*  fix compilation on targets without 64-bit atomics (#282)
   ([5590fdbc](5590fdbc), closes [#279](279))