### PR TITLE
chore(console): prepare to release v0.1.2

### DIFF
--- a/tokio-console/CHANGELOG.md
+++ b/tokio-console/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.1.2"></a>
+## 0.1.2 (2022-02-18)
+
+
+#### Bug Fixes
+
+*  console-api dependencies to require 0.1.2 (#274) ([b95f683f](b95f683f), closes [#270](270))
+*  missing histogram in task details (#296) ([884f4eca](884f4eca), closes [#296](296))
+
+  
 <a name="0.1.1"></a>
 ## 0.1.1 (2022-01-18)
 

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-console"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 repository = "https://github.com/tokio-rs/console"
 edition = "2021"


### PR DESCRIPTION
<a name="0.1.2"></a>
## 0.1.2 (2022-02-18)

#### Bug Fixes

*  console-api dependencies to require 0.1.2 (#274) ([b95f683f](b95f683f), closes [#270](270))
*  missing histogram in task details (#296) ([884f4eca](884f4eca), closes [#296](296))