### PR TITLE
Fix links to console-subscriber's API docs

### DIFF
--- a/console-subscriber/README.md
+++ b/console-subscriber/README.md
@@ -141,8 +141,8 @@ Other instrumentation is added in later Tokio releases:
 [`TRACE` level]: https://docs.rs/tracing/latest/tracing/struct.Level.html#associatedconstant.TRACE
 [`EnvFilter`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html
 [`Targets`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html
-[builder]: https:/docs.rs/console-subscriber/latest/console_subscriber/struct.builder.html
-[init]: https:/docs.rs/console-subscriber/latest/console_subscriber/fn.init.html
+[builder]: https://docs.rs/console-subscriber/latest/console_subscriber/struct.Builder.html
+[init]: https://docs.rs/console-subscriber/latest/console_subscriber/fn.init.html
 [compile_time_filters]: https://docs.rs/tracing/latest/tracing/level_filters/index.html#compile-time-filters
 
 ### Adding the Console Subscriber


### PR DESCRIPTION
Links to builder and init APIs were broken.