### PR TITLE
fix(subscriber): fix memory leak from resizing histograms 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "prost",
  "prost-types",

--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console-api"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT"
 edition = "2021"
 rust-version = "1.58.0"

--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -47,8 +47,18 @@ message TaskDetails {
     // The timestamp for when the update to the task took place.
     google.protobuf.Timestamp now = 2;
 
-    // HdrHistogram.rs `Histogram` serialized to binary in the V2 format
-    optional bytes poll_times_histogram = 3;
+    // A histogram of task poll durations.
+    //
+    // This is either:
+    // - the raw binary representation of a HdrHistogram.rs `Histogram`
+    //   serialized to binary in the V2 format (legacy)
+    // - a binary histogram plus details on outliers (current)
+    oneof poll_times_histogram {
+        // HdrHistogram.rs `Histogram` serialized to binary in the V2 format
+        bytes legacy_histogram = 3;
+        // A histogram plus additional data.
+        DurationHistogram histogram = 4;
+    }
 }
 
 // Data recorded when a new task is spawned.
@@ -120,4 +130,22 @@ message Stats {
     common.PollStats poll_stats = 7;
     // The total number of times this task has woken itself.
     uint64 self_wakes = 8;
+}
+
+
+message DurationHistogram {
+
+    // HdrHistogram.rs `Histogram` serialized to binary in the V2 format
+    bytes raw_histogram = 1;
+
+    // The histogram's maximum value.
+    uint64 max_value = 2;
+
+    // The number of outliers which have exceeded the histogram's maximum value.
+    uint64 high_outliers = 3;
+
+    // The highest recorded outlier. This is only present if `high_outliers` is
+    // greater than zero.
+    optional uint64 highest_outlier = 4;
+
 }

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -35,7 +35,7 @@ crossbeam-utils = "0.8.7"
 tokio = { version = "^1.15", features = ["sync", "time", "macros", "tracing"] }
 tokio-stream = "0.1"
 thread_local = "1.1.3"
-console-api = { version = "0.2.0", path = "../console-api", features = ["transport"] }
+console-api = { version = "0.3.0", path = "../console-api", features = ["transport"] }
 tonic = { version = "0.7", features = ["transport"] }
 tracing-core = "0.1.24"
 tracing = "0.1.26"

