### PR TITLE
chore(CI): don't trigger duplicate CI runs on pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
-
-on: [push, pull_request]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
 
 name: CI
 


### PR DESCRIPTION
Currently, CI is configured to run on all pushes, and on all pull
requests. This means that when changes are pushed to a PR, the CI jobs
run *twice*. That's not great, as it means our builds take a bit longer.

For example: 
![image](https://user-images.githubusercontent.com/2796466/156822256-ace3d7f6-1d3f-44af-a838-08f05af3e86a.png)

This branch fixes the CI configuration, so that CI jobs are triggered on
all pull requests, and on pushes to `main`, rather than on all pushes.
Now, all jobs should only run a single time for every push to a PR.