### PR TITLE
feat(console): add missing configuration

### DIFF
--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -34,7 +34,7 @@ OPTIONS:
             application runs interactively, stderr should generally be redirected to a file to avoid
             interfering with the console's text output.
             
-            [env: RUST_LOG=info]
+            [env: RUST_LOG=]
 
         --no-colors <no-colors>
             Disable ANSI colors entirely

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -36,6 +36,8 @@ OPTIONS:
             application runs interactively, stderr should generally be redirected to a file to avoid
             interfering with the console's text output.
             
+            [default: off]
+            
             [env: RUST_LOG=]
 
         --no-colors <no-colors>
@@ -80,6 +82,8 @@ OPTIONS:
             * `months`, `month`, `M` -- defined as 30.44 days
             
             * `years`, `year`, `y` -- defined as 365.25 days
+            
+            [default: 6s]
 
     -V, --version
             Print version information

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -6,8 +6,6 @@ ARGS:
             The address of a console-enabled process to connect to.
             
             This may be an IP address and port, or a DNS name.
-            
-            [default: http://127.0.0.1:6669]
 
 OPTIONS:
         --ascii-only <ASCII_ONLY>
@@ -36,8 +34,7 @@ OPTIONS:
             application runs interactively, stderr should generally be redirected to a file to avoid
             interfering with the console's text output.
             
-            [env: RUST_LOG=]
-            [default: off]
+            [env: RUST_LOG=info]
 
         --no-colors <no-colors>
             Disable ANSI colors entirely
@@ -81,8 +78,6 @@ OPTIONS:
             * `months`, `month`, `M` -- defined as 30.44 days
             
             * `years`, `year`, `y` -- defined as 365.25 days
-            
-            [default: 6s]
 
     -V, --version
             Print version information

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -6,6 +6,8 @@ ARGS:
             The address of a console-enabled process to connect to.
             
             This may be an IP address and port, or a DNS name.
+            
+            [default: http://127.0.0.1:6669]
 
 OPTIONS:
         --ascii-only <ASCII_ONLY>

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -1,6 +1,6 @@
 target_addr = 'http://127.0.0.1:6669/'
-env_filter = 'info'
 retain_for = '6s'
+log = 'info'
 
 [charset]
 lang = 'en_US.UTF-8'

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -1,5 +1,5 @@
 target_addr = 'http://127.0.0.1:6669/'
-log = 'info'
+log = 'off'
 retention = '6s'
 
 [charset]

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -1,6 +1,6 @@
 target_addr = 'http://127.0.0.1:6669/'
-retain_for = '6s'
 log = 'info'
+retention = '6s'
 
 [charset]
 lang = 'en_US.UTF-8'

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -1,4 +1,4 @@
-target_addr = 'http://127.0.0.1:6669/'
+default_target_addr = 'http://127.0.0.1:6669/'
 log = 'off'
 retention = '6s'
 

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -1,3 +1,7 @@
+target_addr = 'http://127.0.0.1:6669/'
+env_filter = 'info'
+retain_for = '6s'
+
 [charset]
 lang = 'en_US.UTF-8'
 ascii_only = false

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -177,7 +177,7 @@ pub struct ColorToggles {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct ConfigFile {
-    target_addr: Option<String>,
+    default_target_addr: Option<String>,
     log: Option<String>,
     retention: Option<RetainFor>,
     charset: Option<CharsetConfig>,
@@ -459,14 +459,14 @@ impl ConfigFile {
 
     fn target_addr(&self) -> color_eyre::Result<Option<Uri>> {
         let uri = self
-            .target_addr
+            .default_target_addr
             .as_ref()
             .map(|addr| addr.parse::<Uri>())
             .transpose()
             .wrap_err_with(|| {
                 format!(
                     "failed to parse target address {:?} as URI",
-                    self.target_addr
+                    self.default_target_addr
                 )
             })?;
         Ok(uri)
@@ -508,7 +508,7 @@ impl ConfigFile {
 impl From<Config> for ConfigFile {
     fn from(config: Config) -> Self {
         Self {
-            target_addr: config.target_addr.map(|addr| addr.to_string()),
+            default_target_addr: config.target_addr.map(|addr| addr.to_string()),
             log: config.env_filter.map(|filter| filter.to_string()),
             retention: config.retain_for,
             charset: Some(CharsetConfig {

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -457,7 +457,12 @@ impl ConfigFile {
             .as_ref()
             .map(|addr| addr.parse::<Uri>())
             .transpose()
-            .wrap_err(format!("failed to parse Uri, {:?}", self.target_addr))?;
+            .wrap_err_with(|| {
+                format!(
+                    "failed to parse target address {:?} as URI",
+                    self.target_addr
+                )
+            })?;
         Ok(uri)
     }
 
@@ -467,7 +472,7 @@ impl ConfigFile {
             .as_ref()
             .map(|directive| directive.parse::<tracing_subscriber::EnvFilter>())
             .transpose()
-            .wrap_err(format!("failed to parse EnvFilter, {:?}", self.log))?;
+            .wrap_err_with(|| format!("failed to parse log filter {:?}", self.log))?;
         Ok(env_filter)
     }
 

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -34,6 +34,8 @@ pub struct Config {
     /// The console will log to stderr if a log level filter is provided. Since
     /// the console application runs interactively, stderr should generally be
     /// redirected to a file to avoid interfering with the console's text output.
+    ///
+    /// [default: off]
     #[clap(long = "log", env = "RUST_LOG")]
     pub(crate) env_filter: Option<tracing_subscriber::EnvFilter>,
 
@@ -68,6 +70,8 @@ pub struct Config {
     /// * `months`, `month`, `M` -- defined as 30.44 days
     ///
     /// * `years`, `year`, `y` -- defined as 365.25 days
+    ///
+    /// [default: 6s]
     #[clap(long = "retain-for")]
     retain_for: Option<RetainFor>,
 
@@ -292,7 +296,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             target_addr: Some(default_target_addr()),
-            env_filter: Some(tracing_subscriber::EnvFilter::new("info")),
+            env_filter: Some(tracing_subscriber::EnvFilter::new("off")),
             retain_for: Some(RetainFor(Some(Duration::from_secs(6)))),
             view_options: ViewOptions::default(),
             subcmd: None,

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -2,6 +2,7 @@ use crate::view::Palette;
 use clap::{ArgGroup, Parser as Clap, Subcommand, ValueHint};
 use color_eyre::eyre::WrapErr;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::fs;
 use std::ops::Not;
 use std::path::PathBuf;
@@ -23,16 +24,16 @@ pub struct Config {
     /// The address of a console-enabled process to connect to.
     ///
     /// This may be an IP address and port, or a DNS name.
-    #[clap(default_value = "http://127.0.0.1:6669", value_hint = ValueHint::Url)]
-    pub(crate) target_addr: Uri,
+    #[clap(value_hint = ValueHint::Url)]
+    pub(crate) target_addr: Option<Uri>,
 
     /// Log level filter for the console's internal diagnostics.
     ///
     /// The console will log to stderr if a log level filter is provided. Since
     /// the console application runs interactively, stderr should generally be
     /// redirected to a file to avoid interfering with the console's text output.
-    #[clap(long = "log", env = "RUST_LOG", default_value = "off")]
-    pub(crate) env_filter: tracing_subscriber::EnvFilter,
+    #[clap(long = "log", env = "RUST_LOG")]
+    pub(crate) env_filter: Option<tracing_subscriber::EnvFilter>,
 
     #[clap(flatten)]
     pub(crate) view_options: ViewOptions,
@@ -65,8 +66,8 @@ pub struct Config {
     /// * `months`, `month`, `M` -- defined as 30.44 days
     ///
     /// * `years`, `year`, `y` -- defined as 365.25 days
-    #[clap(long = "retain-for", default_value = "6s")]
-    retain_for: RetainFor,
+    #[clap(long = "retain-for")]
+    retain_for: Option<RetainFor>,
 
     /// An optional subcommand.
     ///
@@ -92,6 +93,15 @@ pub enum OptionalCmd {
 
 #[derive(Debug)]
 struct RetainFor(Option<Duration>);
+
+impl fmt::Display for RetainFor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            None => write!(f, ""),
+            Some(duration) => write!(f, "{:?}", duration),
+        }
+    }
+}
 
 #[derive(Clap, Debug, Clone)]
 #[clap(group = ArgGroup::new("colors").conflicts_with("no-colors"))]
@@ -152,6 +162,9 @@ pub struct ColorToggles {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct ConfigFile {
+    target_addr: Option<String>,
+    env_filter: Option<String>,
+    retain_for: Option<String>,
     charset: Option<CharsetConfig>,
     colors: Option<ColorsConfig>,
 }
@@ -177,26 +190,25 @@ struct ColorsConfig {
 impl Config {
     /// Parse from config files and command line options.
     pub fn parse() -> color_eyre::Result<Self> {
-        let home = ViewOptions::from_config(ConfigPath::Home)?;
-        let current = ViewOptions::from_config(ConfigPath::Current)?;
+        let home = Self::from_path(ConfigPath::Home)?;
+        let current = Self::from_path(ConfigPath::Current)?;
         let base = match (home, current) {
             (None, None) => None,
             (Some(home), None) => Some(home),
             (None, Some(current)) => Some(current),
             (Some(home), Some(current)) => Some(home.merge_with(current)),
         };
-        let mut config = <Self as Clap>::parse();
-        let view_options = match base {
-            None => config.view_options,
-            Some(base) => base.merge_with(config.view_options),
+        let config = <Self as Clap>::parse();
+        let config = match base {
+            None => config,
+            Some(base) => base.merge_with(config),
         };
-        config.view_options = view_options;
         Ok(config)
     }
 
     pub fn gen_config_file(self) -> color_eyre::Result<String> {
-        let defaults = ViewOptions::default().merge_with(self.view_options);
-        let config = ConfigFile::from_view_options(defaults);
+        let defaults = Self::default().merge_with(self);
+        let config: ConfigFile = defaults.into();
         toml::to_string_pretty(&config).map_err(Into::into)
     }
 
@@ -238,8 +250,47 @@ impl Config {
     }
 
     pub(crate) fn retain_for(&self) -> Option<Duration> {
-        self.retain_for.0
+        self.retain_for.as_ref().and_then(|value| value.0)
     }
+
+    pub(crate) fn target_addr(&self) -> Uri {
+        self.target_addr
+            .as_ref()
+            .unwrap_or(&default_target_addr())
+            .clone()
+    }
+
+    fn from_path(config_path: ConfigPath) -> color_eyre::Result<Option<Self>> {
+        ConfigFile::from_path(config_path)?
+            .map(|config| config.try_into())
+            .transpose()
+    }
+
+    fn merge_with(self, other: Self) -> Self {
+        Self {
+            target_addr: other.target_addr.or(self.target_addr),
+            env_filter: other.env_filter.or(self.env_filter),
+            retain_for: other.retain_for.or(self.retain_for),
+            view_options: self.view_options.merge_with(other.view_options),
+            subcmd: other.subcmd.or(self.subcmd),
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            target_addr: Some(default_target_addr()),
+            env_filter: Some(tracing_subscriber::EnvFilter::new("info")),
+            retain_for: Some(RetainFor(Some(Duration::from_secs(6)))),
+            view_options: ViewOptions::default(),
+            subcmd: None,
+        }
+    }
+}
+
+fn default_target_addr() -> Uri {
+    "http://127.0.0.1:6669".parse::<Uri>().unwrap_or_default()
 }
 
 // === impl ViewOptions ===
@@ -300,11 +351,6 @@ impl ViewOptions {
 
     pub(crate) fn toggles(&self) -> ColorToggles {
         self.toggles
-    }
-
-    fn from_config(path: ConfigPath) -> color_eyre::Result<Option<Self>> {
-        let options = ConfigFile::from_config(path)?.map(|config| config.into_view_options());
-        Ok(options)
     }
 
     fn merge_with(self, command_line: ViewOptions) -> Self {
@@ -379,7 +425,7 @@ impl ColorToggles {
 // === impl ColorToggles ===
 
 impl ConfigFile {
-    fn from_config(path: ConfigPath) -> color_eyre::Result<Option<Self>> {
+    fn from_path(path: ConfigPath) -> color_eyre::Result<Option<Self>> {
         let config = path
             .into_path()
             .and_then(|path| fs::read_to_string(path).ok())
@@ -394,33 +440,34 @@ impl ConfigFile {
         Ok(config)
     }
 
-    fn into_view_options(self) -> ViewOptions {
-        ViewOptions {
-            no_colors: self.no_colors(),
-            lang: self.charset.as_ref().and_then(|config| config.lang.clone()),
-            ascii_only: self.charset.as_ref().and_then(|config| config.ascii_only),
-            truecolor: self.colors.as_ref().and_then(|config| config.truecolor),
-            palette: self.colors.as_ref().and_then(|config| config.palette),
-            toggles: ColorToggles {
-                color_durations: self.color_durations(),
-                color_terminated: self.color_terminated(),
-            },
-        }
+    fn target_addr(&self) -> color_eyre::Result<Option<Uri>> {
+        let uri = self
+            .target_addr
+            .as_ref()
+            .map(|addr| addr.parse::<Uri>())
+            .transpose()
+            .wrap_err(format!("failed to parse Uri, {:?}", self.target_addr))?;
+        Ok(uri)
     }
 
-    fn from_view_options(view_options: ViewOptions) -> Self {
-        Self {
-            charset: Some(CharsetConfig {
-                lang: view_options.lang,
-                ascii_only: view_options.ascii_only,
-            }),
-            colors: Some(ColorsConfig {
-                enabled: view_options.no_colors.map(Not::not),
-                truecolor: view_options.truecolor,
-                palette: view_options.palette,
-                enable: Some(view_options.toggles),
-            }),
-        }
+    fn env_filter(&self) -> color_eyre::Result<Option<tracing_subscriber::EnvFilter>> {
+        let env_filter = self
+            .env_filter
+            .as_ref()
+            .map(|directive| directive.parse::<tracing_subscriber::EnvFilter>())
+            .transpose()
+            .wrap_err(format!("failed to parse EnvFilter, {:?}", self.env_filter))?;
+        Ok(env_filter)
+    }
+
+    fn retain_for(&self) -> color_eyre::Result<Option<RetainFor>> {
+        let retain_for = self
+            .retain_for
+            .as_ref()
+            .map(|retain_for| retain_for.parse::<RetainFor>())
+            .transpose()
+            .wrap_err(format!("failed to parse RetainFor, {:?}", self.retain_for))?;
+        Ok(retain_for)
     }
 
     fn no_colors(&self) -> Option<bool> {
@@ -439,6 +486,53 @@ impl ConfigFile {
         self.colors
             .as_ref()
             .and_then(|config| config.enable.map(|toggles| toggles.color_terminated()))
+    }
+}
+
+impl From<Config> for ConfigFile {
+    fn from(config: Config) -> Self {
+        Self {
+            target_addr: config.target_addr.map(|addr| addr.to_string()),
+            env_filter: config.env_filter.map(|filter| filter.to_string()),
+            retain_for: config.retain_for.map(|value| value.to_string()),
+            charset: Some(CharsetConfig {
+                lang: config.view_options.lang,
+                ascii_only: config.view_options.ascii_only,
+            }),
+            colors: Some(ColorsConfig {
+                enabled: config.view_options.no_colors.map(Not::not),
+                truecolor: config.view_options.truecolor,
+                palette: config.view_options.palette,
+                enable: Some(config.view_options.toggles),
+            }),
+        }
+    }
+}
+
+impl TryFrom<ConfigFile> for Config {
+    type Error = color_eyre::eyre::Error;
+
+    fn try_from(value: ConfigFile) -> Result<Self, Self::Error> {
+        Ok(Config {
+            target_addr: value.target_addr()?,
+            env_filter: value.env_filter()?,
+            retain_for: value.retain_for()?,
+            view_options: ViewOptions {
+                no_colors: value.no_colors(),
+                lang: value
+                    .charset
+                    .as_ref()
+                    .and_then(|config| config.lang.clone()),
+                ascii_only: value.charset.as_ref().and_then(|config| config.ascii_only),
+                truecolor: value.colors.as_ref().and_then(|config| config.truecolor),
+                palette: value.colors.as_ref().and_then(|config| config.palette),
+                toggles: ColorToggles {
+                    color_durations: value.color_durations(),
+                    color_terminated: value.color_terminated(),
+                },
+            },
+            subcmd: None,
+        })
     }
 }
 

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -305,7 +305,9 @@ impl Default for Config {
 }
 
 fn default_target_addr() -> Uri {
-    "http://127.0.0.1:6669".parse::<Uri>().unwrap_or_default()
+    "http://127.0.0.1:6669"
+        .parse::<Uri>()
+        .expect("default target address should be a valid URI")
 }
 
 // === impl ViewOptions ===

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -24,6 +24,8 @@ pub struct Config {
     /// The address of a console-enabled process to connect to.
     ///
     /// This may be an IP address and port, or a DNS name.
+    ///
+    /// [default: http://127.0.0.1:6669]
     #[clap(value_hint = ValueHint::Url)]
     pub(crate) target_addr: Option<Uri>,
 

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -165,7 +165,7 @@ pub struct ColorToggles {
 #[serde(deny_unknown_fields)]
 struct ConfigFile {
     target_addr: Option<String>,
-    env_filter: Option<String>,
+    log: Option<String>,
     retain_for: Option<String>,
     charset: Option<CharsetConfig>,
     colors: Option<ColorsConfig>,
@@ -454,11 +454,11 @@ impl ConfigFile {
 
     fn env_filter(&self) -> color_eyre::Result<Option<tracing_subscriber::EnvFilter>> {
         let env_filter = self
-            .env_filter
+            .log
             .as_ref()
             .map(|directive| directive.parse::<tracing_subscriber::EnvFilter>())
             .transpose()
-            .wrap_err(format!("failed to parse EnvFilter, {:?}", self.env_filter))?;
+            .wrap_err(format!("failed to parse EnvFilter, {:?}", self.log))?;
         Ok(env_filter)
     }
 
@@ -495,7 +495,7 @@ impl From<Config> for ConfigFile {
     fn from(config: Config) -> Self {
         Self {
             target_addr: config.target_addr.map(|addr| addr.to_string()),
-            env_filter: config.env_filter.map(|filter| filter.to_string()),
+            log: config.env_filter.map(|filter| filter.to_string()),
             retain_for: config.retain_for.map(|value| value.to_string()),
             charset: Some(CharsetConfig {
                 lang: config.view_options.lang,

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -38,11 +38,11 @@ async fn main() -> color_eyre::Result<()> {
     args.trace_init()?;
     tracing::debug!(?args.target_addr, ?args.view_options);
 
+    let target = args.target_addr();
+    tracing::info!(?target, "using target addr");
+
     let styles = view::Styles::from_config(args.view_options);
     styles.error_init()?;
-
-    let target = args.target_addr;
-    tracing::info!(?target, "using target addr");
 
     let (mut terminal, _cleanup) = term::init_crossterm()?;
     terminal.clear()?;


### PR DESCRIPTION
This changes supports `target_addr`, `env_filter`, and `retain_for` in configuration file.

```
❯ env -u LANG -u COLORTERM -u RUST_LOG cargo run -- gen-config
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/tokio-console gen-config`
target_addr = 'http://127.0.0.1:6669/'
env_filter = 'info'
retain_for = '6s'

[charset]
lang = 'en_us.UTF8'
ascii_only = false

[colors]
enabled = true
truecolor = true
palette = 'all'

[colors.enable]
durations = true
terminated = true
```

Related to #331 

## Note
- should I use define the table in the config file, like `[charset]`?
- is it better a field name `log` instead of `env_filter`?
- what is the default value for `env_filter`?
    - I used `info` now.
- these changes may conflict with #323 