### PR TITLE
style: fix Rust 1.60 clippy lints

### DIFF
--- a/console-subscriber/src/record.rs
+++ b/console-subscriber/src/record.rs
@@ -61,9 +61,10 @@ impl Recorder {
         let (tx, rx) = crossbeam_channel::bounded(4096);
         let _worker = std::thread::Builder::new()
             .name("console/subscriber/recorder/io".into())
-            .spawn(move || match record_io(file, rx) {
-                Err(e) => eprintln!("event recorder failed: {}", e),
-                Ok(()) => {}
+            .spawn(move || {
+                if let Err(e) = record_io(file, rx) {
+                    eprintln!("event recorder failed: {}", e);
+                }
             })?;
 
         let recorder = Recorder { tx, _worker };

--- a/tokio-console/src/state/async_ops.rs
+++ b/tokio-console/src/state/async_ops.rs
@@ -67,7 +67,7 @@ impl Default for SortBy {
 }
 
 impl SortBy {
-    pub fn sort(&self, now: SystemTime, ops: &mut Vec<Weak<RefCell<AsyncOp>>>) {
+    pub fn sort(&self, now: SystemTime, ops: &mut [Weak<RefCell<AsyncOp>>]) {
         match self {
             Self::Aid => ops.sort_unstable_by_key(|ao| ao.upgrade().map(|a| a.borrow().num)),
             Self::Task => ops.sort_unstable_by_key(|ao| ao.upgrade().map(|a| a.borrow().task_id())),

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -342,7 +342,7 @@ impl Field {
         Some(Self { name, value })
     }
 
-    fn make_formatted(styles: &view::Styles, fields: &mut Vec<Field>) -> Vec<Vec<Span<'static>>> {
+    fn make_formatted(styles: &view::Styles, fields: &mut [Field]) -> Vec<Vec<Span<'static>>> {
         let key_style = styles.fg(Color::LightBlue).add_modifier(Modifier::BOLD);
         let delim_style = styles.fg(Color::LightBlue).add_modifier(Modifier::DIM);
         let val_style = styles.fg(Color::Yellow);
@@ -465,7 +465,7 @@ impl PartialOrd for Attribute {
 impl Attribute {
     fn make_formatted(
         styles: &view::Styles,
-        attributes: &mut Vec<Attribute>,
+        attributes: &mut [Attribute],
     ) -> Vec<Vec<Span<'static>>> {
         let key_style = styles.fg(Color::LightBlue).add_modifier(Modifier::BOLD);
         let delim_style = styles.fg(Color::LightBlue).add_modifier(Modifier::DIM);

--- a/tokio-console/src/state/resources.rs
+++ b/tokio-console/src/state/resources.rs
@@ -74,7 +74,7 @@ impl Default for SortBy {
 }
 
 impl SortBy {
-    pub fn sort(&self, now: SystemTime, resources: &mut Vec<Weak<RefCell<Resource>>>) {
+    pub fn sort(&self, now: SystemTime, resources: &mut [Weak<RefCell<Resource>>]) {
         match self {
             Self::Rid => resources
                 .sort_unstable_by_key(|resource| resource.upgrade().map(|r| r.borrow().num)),

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -420,7 +420,7 @@ impl Default for SortBy {
 }
 
 impl SortBy {
-    pub fn sort(&self, now: SystemTime, tasks: &mut Vec<Weak<RefCell<Task>>>) {
+    pub fn sort(&self, now: SystemTime, tasks: &mut [Weak<RefCell<Task>>]) {
         match self {
             Self::Tid => tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().num)),
             Self::Name => {


### PR DESCRIPTION
Rust 1.60's version of `clippy` introduced a few new lints that now
trigger on the console codebase.

This PR fixes those lints.