### PR TITLE
feat(console): add autogenerated example config file to docs

### DIFF
--- a/tokio-console/README.md
+++ b/tokio-console/README.md
@@ -95,6 +95,8 @@ A DNS name can also be provided as the target address:
 tokio-console http://my.instrumented.application.local:6669
 ```
 
+See [here][cli-ref] for a complete list of all command-line arguments.
+
 When the console CLI is launched, it displays a list of all [asynchronous tasks]
 in the program:
 
@@ -131,112 +133,17 @@ a large number of tasks, such as this [`tokio::sync::Semaphore`]:
 Like the task details view, pressing the <kbd>escape</kbd> key while viewing a resource's details
 returns to the resource list.
 
+A configuration file (`console.toml`) can be used to configure the console's
+behavior. See [the documentation][cfg-ref] for details.
+
 [`tokio-console`]: https://github.com/tokio-rs/console
 [Tokio]: https://tokio.rs
 [asynchronous tasks]: https://tokio.rs/tokio/tutorial/spawning#tasks
 [resources]: https://tokio.rs/tokio/tutorial/async#async-fn-as-a-future
 [`tokio::sync::oneshot`]: https://docs.rs/tokio/latest/tokio/sync/oneshot/index.html
 [`tokio::sync::Semaphore`]: https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html
-
-### Command-Line Arguments
-
-Running `tokio-console --help` displays a list of all available command-line
-arguments:
-```shell
-$ tokio-console --help
-
-tokio-console 0.1.3
-
-USAGE:
-    tokio-console [OPTIONS] [TARGET_ADDR]
-
-ARGS:
-    <TARGET_ADDR>
-            The address of a console-enabled process to connect to.
-
-            This may be an IP address and port, or a DNS name.
-
-            [default: http://127.0.0.1:6669]
-
-OPTIONS:
-        --ascii-only
-            Explicitly use only ASCII characters
-
-        --colorterm <truecolor>
-            Overrides the value of the `COLORTERM` environment variable.
-
-            If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
-
-            [env: COLORTERM=truecolor]
-            [possible values: 24bit, truecolor]
-
-    -h, --help
-            Print help information
-
-        --lang <LANG>
-            Overrides the terminal's default language
-
-            [env: LANG=en_US.UTF-8]
-            [default: en_us.UTF-8]
-
-        --log <ENV_FILTER>
-            Log level filter for the console's internal diagnostics.
-
-            The console will log to stderr if a log level filter is provided. Since the console
-            application runs interactively, stderr should generally be redirected to a file to avoid
-            interfering with the console's text output.
-
-            [env: RUST_LOG=]
-            [default: off]
-
-        --no-colors
-            Disable ANSI colors entirely
-
-        --no-duration-colors
-            Disable color-coding for duration units
-
-        --no-terminated-colors
-            Disable color-coding for terminated tasks
-
-        --palette <PALETTE>
-            Explicitly set which color palette to use
-
-            [possible values: 8, 16, 256, all, off]
-
-        --retain-for <RETAIN_FOR>
-            How long to continue displaying completed tasks and dropped resources after they have
-            been closed.
-
-            This accepts either a duration, parsed as a combination of time spans (such as `5days
-            2min 2s`), or `none` to disable removing completed tasks and dropped resources.
-
-            Each time span is an integer number followed by a suffix. Supported suffixes are:
-
-            * `nsec`, `ns` -- nanoseconds
-
-            * `usec`, `us` -- microseconds
-
-            * `msec`, `ms` -- milliseconds
-
-            * `seconds`, `second`, `sec`, `s`
-
-            * `minutes`, `minute`, `min`, `m`
-
-            * `hours`, `hour`, `hr`, `h`
-
-            * `days`, `day`, `d`
-
-            * `weeks`, `week`, `w`
-
-            * `months`, `month`, `M` -- defined as 30.44 days
-
-            * `years`, `year`, `y` -- defined as 365.25 days
-
-            [default: 6s]
-
-    -V, --version
-            Print version information
-```
+[cli-ref]: https://docs.rs/tokio-console/latest/tokio_console/config_reference/index.html#command-line-arguments
+[cfg-ref]: https://docs.rs/tokio-console/latest/tokio_console/config_reference/index.html#configuration-file
 
 ## Getting Help
 

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -1,0 +1,190 @@
+USAGE:
+
+    tokio-console [OPTIONS] [TARGET_ADDR] [SUBCOMMAND]
+
+
+
+ARGS:
+
+    <TARGET_ADDR>
+
+            The address of a console-enabled process to connect to.
+
+            
+
+            This may be an IP address and port, or a DNS name.
+
+            
+
+            [default: http://127.0.0.1:6669]
+
+
+
+OPTIONS:
+
+        --ascii-only <ASCII_ONLY>
+
+            Explicitly use only ASCII characters
+
+
+
+        --colorterm <truecolor>
+
+            Overrides the value of the `COLORTERM` environment variable.
+
+            
+
+            If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
+
+            
+
+            [env: COLORTERM=truecolor]
+
+            [possible values: 24bit, truecolor]
+
+
+
+    -h, --help
+
+            Print help information
+
+
+
+        --lang <LANG>
+
+            Overrides the terminal's default language
+
+            
+
+            [env: LANG=en_US.UTF-8]
+
+
+
+        --log <ENV_FILTER>
+
+            Log level filter for the console's internal diagnostics.
+
+            
+
+            The console will log to stderr if a log level filter is provided. Since the console
+
+            application runs interactively, stderr should generally be redirected to a file to avoid
+
+            interfering with the console's text output.
+
+            
+
+            [env: RUST_LOG=]
+
+            [default: off]
+
+
+
+        --no-colors <no-colors>
+
+            Disable ANSI colors entirely
+
+
+
+        --no-duration-colors <COLOR_DURATIONS>
+
+            Disable color-coding for duration units
+
+
+
+        --no-terminated-colors <COLOR_TERMINATED>
+
+            Disable color-coding for terminated tasks
+
+
+
+        --palette <PALETTE>
+
+            Explicitly set which color palette to use
+
+            
+
+            [possible values: 8, 16, 256, all, off]
+
+
+
+        --retain-for <RETAIN_FOR>
+
+            How long to continue displaying completed tasks and dropped resources after they have
+
+            been closed.
+
+            
+
+            This accepts either a duration, parsed as a combination of time spans (such as `5days
+
+            2min 2s`), or `none` to disable removing completed tasks and dropped resources.
+
+            
+
+            Each time span is an integer number followed by a suffix. Supported suffixes are:
+
+            
+
+            * `nsec`, `ns` -- nanoseconds
+
+            
+
+            * `usec`, `us` -- microseconds
+
+            
+
+            * `msec`, `ms` -- milliseconds
+
+            
+
+            * `seconds`, `second`, `sec`, `s`
+
+            
+
+            * `minutes`, `minute`, `min`, `m`
+
+            
+
+            * `hours`, `hour`, `hr`, `h`
+
+            
+
+            * `days`, `day`, `d`
+
+            
+
+            * `weeks`, `week`, `w`
+
+            
+
+            * `months`, `month`, `M` -- defined as 30.44 days
+
+            
+
+            * `years`, `year`, `y` -- defined as 365.25 days
+
+            
+
+            [default: 6s]
+
+
+
+    -V, --version
+
+            Print version information
+
+
+
+SUBCOMMANDS:
+
+    gen-config
+
+            Generate a `console.toml` config file with the default configuration values, overridden
+
+            by any provided command-line arguments
+
+    help
+
+            Print this message or the help of the given subcommand(s)
+

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -1,190 +1,95 @@
 USAGE:
-
     tokio-console [OPTIONS] [TARGET_ADDR] [SUBCOMMAND]
 
-
-
 ARGS:
-
     <TARGET_ADDR>
-
             The address of a console-enabled process to connect to.
-
             
-
             This may be an IP address and port, or a DNS name.
-
             
-
             [default: http://127.0.0.1:6669]
 
-
-
 OPTIONS:
-
         --ascii-only <ASCII_ONLY>
-
             Explicitly use only ASCII characters
 
-
-
         --colorterm <truecolor>
-
             Overrides the value of the `COLORTERM` environment variable.
-
             
-
             If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
-
             
-
             [env: COLORTERM=truecolor]
-
             [possible values: 24bit, truecolor]
 
-
-
     -h, --help
-
             Print help information
 
-
-
         --lang <LANG>
-
             Overrides the terminal's default language
-
             
-
             [env: LANG=en_US.UTF-8]
 
-
-
         --log <ENV_FILTER>
-
             Log level filter for the console's internal diagnostics.
-
             
-
             The console will log to stderr if a log level filter is provided. Since the console
-
             application runs interactively, stderr should generally be redirected to a file to avoid
-
             interfering with the console's text output.
-
             
-
             [env: RUST_LOG=]
-
             [default: off]
 
-
-
         --no-colors <no-colors>
-
             Disable ANSI colors entirely
 
-
-
         --no-duration-colors <COLOR_DURATIONS>
-
             Disable color-coding for duration units
 
-
-
         --no-terminated-colors <COLOR_TERMINATED>
-
             Disable color-coding for terminated tasks
 
-
-
         --palette <PALETTE>
-
             Explicitly set which color palette to use
-
             
-
             [possible values: 8, 16, 256, all, off]
 
-
-
         --retain-for <RETAIN_FOR>
-
             How long to continue displaying completed tasks and dropped resources after they have
-
             been closed.
-
             
-
             This accepts either a duration, parsed as a combination of time spans (such as `5days
-
             2min 2s`), or `none` to disable removing completed tasks and dropped resources.
-
             
-
             Each time span is an integer number followed by a suffix. Supported suffixes are:
-
             
-
             * `nsec`, `ns` -- nanoseconds
-
             
-
             * `usec`, `us` -- microseconds
-
             
-
             * `msec`, `ms` -- milliseconds
-
             
-
             * `seconds`, `second`, `sec`, `s`
-
             
-
             * `minutes`, `minute`, `min`, `m`
-
             
-
             * `hours`, `hour`, `hr`, `h`
-
             
-
             * `days`, `day`, `d`
-
             
-
             * `weeks`, `week`, `w`
-
             
-
             * `months`, `month`, `M` -- defined as 30.44 days
-
             
-
             * `years`, `year`, `y` -- defined as 365.25 days
-
             
-
             [default: 6s]
 
-
-
     -V, --version
-
             Print version information
 
-
-
 SUBCOMMANDS:
-
     gen-config
-
             Generate a `console.toml` config file with the default configuration values, overridden
-
             by any provided command-line arguments
-
     help
-
             Print this message or the help of the given subcommand(s)
-

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -9,4 +9,4 @@ palette = 'all'
 
 [colors.enable]
 durations = true
-terminated = "barf"
+terminated = true

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -1,0 +1,12 @@
+[charset]
+lang = 'en_US.UTF-8'
+ascii_only = false
+
+[colors]
+enabled = true
+truecolor = true
+palette = 'all'
+
+[colors.enable]
+durations = true
+terminated = true

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -9,4 +9,4 @@ palette = 'all'
 
 [colors.enable]
 durations = true
-terminated = true
+terminated = "barf"

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -579,7 +579,7 @@ mod tests {
 
         ENV_VARS_CLOBBERED.call_once(|| {
             env::set_var("COLORTERM", "truecolor");
-            env::set_var("LANG", "en_us.UTF-8");
+            env::set_var("LANG", "en_US.UTF-8");
         })
     }
 }

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -495,7 +495,7 @@ mod tests {
         // version number, and it seems like a pain to have to re-generate the
         // file every time the version changes...
         for line in helptext.lines().skip(4) {
-            writeln!(file, "{}\n", line).expect("writing to file succeeds");
+            writeln!(file, "{}", line).expect("writing to file succeeds");
         }
 
         file.flush().expect("flushing should succeed");
@@ -547,16 +547,23 @@ mod tests {
         let output = process::Command::new("git")
             .arg("diff")
             .arg("--exit-code")
+            .arg(format!(
+                "--color={}",
+                std::env::var("CARGO_TERM_COLOR")
+                    .as_ref()
+                    .map(String::as_str)
+                    .unwrap_or("always")
+            ))
             .arg("--")
             .arg(path.as_ref().display().to_string())
             .output()
             .unwrap();
 
+        let diff = String::from_utf8(output.stdout).expect("git diff output not utf8");
         if output.status.success() {
+            println!("git diff:\n{}", diff);
             return Ok(());
         }
-
-        let diff = String::from_utf8(output.stdout).expect("git diff output not utf8");
 
         Err(diff)
     }

--- a/tokio-console/src/lib.rs
+++ b/tokio-console/src/lib.rs
@@ -1,2 +1,69 @@
 // this file is here to make a binary target so that cargo metadata works with this crate
 #![doc = include_str!("../README.md")]
+
+/// # Configuration Reference
+///
+/// `tokio-console`'s behavior can be configured in two ways: via command-line
+/// arguments, or using a [TOML] config file.
+///
+/// ## Command-Line Arguments
+///
+/// The following is the complete list of command-line arguments accepted by
+/// `tokio-console`:
+///
+/// ```text
+#[doc = include_str!("../args.example")]
+/// ```
+///
+/// This text can also be displayed by running `tokio-console help`.
+///
+///
+/// ## Configuration File
+///
+/// In addition to command-line arguments, the console can also be configured by a
+/// [TOML] configuration file. All settings that can be configured by the
+/// command line (with the exception of the target address to connect to) can
+/// also be set by the config file.
+///
+/// The `tokio-console gen-config` subcommand generates a config file based on
+/// the default configuration, overridden by any command-line arguments passed
+/// by the user.
+///
+/// ### Examples
+///
+/// The default configuration:
+///
+/// ```toml
+#[doc = include_str!("../console.example.toml")]
+/// ```
+///
+/// ### Config File Locations
+///
+/// Configuration files are read from two locations:
+///
+/// 1. A `tokio-console` directory in the system default configuration
+///    directory (as determined by the  [`dirs` crate]). This directory depends
+///    on the operating system:
+///
+///    |Platform | Value                                                             |
+///    | ------- | ----------------------------------------------------------------- |
+///    | Linux   | `$XDG_CONFIG_HOME/tokio-console` or `$HOME/.config/tokio-console` |
+///    | macOS   | `$HOME/Library/Application Support/tokio-console`                 |
+///    | Windows | `{FOLDERID_RoamingAppData}\tokio-console`                         |
+///
+/// 2. The current working directory.
+///
+///    If both the current working directory *and* the system default config directory
+///    contain a `console.toml` file, any values set in the current working directory
+///    will override those set in the system config directory. This allows overriding
+///    the user-level default configuration with project specific configurations. Some
+///    projects may wish to check project-specific configurations into source control
+///    so that they may be shared by multiple developers.
+///
+/// Any command-line arguments will override the configuration set in both config files.
+///
+/// [TOML]: https://github.com/toml-lang/toml
+/// [`dirs` crate]: https://docs.rs/dirs/4.0.0/dirs/fn.config_dir.html
+pub mod config_reference {
+    // empty module, used only for documentation
+}

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> color_eyre::Result<()> {
 
     if args.subcmd == Some(config::OptionalCmd::GenConfig) {
         // Generate a default config file and exit.
-        let toml = config::Config::gen_config_file()?;
+        let toml = args.gen_config_file()?;
         println!("{}", toml);
         return Ok(());
     }


### PR DESCRIPTION
This branch updates `tokio-console`'s documentation to include a
configuration reference describing the config file and the CLI
arguments.

In addition, I've added code to automatically generate the example
config file and the help text for the CLI arguments as files that can be
checked in to Git. The example text is generated in a test, which will
fail if the generated output has changed. This way, we can ensure that
changes that change CLI arguments or config file fields will include
updates to the example files. In the RustDoc configuration reference, we
use `include_str!` to pull in those files. This means the docs are
always kept up to date, and the actual code that defines the config file
and the CLI args are used as a single source of truth from which the
documentation can be generated.

Check out the [Netlify deploy preview][1] to see the new docs!

[1]: https://62570bc00775d9000823486d--tokio-console.netlify.app/tokio_console/config_reference/index.html