### PR TITLE
chore(subscriber): prepare to release v0.1.5

### DIFF
--- a/console-subscriber/CHANGELOG.md
+++ b/console-subscriber/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name=""></a>
+##  (2022-04-30)
+
+
+#### Features
+
+
+*  add support for `EnvFilter` in `Builder::init` (#337) ([1fe84b72](1fe84b72))
+
 <a name="0.1.4"></a>
 ## 0.1.4  (2022-04-11)
 

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console-subscriber"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT"
 edition = "2021"
 rust-version = "1.58.0"


### PR DESCRIPTION
<a name=""></a>
## 0.1.5 (2022-04-30)

#### Features

*  add support for `EnvFilter` in `Builder::init` (#337) ([1fe84b72](1fe84b72))