### PR TITLE
(WIP) Support configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,9 @@ dependencies = [
  "once_cell",
  "prost-types",
  "regex",
+ "serde",
  "tokio",
+ "toml",
  "tonic",
  "tracing",
  "tracing-journald",
@@ -1340,6 +1342,15 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/console.toml
+++ b/console.toml
@@ -1,0 +1,9 @@
+no_colors = false
+lang = "en_us.UTF-8"
+ascii_only = true
+palette = "8"
+
+
+[toggles]
+color_durations = true
+color_terminated = true

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -44,3 +44,5 @@ h2 = "0.3"
 regex = "1.5"
 once_cell = "1.8"
 humantime = "2.1.0"
+serde = { version = "1", features = ["derive"] }
+toml = "0.5"

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -2,7 +2,6 @@ use color_eyre::{eyre::eyre, Help, SectionExt};
 use console_api::tasks::TaskDetails;
 use state::State;
 
-use clap::Parser as Clap;
 use futures::stream::StreamExt;
 use tokio::sync::{mpsc, watch};
 use tui::{
@@ -26,7 +25,7 @@ mod warnings;
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
-    let mut args = config::Config::parse();
+    let mut args = config::Config::from_config()?;
     let retain_for = args.retain_for();
     args.trace_init()?;
     tracing::debug!(?args.target_addr, ?args.view_options);

--- a/tokio-console/src/view/styles.rs
+++ b/tokio-console/src/view/styles.rs
@@ -1,4 +1,5 @@
 use crate::config;
+use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, str::FromStr};
 use tui::{
     style::{Color, Modifier, Style},
@@ -12,17 +13,23 @@ pub struct Styles {
     pub(crate) utf8: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+// possible_values = &["8", "16", "256", "all", "off"],
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
 #[repr(u8)]
 pub enum Palette {
+    #[serde(rename = "off")]
     NoColors,
     /// Use ANSI 8 color palette only.
+    #[serde(rename = "8")]
     Ansi8,
     /// Use ANSI 16 color palette only.
+    #[serde(rename = "16")]
     Ansi16,
     /// Enable ANSI 256-color palette.
+    #[serde(rename = "256")]
     Ansi256,
     /// Enable all RGB colors.
+    #[serde(rename = "all")]
     All,
 }
 


### PR DESCRIPTION
This pull request is a draft of the supporting configuration file.
I'm worried about implementations as follows.

- two kinds of types of configuration files are supported.
    - `$XDG_CONFIG_HOME/tokio-console/console.toml`
    - current configuration (`./console.toml`) 

I want some advice about these implementations.
(Should I rewrite clap builder api style?)

Relates to https://github.com/tokio-rs/console/issues/310