--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -326,7 +326,7 @@ impl Aggregator {
                 && subscription.update(&proto::tasks::TaskDetails {
                     task_id: Some(id.clone().into()),
                     now,
-                    poll_times_histogram: stats.serialize_histogram(),
+                    poll_times_histogram: Some(stats.poll_duration_histogram()),
                 })
             {
                 self.details_watchers
@@ -373,7 +373,7 @@ impl Aggregator {
                 let details = proto::tasks::TaskDetails {
                     task_id: Some(id.clone().into()),
                     now: Some(self.base_time.to_timestamp(Instant::now())),
-                    poll_times_histogram: task_stats.serialize_histogram(),
+                    poll_times_histogram: Some(task_stats.poll_duration_histogram()),
                 };
                 watchers.retain(|watch| watch.update(&details));
                 !watchers.is_empty()

--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -42,6 +42,12 @@ pub struct Builder {
 
     /// Whether to trace events coming from the subscriber thread
     self_trace: bool,
+
+    /// The maximum value for the task poll duration histogram.
+    ///
+    /// Any polls exceeding this duration will be clamped to this value. Higher
+    /// values will result in more memory usage.
+    pub(super) poll_duration_max: Duration,
 }
 
 impl Default for Builder {
@@ -51,6 +57,7 @@ impl Default for Builder {
             client_buffer_capacity: ConsoleLayer::DEFAULT_CLIENT_BUFFER_CAPACITY,
             publish_interval: ConsoleLayer::DEFAULT_PUBLISH_INTERVAL,
             retention: ConsoleLayer::DEFAULT_RETENTION,
+            poll_duration_max: ConsoleLayer::DEFAULT_POLL_DURATION_MAX,
             server_addr: SocketAddr::new(Server::DEFAULT_IP, Server::DEFAULT_PORT),
             recording_path: None,
             filter_env_var: "RUST_LOG".to_string(),

--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -187,6 +187,22 @@ impl Builder {
         }
     }
 
+    /// Sets the maximum value for task poll duration histograms.
+    ///
+    /// Any poll durations exceeding this value will be clamped down to this
+    /// duration and recorded as an outlier.
+    ///
+    /// By default, this is [one second]. Higher values will increase per-task
+    /// memory usage.
+    ///
+    /// [one second]: ConsoleLayer::DEFAULT_POLL_DURATION_MAX
+    pub fn poll_duration_histogram_max(self, max: Duration) -> Self {
+        Self {
+            poll_duration_max: max,
+            ..self
+        }
+    }
+
     /// Sets whether tasks, resources, and async ops from the console
     /// subscriber thread are recorded.
     ///

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -27,7 +27,7 @@ keywords = [
 
 [dependencies]
 atty = "0.2"
-console-api = { version = "0.2.0", path = "../console-api", features = ["transport"] }
+console-api = { version = "0.3.0", path = "../console-api", features = ["transport"] }
 clap = { version = "3", features = ["cargo", "derive", "env"] }
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.7", features = ["transport"] }

--- a/tokio-console/src/state/histogram.rs
+++ b/tokio-console/src/state/histogram.rs
@@ -1,0 +1,47 @@
+use console_api::tasks as proto;
+use hdrhistogram::Histogram;
+use std::{io::Cursor, time::Duration};
+
+#[derive(Debug)]
+pub(crate) struct DurationHistogram {
+    pub(crate) histogram: Histogram<u64>,
+    pub(crate) high_outliers: u64,
+    pub(crate) highest_outlier: Option<Duration>,
+}
+
+impl DurationHistogram {
+    pub(crate) fn from_poll_durations(
+        proto: &proto::task_details::PollTimesHistogram,
+    ) -> Option<Self> {
+        match proto {
+            proto::task_details::PollTimesHistogram::Histogram(hist) => Self::from_proto(hist),
+            proto::task_details::PollTimesHistogram::LegacyHistogram(bytes) => {
+                Self::from_proto_legacy(&bytes[..])
+            }
+        }
+    }
+
+    fn from_proto_legacy(bytes: &[u8]) -> Option<Self> {
+        let histogram = deserialize_histogram(bytes)?;
+        Some(Self {
+            histogram,
+            high_outliers: 0,
+            highest_outlier: None,
+        })
+    }
+
+    fn from_proto(proto: &proto::DurationHistogram) -> Option<Self> {
+        let histogram = deserialize_histogram(&proto.raw_histogram[..])?;
+        Some(Self {
+            histogram,
+            high_outliers: proto.high_outliers,
+            highest_outlier: proto.highest_outlier.map(Duration::from_nanos),
+        })
+    }
+}
+
+fn deserialize_histogram(bytes: &[u8]) -> Option<Histogram<u64>> {
+    hdrhistogram::serialization::Deserializer::new()
+        .deserialize(&mut Cursor::new(&bytes))
+        .ok()
+}

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -11,7 +11,6 @@ use std::{
     collections::hash_map::{Entry, HashMap},
     convert::{TryFrom, TryInto},
     fmt,
-    io::Cursor,
     rc::Rc,
     time::{Duration, SystemTime},
 };
@@ -22,6 +21,7 @@ use tui::{
 };
 
 pub mod async_ops;
+pub mod histogram;
 pub mod resources;
 pub mod tasks;
 
@@ -220,11 +220,10 @@ impl State {
         if let Some(id) = update.task_id {
             let details = Details {
                 span_id: id.id,
-                poll_times_histogram: update.poll_times_histogram.and_then(|data| {
-                    hdrhistogram::serialization::Deserializer::new()
-                        .deserialize(&mut Cursor::new(&data))
-                        .ok()
-                }),
+                poll_times_histogram: update
+                    .poll_times_histogram
+                    .as_ref()
+                    .and_then(histogram::DurationHistogram::from_poll_durations),
             };
 
             *self.current_task_details.borrow_mut() = Some(details);

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -1,12 +1,14 @@
 use crate::{
     intern::{self, InternedStr},
-    state::{format_location, pb_duration, Field, Ids, Metadata, Visibility},
+    state::{
+        format_location, histogram::DurationHistogram, pb_duration, Field, Ids, Metadata,
+        Visibility,
+    },
     util::Percentage,
     view,
     warnings::Linter,
 };
 use console_api as proto;
-use hdrhistogram::Histogram;
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -28,7 +30,7 @@ pub(crate) struct TasksState {
 #[derive(Debug, Default)]
 pub(crate) struct Details {
     pub(crate) span_id: u64,
-    pub(crate) poll_times_histogram: Option<Histogram<u64>>,
+    pub(crate) poll_times_histogram: Option<DurationHistogram>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -234,7 +236,7 @@ impl Details {
         self.span_id
     }
 
-    pub(crate) fn poll_times_histogram(&self) -> Option<&Histogram<u64>> {
+    pub(crate) fn poll_times_histogram(&self) -> Option<&DurationHistogram> {
         self.poll_times_histogram.as_ref()
     }
 }

--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -1,6 +1,7 @@
 use crate::{
     input,
     state::{
+        histogram::DurationHistogram,
         tasks::{Details, Task},
         DetailsRef,
     },
@@ -274,43 +275,53 @@ impl Details {
     // many buckets as the width of the render area.
     fn make_chart_data(&self, width: u16) -> (Vec<u64>, HistogramMetadata) {
         self.poll_times_histogram()
-            .map(|histogram| {
-                let step_size =
-                    ((histogram.max() - histogram.min()) as f64 / width as f64).ceil() as u64 + 1;
-                // `iter_linear` panics if step_size is 0
-                let data = if step_size > 0 {
-                    let mut found_first_nonzero = false;
-                    let data: Vec<u64> = histogram
-                        .iter_linear(step_size)
-                        .filter_map(|value| {
-                            let count = value.count_since_last_iteration();
-                            // Remove the 0s from the leading side of the buckets.
-                            // Because HdrHistogram can return empty buckets depending
-                            // on its internal state, as it approximates values.
-                            if count == 0 && !found_first_nonzero {
-                                None
-                            } else {
-                                found_first_nonzero = true;
-                                Some(count)
-                            }
-                        })
-                        .collect();
-                    data
-                } else {
-                    Vec::new()
-                };
-                let max_bucket = data.iter().max().copied().unwrap_or_default();
-                let min_bucket = data.iter().min().copied().unwrap_or_default();
-                (
-                    data,
-                    HistogramMetadata {
-                        max_value: histogram.max(),
-                        min_value: histogram.min(),
-                        max_bucket,
-                        min_bucket,
-                    },
-                )
-            })
+            .map(
+                |&DurationHistogram {
+                     ref histogram,
+                     high_outliers,
+                     highest_outlier,
+                     ..
+                 }| {
+                    let step_size = ((histogram.max() - histogram.min()) as f64 / width as f64)
+                        .ceil() as u64
+                        + 1;
+                    // `iter_linear` panics if step_size is 0
+                    let data = if step_size > 0 {
+                        let mut found_first_nonzero = false;
+                        let data: Vec<u64> = histogram
+                            .iter_linear(step_size)
+                            .filter_map(|value| {
+                                let count = value.count_since_last_iteration();
+                                // Remove the 0s from the leading side of the buckets.
+                                // Because HdrHistogram can return empty buckets depending
+                                // on its internal state, as it approximates values.
+                                if count == 0 && !found_first_nonzero {
+                                    None
+                                } else {
+                                    found_first_nonzero = true;
+                                    Some(count)
+                                }
+                            })
+                            .collect();
+                        data
+                    } else {
+                        Vec::new()
+                    };
+                    let max_bucket = data.iter().max().copied().unwrap_or_default();
+                    let min_bucket = data.iter().min().copied().unwrap_or_default();
+                    (
+                        data,
+                        HistogramMetadata {
+                            max_value: histogram.max(),
+                            min_value: histogram.min(),
+                            max_bucket,
+                            min_bucket,
+                            high_outliers,
+                            highest_outlier,
+                        },
+                    )
+                },
+            )
             .unwrap_or_default()
     }
 
@@ -318,17 +329,20 @@ impl Details {
     fn make_percentiles_widget(&self, styles: &view::Styles) -> Text<'static> {
         let mut text = Text::default();
         let histogram = self.poll_times_histogram();
-        let percentiles = histogram.iter().flat_map(|histogram| {
-            let pairs = [10f64, 25f64, 50f64, 75f64, 90f64, 95f64, 99f64]
+        let percentiles =
+            histogram
                 .iter()
-                .map(move |i| (*i, histogram.value_at_percentile(*i)));
-            pairs.map(|pair| {
-                Spans::from(vec![
-                    bold(format!("p{:>2}: ", pair.0)),
-                    dur(styles, Duration::from_nanos(pair.1)),
-                ])
-            })
-        });
+                .flat_map(|&DurationHistogram { ref histogram, .. }| {
+                    let pairs = [10f64, 25f64, 50f64, 75f64, 90f64, 95f64, 99f64]
+                        .iter()
+                        .map(move |i| (*i, histogram.value_at_percentile(*i)));
+                    pairs.map(|pair| {
+                        Spans::from(vec![
+                            bold(format!("p{:>2}: ", pair.0)),
+                            dur(styles, Duration::from_nanos(pair.1)),
+                        ])
+                    })
+                });
         text.extend(percentiles);
         text
     }


### PR DESCRIPTION
## Motivation

Currently, the console uses the [`hdrhistogram` crate][1] to record poll
duration histograms. We currently construct our histograms with
`HdrHistogram::new`, [which _does not_ bound the maximum memory use of
the histogram][2]. This means that a task may use increasingly large
amounts of memory to store its poll duration histogram. When a program
contains tasks that run for the program's entire lifetime, this can
result in those tasks' histograms using increasingly large amounts of
memory.

## Solution

This branch changes `console-subscriber` to bound the maximum value of
the histogram, and report outliers when a duration higher than the bound
is recorded.

In addition, I've added new data to the wire proto for recording the number
of outliers in a histogram (now that they have an upper bound), and I've
updated the UI to display the outlier count along with the highest outlier.

For example, here's what the UI looks like if I run the example app and
set the maximum duration to 100 microseconds:

![image](https://user-images.githubusercontent.com/2796466/169893884-5325e1af-7269-4747-93c4-9f1d8903751b.png)


Fixes https://github.com/tokio-rs/console/issues/350

[1]: https://docs.rs/hdrhistogram/latest/hdrhistogram/
[2]: https://github.com/HdrHistogram/HdrHistogram_rust#recording-samples

