### PR TITLE
feat(config): default no_colors to false

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-console"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "atty",
  "clap",

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -46,7 +46,7 @@ OPTIONS:
             
             [default: /tmp/tokio-console/logs]
 
-        --no-colors <no-colors>
+        --no-colors
             Disable ANSI colors entirely
 
         --no-duration-colors <COLOR_DURATIONS>


### PR DESCRIPTION

Default `no_colors` setting to false.

## Why?

### Before

Input below would produce no colors in tokio console, tho `palette` flag is explicitly passed, and `no_colors` is not explicitly set to `true`.
```bash
tokio-console --palette 256 http://127.0.0.1:6669
```
---
Input below also would produce no colors in tokio-console, tho `COLORTERM` is set to `truecolor`, and `no_colors` is not explicitly set to `true`.
```bash
COLORTERM=truecolor tokio-console http://127.0.0.1:6669 
```
---
Also would produce no colors in tokio-console, tho `truecolor` is explicitly passed.
```bash
tokio-console --truecolor http://127.0.0.1:6669
```
---
So to enable colors you must explicitly set `no_colors` to `false`, like so:
```bash
tokio-console --truecolor --no-colors false http://127.0.0.1:6669
```

### After PR

Colors are enabled. 
```bash
COLORTERM=truecolor tokio-console http://127.0.0.1:6669
```
---
Colors are enabled too.
```bash
tokio-console --palette 256 http://127.0.0.1:6669
```
---
Colors are disabled, because `no_colors` is explicitly passed, tho `COLORTERM` is set to `truecolor`.
```bash
COLORTERM=truecolor tokio-console --no-colors http://127.0.0.1:6669
```

### Explanation

I think it's just not really obvious that you need to explicitly pass `--no-colors false` to enable colors, so it should default to false.