### PR TITLE
fix(console): prevent panics if subscriber reports out-of-order times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-console"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "atty",
  "clap",

--- a/tokio-console/src/state/async_ops.rs
+++ b/tokio-console/src/state/async_ops.rs
@@ -245,11 +245,10 @@ impl AsyncOp {
     }
 
     pub(crate) fn total(&self, since: SystemTime) -> Duration {
-        self.stats.total.unwrap_or_else(|| {
-            since
-                .duration_since(self.stats.created_at)
-                .unwrap_or_default()
-        })
+        self.stats
+            .total
+            .or_else(|| since.duration_since(self.stats.created_at).ok())
+            .unwrap_or_default()
     }
 
     pub(crate) fn busy(&self, since: SystemTime) -> Duration {
@@ -263,11 +262,10 @@ impl AsyncOp {
     }
 
     pub(crate) fn idle(&self, since: SystemTime) -> Duration {
-        self.stats.idle.unwrap_or_else(|| {
-            self.total(since)
-                .checked_sub(self.busy(since))
-                .unwrap_or_default()
-        })
+        self.stats
+            .idle
+            .or_else(|| self.total(since).checked_sub(self.busy(since)))
+            .unwrap_or_default()
     }
 
     pub(crate) fn total_polls(&self) -> u64 {

--- a/tokio-console/src/state/resources.rs
+++ b/tokio-console/src/state/resources.rs
@@ -246,7 +246,7 @@ impl ResourcesState {
                 .stats
                 .dropped_at
                 .map(|d| {
-                    let dropped_for = now.duration_since(d).unwrap();
+                    let dropped_for = now.duration_since(d).unwrap_or_default();
                     retain_for > dropped_for
                 })
                 .unwrap_or(true)
@@ -296,9 +296,11 @@ impl Resource {
     }
 
     pub(crate) fn total(&self, since: SystemTime) -> Duration {
-        self.stats
-            .total
-            .unwrap_or_else(|| since.duration_since(self.stats.created_at).unwrap())
+        self.stats.total.unwrap_or_else(|| {
+            since
+                .duration_since(self.stats.created_at)
+                .unwrap_or_default()
+        })
     }
 
     pub(crate) fn dropped(&self) -> bool {
@@ -338,7 +340,7 @@ impl ResourceStats {
             .try_into()
             .unwrap();
         let dropped_at: Option<SystemTime> = pb.dropped_at.map(|v| v.try_into().unwrap());
-        let total = dropped_at.map(|d| d.duration_since(created_at).unwrap());
+        let total = dropped_at.map(|d| d.duration_since(created_at).unwrap_or_default());
 
         Self {
             created_at,

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -206,7 +206,7 @@ impl TasksState {
             task.stats
                 .dropped_at
                 .map(|d| {
-                    let dropped_for = now.duration_since(d).unwrap();
+                    let dropped_for = now.duration_since(d).unwrap_or_default();
                     retain_for > dropped_for
                 })
                 .unwrap_or(true)
@@ -279,9 +279,11 @@ impl Task {
     }
 
     pub(crate) fn total(&self, since: SystemTime) -> Duration {
-        self.stats
-            .total
-            .unwrap_or_else(|| since.duration_since(self.stats.created_at).unwrap())
+        self.stats.total.unwrap_or_else(|| {
+            since
+                .duration_since(self.stats.created_at)
+                .unwrap_or_default()
+        })
     }
 
     pub(crate) fn busy(&self, since: SystemTime) -> Duration {
@@ -289,16 +291,18 @@ impl Task {
             (self.stats.last_poll_started, self.stats.last_poll_ended)
         {
             // in this case the task is being polled at the moment
-            let current_time_in_poll = since.duration_since(last_poll_started).unwrap();
+            let current_time_in_poll = since.duration_since(last_poll_started).unwrap_or_default();
             return self.stats.busy + current_time_in_poll;
         }
         self.stats.busy
     }
 
     pub(crate) fn idle(&self, since: SystemTime) -> Duration {
-        self.stats
-            .idle
-            .unwrap_or_else(|| self.total(since) - self.busy(since))
+        self.stats.idle.unwrap_or_else(|| {
+            self.total(since)
+                .checked_sub(self.busy(since))
+                .unwrap_or_default()
+        })
     }
 
     /// Returns the total number of times the task has been polled.
@@ -388,11 +392,11 @@ impl From<proto::tasks::Stats> for TaskStats {
             .unwrap();
 
         let dropped_at: Option<SystemTime> = pb.dropped_at.map(|v| v.try_into().unwrap());
-        let total = dropped_at.map(|d| d.duration_since(created_at).unwrap());
+        let total = dropped_at.map(|d| d.duration_since(created_at).unwrap_or_default());
 
         let poll_stats = pb.poll_stats.expect("task should have poll stats");
         let busy = poll_stats.busy_time.map(pb_duration).unwrap_or_default();
-        let idle = total.map(|total| total - busy);
+        let idle = total.map(|total| total.checked_sub(busy).unwrap_or_default());
         Self {
             total,
             idle,

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -279,11 +279,10 @@ impl Task {
     }
 
     pub(crate) fn total(&self, since: SystemTime) -> Duration {
-        self.stats.total.unwrap_or_else(|| {
-            since
-                .duration_since(self.stats.created_at)
-                .unwrap_or_default()
-        })
+        self.stats
+            .total
+            .or_else(|| since.duration_since(self.stats.created_at).ok())
+            .unwrap_or_default()
     }
 
     pub(crate) fn busy(&self, since: SystemTime) -> Duration {
@@ -298,11 +297,10 @@ impl Task {
     }
 
     pub(crate) fn idle(&self, since: SystemTime) -> Duration {
-        self.stats.idle.unwrap_or_else(|| {
-            self.total(since)
-                .checked_sub(self.busy(since))
-                .unwrap_or_default()
-        })
+        self.stats
+            .idle
+            .or_else(|| self.total(since).checked_sub(self.busy(since)))
+            .unwrap_or_default()
     }
 
     /// Returns the total number of times the task has been polled.


### PR DESCRIPTION
Changes duration_since and unchecked subtractions to assume
Duration::ZERO (via Default) if the alternative would be a crash.

If the subscriber reports nonsensical data this can result in negative
Durations in console's calculations, leading to panics. This has already
happened inadvertently. All changed code relates directly to received
protobuf data whose validity isn't guaranteed.

Relates to #266 (crash) and #289 (fix for root cause)

---

There are a handful of other unwraps/expects I'm not so sure about. These ones looked like pretty clear-cut cases where panicking is possible, undesirable, and clamping to zero is a reasonable response.