### PR TITLE
chore: add issue templates and security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: "🐛 Bug Report"
+description: "Report a bug encountered while using the console."
+labels: ["S-bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out this
+        form as completely as possible.
+
+        Please search to see if an issue already exists for the bug you
+        encountered. Also, please see [the `CONTRIBUTING.md` file][1] for
+        details on how to submit a bug report.
+
+        [1]: https://github.com/tokio-rs/console/blob/main/CONTRIBUTING.md#submitting-a-bug-report
+
+  - type: dropdown
+    id: crates
+    attributes:
+      label: What crate(s) in this repo are involved in the problem?
+      multiple: true
+      options:
+        - tokio-console
+        - console-subscriber
+        - console-api
+
+  - type: textarea
+    attributes:
+      label: What is the issue?
+      description: |
+        A clear and concise description of what the console is doing
+        wrong, and what you would expect it to do.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: How can the bug be reproduced?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Logs, error output, etc
+      description: |
+        If the output is long, please create a [gist](https://gist.github.com/)
+        and paste the link here.
+
+  - type: textarea
+    attributes:
+      label: Versions
+      description: |
+        The versions of any crates involved in the problem. You can
+        use `cargo tree | grep console-` to list the versions of console crates
+        your program depends on, and you can use `tokio-console -V` to print the
+        installed version of the `tokio-console` CLI.
+      placeholder: |
+        ```text
+        $ cargo tree | grep console-
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Possible solution
+      description: If you have suggestions on a fix for the bug.
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context about the problem here. Or a
+        screenshot if applicable.
+
+  - type: dropdown
+    attributes:
+      label: Would you like to work on fixing this bug?
+      description: We are more than happy to help you through the process.
+      options:
+        - "yes"
+        - "no"
+        - "maybe"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+contact_links:
+- name: 🙋🏾 Question
+  url: https://github.com/tokio-rs/console/discussions/new
+  about: Please use the discussions tab for questions about using the console.
+- name: 🔒 Report a security vulnerability
+  url: https://github.com/tokio-rs/console/security/policy
+  about: |
+    Please review our security policy for more details on reporting a
+    vulnerability.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: 💡 Feature Request
+description: Suggest an idea for improving the console.
+labels: ["S-feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature! Please fill out
+        this form as completely as possible.
+
+        Please search to see if an issue already exists for the feature you are
+        suggesting.
+
+  - type: textarea
+    attributes:
+      label: What problem are you trying to solve?
+      description: A concise description of what the problem is.
+      placeholder: I would like to...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: How should the problem be solved?
+      description: What do you want to happen? Add any considered drawbacks.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Any alternatives you've considered?
+      description: |
+        Is there another way to solve this problem that isn't as good
+        a solution?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: How would users interact with this feature?
+      description: |
+        If you can, explain how users will be able to use this. Maybe
+        some sample CLI output?
+
+  - type: dropdown
+    attributes:
+      label: Would you like to work on this feature?
+      description: We are more than happy to help you through the process.
+      options:
+        - "yes"
+        - "no"
+        - "maybe"
+    validations:
+      required: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+## Report a security issue
+
+The Tokio project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [security@tokio.rs](mailto:security@tokio.rs). Security issues should not be reported via the public Github Issue tracker.
+
+## Vulnerability coordination
+
+Remediation of security vulnerabilities is prioritized by the project team. The project team coordinates remediation with third-party project stakeholders via [Github Security Advisories](https://help.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories). Third-party stakeholders may include the reporter of the issue, affected direct or indirect users of Tokio, and maintainers of upstream dependencies if applicable.
+
+Downstream project maintainers and Tokio users can request participation in coordination of applicable security issues by sending your contact email address, Github username(s) and any other salient information to [security@tokio.rs](mailto:security@tokio.rs). Participation in security issue coordination processes is at the discretion of the Tokio team.
+
+## Security advisories
+
+The project team is committed to transparency in the security issue disclosure process. The Tokio team announces security issues via [project Github Release notes](https://github.com/tokio-rs/console/releases) and the [RustSec advisory database](https://github.com/RustSec/advisory-db) (i.e. `cargo-audit`).


### PR DESCRIPTION
Currently, when people report issues with the console, they just get a
blank issue. This makes it difficult to ensure that we get consistent
information reported for issues and suggestions.

This branch adds GitHub issue templates for bug reports and feature
requests, which should generate a form people can fill in with specific
information. Also, I added the security policy from the Tokio
repository, with a link for reporting security vulnerabilities, because
the console should follow the same security policy as the rest of Tokio.