### PR TITLE
chore: add `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tokio-rs/console


### PR DESCRIPTION
This branch adds a `CODEOWNERS` file to automatically assign reviewers
for PRs.

Currently, I've assigned the @tokio-rs/console team to review all
changes. This team consists of @carllerche, @seanmonstar, @pnkfelix,
myself, and @zaharidichev. If any of you don't want to be automatically
assigned as reviewers for console PRs, let me know, and I can change the
settings to just assign the remaining team members individually.

We can also add people who contributed to specific parts of the project
as reviewers for certain files. I didn't actually do that in this PR,
because everyone who's made really major contributions to specific parts
of the codebase are already part of the @tokio-rs/console team...