### PR TITLE
feat(console): parse error when use unknown fields

### DIFF
--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -135,6 +135,7 @@ pub struct ViewOptions {
 
 /// Toggles on and off color coding for individual UI elements.
 #[derive(Clap, Debug, Copy, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ColorToggles {
     /// Disable color-coding for duration units.
     #[clap(long = "no-duration-colors", group = "colors")]
@@ -149,18 +150,21 @@ pub struct ColorToggles {
 
 /// A sturct used to parse the toml config file
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct ConfigFile {
     charset: Option<CharsetConfig>,
     colors: Option<ColorsConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct CharsetConfig {
     lang: Option<String>,
     ascii_only: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct ColorsConfig {
     enabled: Option<bool>,
     truecolor: Option<bool>,


### PR DESCRIPTION
This work is related to https://github.com/tokio-rs/console/pull/320#issuecomment-1095416429
return error message if the config file includes unknown fields.  

reference: https://serde.rs/container-attrs.html#deny_unknown_fields

## test

console.toml

```toml
[charset]
lang = "en_us.UTF-8"
ascii_only = true

[colors]
enabled = true
palette = "all"
truecolor = true

[colors.enable]
durations = true 
terminated = true
unknown = true  # unknown field
```

```
❯ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/tokio-console`
Error: failed to parse ./console.toml

Caused by:
    unknown field `unknown`, expected `durations` or `terminated` for key `colors.enable` at line 10 column 1

Location:
    tokio-console/src/config.rs:388:14
```