### PR TITLE
chore(subscriber): rm duplicate changelog entries

### DIFF
--- a/console-subscriber/CHANGELOG.md
+++ b/console-subscriber/CHANGELOG.md
@@ -33,17 +33,6 @@
 *  increased default event buffer capacity (#235) ([0cf0aee](0cf0aee))
 *  use saturating arithmetic for attribute updates (#234) ([fe82e170](fe82e170))
 
-
-<a name="0.1.1"></a>
-## 0.1.1 (2022-01-18)
-
-
-#### Bug Fixes
-
-*  only send *new* tasks/resources/etc over the event channel (#238) ([fdc77e28](fdc77e28))
-*  increased default event buffer capacity (#235) ([0cf0aee](0cf0aee))
-*  use saturating arithmetic for attribute updates (#234) ([fe82e170](fe82e170))
-
 #### Changes
 
 *  moved ID rewriting from `console-subscriber` to the client (#244) ([095b1ef](095b1ef))


### PR DESCRIPTION
The `console-subscriber` changelog somehow ended up with two entries
for v0.1.1. This caused the automatic release publishing action to get
confused.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>