### PR TITLE
chore(console): prepare to release v0.1.5

### DIFF
--- a/tokio-console/CHANGELOG.md
+++ b/tokio-console/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="0.1.5"></a>
+## 0.1.5 (2022-04-30)
+
+
+#### Bug Fixes
+
+*  always log to a file instead of `stderr` (#340) ([ef39b9a6](ef39b9a6), closes [#339](339))
+
+#### Features
+
+*  add missing configurations to config file (#334) ([472ff52e](472ff52e), closes [#331](331))
+*  emit a parse error a config file contains unknown fields (#330) ([3a67d476](3a67d476))
+
+
 <a name="0.1.4"></a>
 ## 0.1.4 (2022-04-13)
 

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-console"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT"
 repository = "https://github.com/tokio-rs/console"
 edition = "2021"


### PR DESCRIPTION
<a name="0.1.5"></a>
## 0.1.5 (2022-04-30)

#### Bug Fixes

*  always log to a file instead of `stderr` (#340) ([ef39b9a6](ef39b9a6), closes [#339](339))

#### Features

*  add missing configurations to config file (#334) ([472ff52e](472ff52e), closes [#331](331))
*  emit a parse error a config file contains unknown fields (#330) ([3a67d476](3a67d476))