### PR TITLE
chore(ci): test `tokio-console` with `--locked`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,6 @@ env:
   RUSTUP_MAX_RETRIES: 10
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
-  # Make 1.58 MSRV due to <=1.57 failing to build console-api due to a bug
-  # with cargo version resolution.
-  minrust: 1.58.0
 
 jobs:
   check:
@@ -57,9 +54,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable]
-        # test MSRV on ubuntu as well
+        # Make 1.58 MSRV due to <=1.57 failing to build console-api due to a bug
+        # with cargo version resolution.
         include:
-          - rust: ${{ env.minrust }}
+          - rust: 1.58.0
             os: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   # Make 1.58 MSRV due to <=1.57 failing to build console-api due to a bug
-  # with cargo version resolution. 
+  # with cargo version resolution.
   minrust: 1.58.0
 
 jobs:
@@ -50,48 +50,46 @@ jobs:
           command: check
 
   test_os:
-    name: Tests on ${{ matrix.os }}
+    name: Tests on ${{ matrix.os }} with Rust ${{ matrix.rust }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [stable]
+        # test MSRV on ubuntu as well
+        include:
+          - rust: ${{ env.minrust }}
+            os: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install ${{ matrix.rust }} toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - uses: Swatinem/rust-cache@v1
 
-      - name: Run cargo test
+      - name: Run cargo test (API)
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: -p console-api
 
-  test_msrv:
-    name: Tests on MSRV
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install MSRV toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.minrust }}
-          override: true
-      - uses: Swatinem/rust-cache@v1
-
-      - name: Run cargo test
+      - name: Run cargo test (subscriber)
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: -p console-subscriber
+
+      - name: Run cargo test (console)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p tokio-console --locked
 
   lints:
     name: Lints


### PR DESCRIPTION
This branch changes the CI configuration to run `cargo test` for the
`tokio-console` crate with `--locked`, to ensure the lockfile is up to
date.

Additionally, I consolidated all the test workflows into a single job
definition, to reduce duplication.