### PR TITLE
chore(console): prepare to release v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,32 +192,50 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.1.7"
+name = "clap_complete"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -897,9 +915,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "owo-colors"
@@ -1430,10 +1445,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-console"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "atty",
  "clap",
+ "clap_complete",
  "color-eyre",
  "console-api",
  "crossterm",

--- a/tokio-console/CHANGELOG.md
+++ b/tokio-console/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="0.1.6"></a>
+## 0.1.6 (2022-05-24)
+
+
+#### Bug Fixes
+
+*  default `--no_colors` to `false` (#344) ([e58352fe](e58352fe))
+
+#### Features
+
+*  add subcommand to gen shell completions (#336) ([df4d4683](df4d4683))
+*  display outliers in histogram view (#351) ([dec891ff](dec891ff))
+
+
 <a name="0.1.5"></a>
 ## 0.1.5 (2022-04-30)
 

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-console"
-version = "0.1.5"
+version = "0.1.6"
 license = "MIT"
 repository = "https://github.com/tokio-rs/console"
 edition = "2021"


### PR DESCRIPTION
<a name="0.1.6"></a>
## 0.1.6 (2022-05-24)

#### Bug Fixes

*  default `--no_colors` to `false` (#344) ([e58352fe](e58352fe))

#### Features

*  add subcommand to gen shell completions (#336) ([df4d4683](df4d4683))
*  display outliers in histogram view (#351) ([dec891ff](dec891ff))