### PR TITLE
docs(subscriber): fix broken `Server` rustdoc

### DIFF
--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -118,7 +118,7 @@ pub struct ConsoleLayer {
 
 /// A gRPC [`Server`] that implements the [`tokio-console` wire format][wire].
 ///
-/// Client applications, such as the [`tokio-console CLI][cli] connect to the gRPC
+/// Client applications, such as the [`tokio-console` CLI][cli] connect to the gRPC
 /// server, and stream data about the runtime's history (such as a list of the
 /// currently active tasks, or statistics summarizing polling times). A [`Server`] also
 /// interprets commands from a client application, such a request to focus in on


### PR DESCRIPTION
Currently, the RustDoc for the `Server` type has a single backtick
without a corresponding backtick, resulting in the rest of the docs
incorrectly formatted as code (and breaking a link).

This PR fixes it.

Before:
![image](https://user-images.githubusercontent.com/2796466/163465563-4c47bf29-8e1d-431a-9d78-85bd4ed68e69.png)

After:
![image](https://user-images.githubusercontent.com/2796466/163465758-33273f9f-a8f9-482a-b759-ab1ca42bcd90.png)
