### PR TITLE
feat(console): Add icon that sorting state

### DIFF
--- a/tokio-console/src/view/mod.rs
+++ b/tokio-console/src/view/mod.rs
@@ -33,8 +33,8 @@ pub struct View {
     /// details view), we want to leave the task list's state the way we left it
     /// --- e.g., if the user previously selected a particular sorting, we want
     /// it to remain sorted that way when we return to it.
-    tasks_list: TableListState<TasksTable>,
-    resources_list: TableListState<ResourcesTable>,
+    tasks_list: TableListState<TasksTable, 11>,
+    resources_list: TableListState<ResourcesTable, 9>,
     state: ViewState,
     pub(crate) styles: Styles,
 }
@@ -87,8 +87,8 @@ impl View {
     pub fn new(styles: Styles) -> Self {
         Self {
             state: ViewState::TasksList,
-            tasks_list: TableListState::<TasksTable>::default(),
-            resources_list: TableListState::<ResourcesTable>::default(),
+            tasks_list: TableListState::<TasksTable, 11>::default(),
+            resources_list: TableListState::<ResourcesTable, 9>::default(),
             styles,
         }
     }

--- a/tokio-console/src/view/mod.rs
+++ b/tokio-console/src/view/mod.rs
@@ -228,4 +228,8 @@ impl Width {
     pub(crate) fn chars(&self) -> u16 {
         self.curr
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.curr as usize
+    }
 }

--- a/tokio-console/src/view/mod.rs
+++ b/tokio-console/src/view/mod.rs
@@ -228,8 +228,4 @@ impl Width {
     pub(crate) fn chars(&self) -> u16 {
         self.curr
     }
-
-    pub(crate) fn len(&self) -> usize {
-        self.curr as usize
-    }
 }

--- a/tokio-console/src/view/resource.rs
+++ b/tokio-console/src/view/resource.rs
@@ -17,7 +17,7 @@ use tui::{
 
 pub(crate) struct ResourceView {
     resource: Rc<RefCell<Resource>>,
-    async_ops_table: TableListState<AsyncOpsTable>,
+    async_ops_table: TableListState<AsyncOpsTable, 9>,
     initial_render: bool,
 }
 
@@ -25,7 +25,7 @@ impl ResourceView {
     pub(super) fn new(resource: Rc<RefCell<Resource>>) -> Self {
         ResourceView {
             resource,
-            async_ops_table: TableListState::<AsyncOpsTable>::default(),
+            async_ops_table: TableListState::<AsyncOpsTable, 9>::default(),
             initial_render: true,
         }
     }

--- a/tokio-console/src/view/resources.rs
+++ b/tokio-console/src/view/resources.rs
@@ -20,12 +20,12 @@ use tui::{
 #[derive(Debug, Default)]
 pub(crate) struct ResourcesTable {}
 
-impl TableList for ResourcesTable {
+impl TableList<9> for ResourcesTable {
     type Row = Resource;
     type Sort = SortBy;
     type Context = ();
 
-    const HEADER: &'static [&'static str] = &[
+    const HEADER: &'static [&'static str; 9] = &[
         "ID",
         "Parent",
         "Kind",
@@ -37,8 +37,20 @@ impl TableList for ResourcesTable {
         "Attributes",
     ];
 
+    const WIDTHS: &'static [usize; 9] = &[
+        Self::HEADER[0].len() + 1,
+        Self::HEADER[1].len() + 1,
+        Self::HEADER[2].len() + 1,
+        Self::HEADER[3].len() + 1,
+        Self::HEADER[4].len() + 1,
+        Self::HEADER[5].len() + 1,
+        Self::HEADER[6].len() + 1,
+        Self::HEADER[7].len() + 1,
+        Self::HEADER[8].len() + 1,
+    ];
+
     fn render<B: tui::backend::Backend>(
-        table_list_state: &mut TableListState<Self>,
+        table_list_state: &mut TableListState<Self, 9>,
         styles: &view::Styles,
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
@@ -59,15 +71,15 @@ impl TableList for ResourcesTable {
             .sort_by
             .sort(now, &mut table_list_state.sorted_items);
 
-        let viz_len: u16 = Self::HEADER[6].len() as u16;
+        let viz_len: u16 = Self::WIDTHS[6] as u16;
 
-        let mut id_width = view::Width::new(Self::HEADER[0].len() as u16);
-        let mut parent_width = view::Width::new(Self::HEADER[1].len() as u16);
+        let mut id_width = view::Width::new(Self::WIDTHS[0] as u16);
+        let mut parent_width = view::Width::new(Self::WIDTHS[1] as u16);
 
-        let mut kind_width = view::Width::new(Self::HEADER[2].len() as u16);
-        let mut target_width = view::Width::new(Self::HEADER[4].len() as u16);
-        let mut type_width = view::Width::new(Self::HEADER[5].len() as u16);
-        let mut location_width = view::Width::new(Self::HEADER[7].len() as u16);
+        let mut kind_width = view::Width::new(Self::WIDTHS[2] as u16);
+        let mut target_width = view::Width::new(Self::WIDTHS[4] as u16);
+        let mut type_width = view::Width::new(Self::WIDTHS[5] as u16);
+        let mut location_width = view::Width::new(Self::WIDTHS[7] as u16);
 
         let rows = {
             let id_width = &mut id_width;
@@ -120,22 +132,22 @@ impl TableList for ResourcesTable {
                 })
         };
 
-        let (selected_style, header_style) = if let Some(cyan) = styles.color(Color::Cyan) {
-            (Style::default().fg(cyan), Style::default())
+        let header_style = if styles.color(Color::Cyan).is_some() {
+            Style::default()
         } else {
-            (
-                Style::default().remove_modifier(style::Modifier::REVERSED),
-                Style::default().add_modifier(style::Modifier::REVERSED),
-            )
+            Style::default().add_modifier(style::Modifier::REVERSED)
         };
         let header_style = header_style.add_modifier(style::Modifier::BOLD);
 
         let header = Row::new(Self::HEADER.iter().enumerate().map(|(idx, &value)| {
-            let cell = Cell::from(value);
             if idx == table_list_state.selected_column {
-                cell.style(selected_style)
+                if table_list_state.sort_descending {
+                    Cell::from(styles.ascending(value))
+                } else {
+                    Cell::from(styles.descending(value))
+                }
             } else {
-                cell
+                Cell::from(value)
             }
         }))
         .height(1)

--- a/tokio-console/src/view/styles.rs
+++ b/tokio-console/src/view/styles.rs
@@ -127,7 +127,7 @@ impl Styles {
         )
     }
 
-    pub fn selected<'a>(&self, value: &str) -> Span<'static> {
+    pub fn selected(&self, value: &str) -> Span<'static> {
         let style = if let Some(cyan) = self.color(Color::Cyan) {
             Style::default().fg(cyan)
         } else {

--- a/tokio-console/src/view/styles.rs
+++ b/tokio-console/src/view/styles.rs
@@ -127,6 +127,25 @@ impl Styles {
         )
     }
 
+    pub fn selected<'a>(&self, value: &str) -> Span<'static> {
+        let style = if let Some(cyan) = self.color(Color::Cyan) {
+            Style::default().fg(cyan)
+        } else {
+            Style::default().remove_modifier(Modifier::REVERSED)
+        };
+        Span::styled(value.to_string(), style)
+    }
+
+    pub fn ascending(&self, value: &str) -> Span<'static> {
+        let value = format!("{}{}", value, self.if_utf8("▵", "+"));
+        self.selected(&value)
+    }
+
+    pub fn descending(&self, value: &str) -> Span<'static> {
+        let value = format!("{}{}", value, self.if_utf8("▿", "-"));
+        self.selected(&value)
+    }
+
     pub fn color(&self, color: Color) -> Option<Color> {
         use Palette::*;
         match (self.palette, color) {

--- a/tokio-console/src/view/table.rs
+++ b/tokio-console/src/view/table.rs
@@ -12,15 +12,16 @@ use tui::{
 use std::cell::RefCell;
 use std::rc::Weak;
 
-pub(crate) trait TableList {
+pub(crate) trait TableList<const N: usize> {
     type Row;
     type Sort: SortBy + TryFrom<usize>;
     type Context;
 
-    const HEADER: &'static [&'static str];
+    const HEADER: &'static [&'static str; N];
+    const WIDTHS: &'static [usize; N];
 
     fn render<B: tui::backend::Backend>(
-        state: &mut TableListState<Self>,
+        state: &mut TableListState<Self, N>,
         styles: &view::Styles,
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
@@ -34,7 +35,7 @@ pub(crate) trait SortBy {
     fn as_column(&self) -> usize;
 }
 
-pub(crate) struct TableListState<T: TableList> {
+pub(crate) struct TableListState<T: TableList<N>, const N: usize> {
     pub(crate) sorted_items: Vec<Weak<RefCell<T::Row>>>,
     pub(crate) sort_by: T::Sort,
     pub(crate) selected_column: usize,
@@ -49,7 +50,7 @@ pub(crate) struct Controls {
     pub(crate) height: u16,
 }
 
-impl<T: TableList> TableListState<T> {
+impl<T: TableList<N>, const N: usize> TableListState<T, N> {
     pub(in crate::view) fn len(&self) -> usize {
         self.sorted_items.len()
     }
@@ -181,9 +182,9 @@ impl<T: TableList> TableListState<T> {
     }
 }
 
-impl<T> Default for TableListState<T>
+impl<T, const N: usize> Default for TableListState<T, N>
 where
-    T: TableList,
+    T: TableList<N>,
     T::Sort: Default,
 {
     fn default() -> Self {

--- a/tokio-console/src/view/tasks.rs
+++ b/tokio-console/src/view/tasks.rs
@@ -163,9 +163,9 @@ impl TableList for TasksTable {
         let header = Row::new(Self::HEADER.iter().enumerate().map(|(idx, &value)| {
             if idx == table_list_state.selected_column {
                 let suffix = if table_list_state.sort_descending {
-                    "▵"
+                    styles.if_utf8("▵", "+")
                 } else {
-                    "▿"
+                    styles.if_utf8("▿", "-")
                 };
                 Cell::from(format!("{}{}", value, suffix)).style(selected_style)
             } else {

--- a/tokio-console/src/view/tasks.rs
+++ b/tokio-console/src/view/tasks.rs
@@ -19,25 +19,39 @@ use tui::{
 #[derive(Debug, Default)]
 pub(crate) struct TasksTable {}
 
-impl TableList for TasksTable {
+impl TableList<11> for TasksTable {
     type Row = Task;
     type Sort = SortBy;
     type Context = ();
 
-    const HEADER: &'static [&'static str] = &[
+    const HEADER: &'static [&'static str; 11] = &[
         "Warn", "ID", "State", "Name", "Total", "Busy", "Idle", "Polls", "Target", "Location",
         "Fields",
     ];
 
+    const WIDTHS: &'static [usize; 11] = &[
+        Self::HEADER[0].len() + 1,
+        Self::HEADER[1].len() + 1,
+        Self::HEADER[2].len() + 1,
+        Self::HEADER[3].len() + 1,
+        Self::HEADER[4].len() + 1,
+        Self::HEADER[5].len() + 1,
+        Self::HEADER[6].len() + 1,
+        Self::HEADER[7].len() + 1,
+        Self::HEADER[8].len() + 1,
+        Self::HEADER[9].len() + 1,
+        Self::HEADER[10].len() + 1,
+    ];
+
     fn render<B: tui::backend::Backend>(
-        table_list_state: &mut TableListState<Self>,
+        table_list_state: &mut TableListState<Self, 11>,
         styles: &view::Styles,
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
         state: &mut State,
         _: Self::Context,
     ) {
-        let mut state_len: u16 = Self::HEADER[2].len() as u16;
+        let state_len: u16 = Self::WIDTHS[2] as u16;
         let now = if let Some(now) = state.last_updated_at() {
             now
         } else {
@@ -63,26 +77,15 @@ impl TableList for TasksTable {
         };
 
         // Start out wide enough to display the column headers...
-        let mut warn_width = view::Width::new(Self::HEADER[0].len() as u16);
-        let mut id_width = view::Width::new(Self::HEADER[1].len() as u16);
-        let mut name_width = view::Width::new(Self::HEADER[3].len() as u16);
-        let mut polls_width = view::Width::new(Self::HEADER[7].len() as u16);
-        let mut target_width = view::Width::new(Self::HEADER[8].len() as u16);
-        let mut location_width = view::Width::new(Self::HEADER[9].len() as u16);
+        let mut warn_width = view::Width::new(Self::WIDTHS[0] as u16);
+        let mut id_width = view::Width::new(Self::WIDTHS[1] as u16);
+        let mut name_width = view::Width::new(Self::WIDTHS[3] as u16);
+        let mut polls_width = view::Width::new(Self::WIDTHS[7] as u16);
+        let mut target_width = view::Width::new(Self::WIDTHS[8] as u16);
+        let mut location_width = view::Width::new(Self::WIDTHS[9] as u16);
 
         let mut num_idle = 0;
         let mut num_running = 0;
-
-        match table_list_state.sort_by {
-            SortBy::Warns => warn_width.update_len(warn_width.len() + 1),
-            SortBy::Tid => id_width.update_len(id_width.len() + 1),
-            SortBy::State => state_len += 1,
-            SortBy::Name => name_width.update_len(name_width.len() + 1),
-            SortBy::Polls => polls_width.update_len(polls_width.len() + 1),
-            SortBy::Target => target_width.update_len(target_width.len() + 1),
-            SortBy::Location => location_width.update_len(location_width.len() + 1),
-            SortBy::Total | SortBy::Busy | SortBy::Idle => (),
-        };
 
         let rows = {
             let id_width = &mut id_width;
@@ -150,24 +153,20 @@ impl TableList for TasksTable {
                 })
         };
 
-        let (selected_style, header_style) = if let Some(cyan) = styles.color(Color::Cyan) {
-            (Style::default().fg(cyan), Style::default())
+        let header_style = if styles.color(Color::Cyan).is_some() {
+            Style::default()
         } else {
-            (
-                Style::default().remove_modifier(style::Modifier::REVERSED),
-                Style::default().add_modifier(style::Modifier::REVERSED),
-            )
+            Style::default().add_modifier(style::Modifier::REVERSED)
         };
         let header_style = header_style.add_modifier(style::Modifier::BOLD);
 
         let header = Row::new(Self::HEADER.iter().enumerate().map(|(idx, &value)| {
             if idx == table_list_state.selected_column {
-                let suffix = if table_list_state.sort_descending {
-                    styles.if_utf8("▵", "+")
+                if table_list_state.sort_descending {
+                    Cell::from(styles.ascending(value))
                 } else {
-                    styles.if_utf8("▿", "-")
-                };
-                Cell::from(format!("{}{}", value, suffix)).style(selected_style)
+                    Cell::from(styles.descending(value))
+                }
             } else {
                 Cell::from(value)
             }


### PR DESCRIPTION
Add `▵` or `▿` icon that represents the sorting state.

|  |  |
| ---- | ---- |
| ![Screenshot_20220304_183030](https://user-images.githubusercontent.com/10936241/156740512-05fa5be1-c9fa-43a5-adf7-fd8d99ea7e14.png) | ![Screenshot_20220304_183046](https://user-images.githubusercontent.com/10936241/156740520-a73c25e1-5aca-40f0-963d-966d50009bf4.png) |

Relates to #300 