### PR TITLE
style(console): fix Clippy lints on "unnecessary" `to_owned` calls

### DIFF
--- a/tokio-console/src/view/resources.rs
+++ b/tokio-console/src/view/resources.rs
@@ -101,7 +101,7 @@ impl TableList for ResourcesTable {
                         Cell::from(target_width.update_str(resource.target()).to_owned()),
                         Cell::from(type_width.update_str(resource.concrete_type()).to_owned()),
                         Cell::from(resource.type_visibility().render(styles)),
-                        Cell::from(location_width.update_str(resource.location().to_owned())),
+                        Cell::from(location_width.update_str(resource.location()).to_owned()),
                         Cell::from(Spans::from(
                             resource
                                 .formatted_attributes()

--- a/tokio-console/src/view/tasks.rs
+++ b/tokio-console/src/view/tasks.rs
@@ -116,13 +116,13 @@ impl TableList for TasksTable {
                             width = id_width.chars() as usize
                         ))),
                         Cell::from(task.state().render(styles)),
-                        Cell::from(name_width.update_str(task.name().unwrap_or("").to_string())),
+                        Cell::from(name_width.update_str(task.name().unwrap_or("")).to_string()),
                         dur_cell(task.total(now)),
                         dur_cell(task.busy(now)),
                         dur_cell(task.idle(now)),
                         Cell::from(polls_width.update_str(task.total_polls().to_string())),
                         Cell::from(target_width.update_str(task.target()).to_owned()),
-                        Cell::from(location_width.update_str(task.location().to_owned())),
+                        Cell::from(location_width.update_str(task.location()).to_owned()),
                         Cell::from(Spans::from(
                             task.formatted_fields()
                                 .iter()


### PR DESCRIPTION
Currently, Clippy's [`unnecessary_to_owned`][1] lint is triggering in a
couple of places in `tokio-console`.

In this case, the `to_owned` calls actually _are_ necessary before
passing a string to `Cell::new` in a table view. However, in a couple
places, we call `to_owned` _inside_ of the argument to
`Width::update_str`, which does _not_ require an owned string, so Clippy
thinks the `to_owned` call is unnecessary. `update_str` returns the
argument, which is then passed to `Cell::new`.

This commit moves the `to_owned` call to _after_ the `update_str` call,
so that the string is passed to `update_str` as an `&str`, and
`to_owned` is only called afterwards. This doesn't actually meaningfully
change the code in any way, but it makes Clippy happy. :)

[1]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned