### PR TITLE
chore: deduplicate security report issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,8 +2,3 @@ contact_links:
 - name: 🙋🏾 Question
   url: https://github.com/tokio-rs/console/discussions/new
   about: Please use the discussions tab for questions about using the console.
-- name: 🔒 Report a security vulnerability
-  url: https://github.com/tokio-rs/console/security/policy
-  about: |
-    Please review our security policy for more details on reporting a
-    vulnerability.


### PR DESCRIPTION
It turns out GitHub automatically generates a security report link,
so it ended up duplicated. My bad!

![image](https://user-images.githubusercontent.com/2796466/156822574-9c5d96a3-3ab0-4881-9825-1821fc7520a0.png)

This PR fixes that.