### PR TITLE
fix(console): always log to a file instead of `stderr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-console"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "atty",
  "clap",

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -32,13 +32,14 @@ OPTIONS:
         --log <ENV_FILTER>
             Log level filter for the console's internal diagnostics.
             
-            The console will log to stderr if a log level filter is provided. Since the console
-            application runs interactively, stderr should generally be redirected to a file to avoid
-            interfering with the console's text output.
-            
             [default: off]
             
             [env: RUST_LOG=]
+
+        --log-dir <LOG_DIRECTORY>
+            Path to a directory to write the console's internal logs to.
+            
+            [default: /tmp/tokio-console/logs]
 
         --no-colors <no-colors>
             Disable ANSI colors entirely

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -32,6 +32,11 @@ OPTIONS:
         --log <ENV_FILTER>
             Log level filter for the console's internal diagnostics.
             
+            Logs are written to a new file at the path given by the `--log-dir` argument (or its
+            default value), or to the system journal if `systemd-journald` support is enabled.
+            
+            If this is set to 'off' or is not set, no logs will be written.
+            
             [default: off]
             
             [env: RUST_LOG=]

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -1,5 +1,6 @@
 default_target_addr = 'http://127.0.0.1:6669/'
 log = 'off'
+log_directory = '/tmp/tokio-console/logs'
 retention = '6s'
 
 [charset]

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -31,6 +31,11 @@ pub struct Config {
 
     /// Log level filter for the console's internal diagnostics.
     ///
+    /// Logs are written to a new file at the path given by the `--log-dir`
+    /// argument (or its default value), or to the system journal if
+    /// `systemd-journald` support is enabled.
+    ///
+    /// If this is set to 'off' or is not set, no logs will be written.
     ///
     /// [default: off]
     #[clap(long = "log", env = "RUST_LOG")]
@@ -681,6 +686,8 @@ mod tests {
     }
 
     #[test]
+    // The example output includes paths, so skip this test on windows. :/
+    #[cfg_attr(windows, ignore)]
     fn toml_example_changed() {
         // Override env vars that may effect the defaults.
         clobber_env_vars();


### PR DESCRIPTION
## Motivation

Currently, the `tokio-console` CLI includes `tracing` support for
internal debugging. By default, the logs are written to `stderr`, with
the expectations that users will redirect them to a file if logging is
enabled. 

This isn't great: it means that if a `RUST_LOG` env var is set, but the
user didn't intend to enable the console's logging, logs will be written
to the terminal *while displaying the console TUI*. This results in the
TUI itself getting all messed up (see #339).

If support for `systemd-journald` is enabled, logs are instead written
to the system journal, to avoid having to use this redirection dance. We
should probably change our `tracing` configuration so logs are never
written to stderr/stdout, regardless of whether `journald` is enabled.

## Solution

This branch changes the console so that it logs to a file when
`journald` support is not enabled, rather than to stderr. The log file
location can be overridden from the CLI and config file, and defaults to
`/tmp/tokio-console/logs`. This should fix logging messing up the TUI.

Fixes #339