### PR TITLE
Don't trace tasks spawned through the console server

### DIFF
--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -36,7 +36,7 @@ tokio-stream = "0.1"
 thread_local = "1.1.3"
 console-api = { version = "0.2.0", path = "../console-api", features = ["transport"] }
 tonic = { version = "0.7", features = ["transport"] }
-tracing-core = "0.1.18"
+tracing-core = "0.1.24"
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["fmt", "registry"] }
 futures = { version = "0.3", default-features = false }

--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -180,9 +180,11 @@ impl Builder {
         }
     }
 
-    /// Sets whether we are are tracing events coming from the console subscriber
+    /// Sets whether tasks, resources, and async ops from the console
+    /// subscriber thread are recorded.
     ///
-    /// The default is to drop events coming from the console subscriber thread.
+    /// By default, events from the console subscriber are discarded and
+    /// not exported to clients.
     pub fn enable_self_trace(self, self_trace: bool) -> Self {
         Self { self_trace, ..self }
     }


### PR DESCRIPTION
The console subscriber's server generates a lot of async activity,
introspecting or logging that drowns out the activity the program
has outside of instrumentation.

Set a thread-local subscriber that drops events coming from the server thread.

Implementation requires a simple wrapper for NoSubscriber, because the dispatch implementation uses it as a sentinel value (https://github.com/tokio-rs/tracing/pull/2001 explains the history) and logs through the global dispatcher when a thread-local NoSubscriber is set.