### PR TITLE
feat(console): add `gen-config` subcommand to generate a config file

### DIFF
--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -26,6 +26,14 @@ mod warnings;
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
     let mut args = config::Config::parse()?;
+
+    if args.subcmd == Some(config::OptionalCmd::GenConfig) {
+        // Generate a default config file and exit.
+        let toml = config::Config::gen_config_file()?;
+        println!("{}", toml);
+        return Ok(());
+    }
+
     let retain_for = args.retain_for();
     args.trace_init()?;
     tracing::debug!(?args.target_addr, ?args.view_options);

--- a/tokio-console/src/view/styles.rs
+++ b/tokio-console/src/view/styles.rs
@@ -1,5 +1,5 @@
 use crate::config;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, str::FromStr};
 use tui::{
     style::{Color, Modifier, Style},
@@ -13,7 +13,7 @@ pub struct Styles {
     pub(crate) utf8: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
 #[repr(u8)]
 pub enum Palette {
     #[serde(rename = "off")]


### PR DESCRIPTION
This branch builds upon the config file support added in #320 and adds a
new `gen-config` subcommand to the `tokio-console` CLI. This command
generates a new config TOML file with all config options populated with
their default values (overridden by any CLI arguments passed to the
console).

This can be used when generating a new configuration file, so that the
user can see all the default values. We can also use it to generate a
config file for the documentation, which can be automatically kept in
sync with the config file definintion in the app.

This seems much nicer than hand-writing a config file for the docs, as
the struct definitions in the `config` module serve as a single source
of truth for the config file definition.

## Example usage:

```shell
:; cargo run -- gen-config
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/tokio-console gen-config`
[charset]
lang = 'en_US.UTF-8'
ascii_only = false

[colors]
enabled = true
truecolor = true
palette = 'all'

[colors.enable]
durations = true
terminated = true
```