### PR TITLE
chore: update Tonic and Prost dependencies

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+
+[alias]
+xtask = "run --manifest-path ./xtask/Cargo.toml --"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,11 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v1
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run cargo test (API)
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ name = "console-api"
 version = "0.4.0"
 dependencies = [
  "prost",
+ "prost-build",
  "prost-types",
  "tonic",
  "tonic-build",
@@ -1070,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49d928704208aba2cb1fb022ce1a319bdedcb03caf51ddf82734fa903407762"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
  "bytes",
  "heck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,5 +1906,6 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "color-eyre",
  "tonic-build",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,15 +239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "color-eyre"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "prost",
  "prost-types",
@@ -1069,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd5316aa8f5c82add416dfbc25116b84b748a21153f512917e8143640a71bbd"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1079,13 +1070,11 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328f9f29b82409216decb172d81e936415d21245befa79cd34c3f29d87d1c50b"
+checksum = "d49d928704208aba2cb1fb022ce1a319bdedcb03caf51ddf82734fa903407762"
 dependencies = [
  "bytes",
- "cfg-if",
- "cmake",
  "heck",
  "itertools",
  "lazy_static",
@@ -1101,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df35198f0777b75e9ff669737c6da5136b59dba33cf5a010a6d1cc4d56defc6f"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1114,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926681c118ae6e512a3ccefd4abbe5521a14f4cc1e207356d4d00c0b7f2006fd"
+checksum = "d30bc806a29b347314be074ff0608ef8e547286e8ea68b061a2fe55689edc01f"
 dependencies = [
  "bytes",
  "prost",
@@ -1528,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1a361140b1af3f548e0a5105126b3fc737542f6cd4947b66419c80be07db22"
+checksum = "498f271adc46acce75d66f639e4d35b31b2394c295c82496727dafa16d465dd2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1560,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d17087af5c80e5d5fc8ba9878e60258065a0a757e35efe7a05b7904bece1943"
+checksum = "2fbcd2800e34e743b9ae795867d5f77b535d3a3be69fd731e39145719752df8c"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1910,3 +1899,11 @@ name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "tonic-build",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "tokio-console",
     "console-subscriber",
-    "console-api"
+    "console-api",
+    "xtask"
 ]
 resolver = "2"

--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console-api"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 edition = "2021"
 rust-version = "1.58.0"
@@ -29,17 +29,17 @@ keywords = [
 transport = ["tonic-build/transport", "tonic/transport"]
 
 [dependencies]
-tonic = { version = "0.7", default-features = false, features = [
+tonic = { version = "0.8", default-features = false, features = [
     "prost",
     "codegen",
     "transport",
 ] }
-prost = "0.10"
-prost-types = "0.10"
+prost = "0.11"
+prost-types = "0.11"
 tracing-core = "0.1.17"
 
 [dev-dependencies]
-tonic-build = { version = "0.7", default-features = false, features = [
+tonic-build = { version = "0.8", default-features = false, features = [
     "prost", "transport"
 ] }
 

--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -42,6 +42,8 @@ tracing-core = "0.1.17"
 tonic-build = { version = "0.8", default-features = false, features = [
     "prost", "transport"
 ] }
+# explicit dep so we can get the version with fixed whitespace.
+prost-build = "0.11.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/console-api/src/generated/rs.tokio.console.async_ops.rs
+++ b/console-api/src/generated/rs.tokio.console.async_ops.rs
@@ -1,85 +1,85 @@
-/// An `AsyncOp` state update. 
+///  An `AsyncOp` state update. 
 ///
-/// This includes a list of any new async ops, and updates to the associated statistics
-/// for any async ops that have changed since the last update.
+///  This includes a list of any new async ops, and updates to the associated statistics
+///  for any async ops that have changed since the last update.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AsyncOpUpdate {
-    /// A list of new async operations that were created since the last `AsyncOpUpdate`
-    /// was sent. Note that the fact that an async operation has been created
-    /// does not mean that is has been polled or is being polled. This information
-    /// is reflected in the `Stats` of the operation.
+    ///  A list of new async operations that were created since the last `AsyncOpUpdate`
+    ///  was sent. Note that the fact that an async operation has been created
+    ///  does not mean that is has been polled or is being polled. This information
+    ///  is reflected in the `Stats` of the operation.
     #[prost(message, repeated, tag="1")]
     pub new_async_ops: ::prost::alloc::vec::Vec<AsyncOp>,
-    /// Any async op stats that have changed since the last update.
+    ///  Any async op stats that have changed since the last update.
     #[prost(map="uint64, message", tag="2")]
     pub stats_update: ::std::collections::HashMap<u64, Stats>,
-    /// A count of how many async op events (e.g. polls, creation, etc) were not
-    /// recorded because the application's event buffer was at capacity.
+    ///  A count of how many async op events (e.g. polls, creation, etc) were not
+    ///  recorded because the application's event buffer was at capacity.
     ///
-    /// If everything is working normally, this should be 0. If it is greater
-    /// than 0, that may indicate that some data is missing from this update, and
-    /// it may be necessary to increase the number of events buffered by the
-    /// application to ensure that data loss is avoided.
+    ///  If everything is working normally, this should be 0. If it is greater
+    ///  than 0, that may indicate that some data is missing from this update, and
+    ///  it may be necessary to increase the number of events buffered by the
+    ///  application to ensure that data loss is avoided.
     ///
-    /// If the application's instrumentation ensures reliable delivery of events,
-    /// this will always be 0.
+    ///  If the application's instrumentation ensures reliable delivery of events,
+    ///  this will always be 0.
     #[prost(uint64, tag="3")]
     pub dropped_events: u64,
 }
-/// An async operation.
+///  An async operation.
 ///
-/// An async operation is an operation that is associated with a resource
-/// This could, for example, be a a read or write on a TCP stream, or a receive operation on
-/// a channel.
+///  An async operation is an operation that is associated with a resource
+///  This could, for example, be a a read or write on a TCP stream, or a receive operation on
+///  a channel.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AsyncOp {
-    /// The async op's ID.
+    ///  The async op's ID.
     ///
-    /// This uniquely identifies this op across all *currently live*
-    /// ones.
+    ///  This uniquely identifies this op across all *currently live*
+    ///  ones.
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<super::common::Id>,
-    /// The numeric ID of the op's `Metadata`.
+    ///  The numeric ID of the op's `Metadata`.
     ///
-    /// This identifies the `Metadata` that describes the `tracing` span
-    /// corresponding to this async op. The metadata for this ID will have been sent
-    /// in a prior `RegisterMetadata` message.
+    ///  This identifies the `Metadata` that describes the `tracing` span
+    ///  corresponding to this async op. The metadata for this ID will have been sent
+    ///  in a prior `RegisterMetadata` message.
     #[prost(message, optional, tag="2")]
     pub metadata: ::core::option::Option<super::common::MetaId>,
-    /// The source of this async operation. Most commonly this should be the name
-    /// of the method where the instantiation of this op has happened.
+    ///  The source of this async operation. Most commonly this should be the name
+    ///  of the method where the instantiation of this op has happened.
     #[prost(string, tag="3")]
     pub source: ::prost::alloc::string::String,
-    /// The ID of the parent async op.
+    ///  The ID of the parent async op.
     ///
-    /// This field is only set if this async op was created while inside of another
-    /// async op.  For example, `tokio::sync`'s `Mutex::lock` internally calls
-    /// `Semaphore::acquire`.
+    ///  This field is only set if this async op was created while inside of another
+    ///  async op.  For example, `tokio::sync`'s `Mutex::lock` internally calls
+    ///  `Semaphore::acquire`.
     ///
-    /// This field can be empty; if it is empty, this async op is not a child of another
-    /// async op.
+    ///  This field can be empty; if it is empty, this async op is not a child of another
+    ///  async op.
     #[prost(message, optional, tag="4")]
     pub parent_async_op_id: ::core::option::Option<super::common::Id>,
-    /// The resources's ID.
+    ///  The resources's ID.
     #[prost(message, optional, tag="5")]
     pub resource_id: ::core::option::Option<super::common::Id>,
 }
-/// Statistics associated with a given async operation.
+///  Statistics associated with a given async operation.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Stats {
-    /// Timestamp of when the async op has been created.
+    ///  Timestamp of when the async op has been created.
     #[prost(message, optional, tag="1")]
     pub created_at: ::core::option::Option<::prost_types::Timestamp>,
-    /// Timestamp of when the async op was dropped.
+    ///  Timestamp of when the async op was dropped.
     #[prost(message, optional, tag="2")]
     pub dropped_at: ::core::option::Option<::prost_types::Timestamp>,
-    /// The Id of the task that is awaiting on this op.
+    ///  The Id of the task that is awaiting on this op.
     #[prost(message, optional, tag="4")]
     pub task_id: ::core::option::Option<super::common::Id>,
-    /// Contains the operation poll stats.
+    ///  Contains the operation poll stats.
     #[prost(message, optional, tag="5")]
     pub poll_stats: ::core::option::Option<super::common::PollStats>,
-    /// State attributes of the async op.
+    ///  State attributes of the async op.
     #[prost(message, repeated, tag="6")]
     pub attributes: ::prost::alloc::vec::Vec<super::common::Attribute>,
 }

--- a/console-api/src/generated/rs.tokio.console.async_ops.rs
+++ b/console-api/src/generated/rs.tokio.console.async_ops.rs
@@ -1,85 +1,85 @@
-///  An `AsyncOp` state update. 
+/// An `AsyncOp` state update. 
 ///
-///  This includes a list of any new async ops, and updates to the associated statistics
-///  for any async ops that have changed since the last update.
+/// This includes a list of any new async ops, and updates to the associated statistics
+/// for any async ops that have changed since the last update.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AsyncOpUpdate {
-    ///  A list of new async operations that were created since the last `AsyncOpUpdate`
-    ///  was sent. Note that the fact that an async operation has been created
-    ///  does not mean that is has been polled or is being polled. This information
-    ///  is reflected in the `Stats` of the operation.
+    /// A list of new async operations that were created since the last `AsyncOpUpdate`
+    /// was sent. Note that the fact that an async operation has been created
+    /// does not mean that is has been polled or is being polled. This information
+    /// is reflected in the `Stats` of the operation.
     #[prost(message, repeated, tag="1")]
     pub new_async_ops: ::prost::alloc::vec::Vec<AsyncOp>,
-    ///  Any async op stats that have changed since the last update.
+    /// Any async op stats that have changed since the last update.
     #[prost(map="uint64, message", tag="2")]
     pub stats_update: ::std::collections::HashMap<u64, Stats>,
-    ///  A count of how many async op events (e.g. polls, creation, etc) were not
-    ///  recorded because the application's event buffer was at capacity.
+    /// A count of how many async op events (e.g. polls, creation, etc) were not
+    /// recorded because the application's event buffer was at capacity.
     ///
-    ///  If everything is working normally, this should be 0. If it is greater
-    ///  than 0, that may indicate that some data is missing from this update, and
-    ///  it may be necessary to increase the number of events buffered by the
-    ///  application to ensure that data loss is avoided.
+    /// If everything is working normally, this should be 0. If it is greater
+    /// than 0, that may indicate that some data is missing from this update, and
+    /// it may be necessary to increase the number of events buffered by the
+    /// application to ensure that data loss is avoided.
     ///
-    ///  If the application's instrumentation ensures reliable delivery of events,
-    ///  this will always be 0.
+    /// If the application's instrumentation ensures reliable delivery of events,
+    /// this will always be 0.
     #[prost(uint64, tag="3")]
     pub dropped_events: u64,
 }
-///  An async operation.
+/// An async operation.
 ///
-///  An async operation is an operation that is associated with a resource
-///  This could, for example, be a a read or write on a TCP stream, or a receive operation on
-///  a channel.
+/// An async operation is an operation that is associated with a resource
+/// This could, for example, be a a read or write on a TCP stream, or a receive operation on
+/// a channel.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AsyncOp {
-    ///  The async op's ID.
+    /// The async op's ID.
     ///
-    ///  This uniquely identifies this op across all *currently live*
-    ///  ones.
+    /// This uniquely identifies this op across all *currently live*
+    /// ones.
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<super::common::Id>,
-    ///  The numeric ID of the op's `Metadata`.
+    /// The numeric ID of the op's `Metadata`.
     ///
-    ///  This identifies the `Metadata` that describes the `tracing` span
-    ///  corresponding to this async op. The metadata for this ID will have been sent
-    ///  in a prior `RegisterMetadata` message.
+    /// This identifies the `Metadata` that describes the `tracing` span
+    /// corresponding to this async op. The metadata for this ID will have been sent
+    /// in a prior `RegisterMetadata` message.
     #[prost(message, optional, tag="2")]
     pub metadata: ::core::option::Option<super::common::MetaId>,
-    ///  The source of this async operation. Most commonly this should be the name
-    ///  of the method where the instantiation of this op has happened.
+    /// The source of this async operation. Most commonly this should be the name
+    /// of the method where the instantiation of this op has happened.
     #[prost(string, tag="3")]
     pub source: ::prost::alloc::string::String,
-    ///  The ID of the parent async op.
+    /// The ID of the parent async op.
     ///
-    ///  This field is only set if this async op was created while inside of another
-    ///  async op.  For example, `tokio::sync`'s `Mutex::lock` internally calls
-    ///  `Semaphore::acquire`.
+    /// This field is only set if this async op was created while inside of another
+    /// async op.  For example, `tokio::sync`'s `Mutex::lock` internally calls
+    /// `Semaphore::acquire`.
     ///
-    ///  This field can be empty; if it is empty, this async op is not a child of another
-    ///  async op.
+    /// This field can be empty; if it is empty, this async op is not a child of another
+    /// async op.
     #[prost(message, optional, tag="4")]
     pub parent_async_op_id: ::core::option::Option<super::common::Id>,
-    ///  The resources's ID.
+    /// The resources's ID.
     #[prost(message, optional, tag="5")]
     pub resource_id: ::core::option::Option<super::common::Id>,
 }
-///  Statistics associated with a given async operation.
+/// Statistics associated with a given async operation.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Stats {
-    ///  Timestamp of when the async op has been created.
+    /// Timestamp of when the async op has been created.
     #[prost(message, optional, tag="1")]
     pub created_at: ::core::option::Option<::prost_types::Timestamp>,
-    ///  Timestamp of when the async op was dropped.
+    /// Timestamp of when the async op was dropped.
     #[prost(message, optional, tag="2")]
     pub dropped_at: ::core::option::Option<::prost_types::Timestamp>,
-    ///  The Id of the task that is awaiting on this op.
+    /// The Id of the task that is awaiting on this op.
     #[prost(message, optional, tag="4")]
     pub task_id: ::core::option::Option<super::common::Id>,
-    ///  Contains the operation poll stats.
+    /// Contains the operation poll stats.
     #[prost(message, optional, tag="5")]
     pub poll_stats: ::core::option::Option<super::common::PollStats>,
-    ///  State attributes of the async op.
+    /// State attributes of the async op.
     #[prost(message, repeated, tag="6")]
     pub attributes: ::prost::alloc::vec::Vec<super::common::Attribute>,
 }

--- a/console-api/src/generated/rs.tokio.console.common.rs
+++ b/console-api/src/generated/rs.tokio.console.common.rs
@@ -1,168 +1,168 @@
-///  Unique identifier for each task.
+/// Unique identifier for each task.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Id {
-    ///  The unique identifier's concrete value.
+    /// The unique identifier's concrete value.
     #[prost(uint64, tag="1")]
     pub id: u64,
 }
-///  A Rust source code location.
+/// A Rust source code location.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Location {
-    ///  The file path
+    /// The file path
     #[prost(string, optional, tag="1")]
     pub file: ::core::option::Option<::prost::alloc::string::String>,
-    ///  The Rust module path
+    /// The Rust module path
     #[prost(string, optional, tag="2")]
     pub module_path: ::core::option::Option<::prost::alloc::string::String>,
-    ///  The line number in the source code file.
+    /// The line number in the source code file.
     #[prost(uint32, optional, tag="3")]
     pub line: ::core::option::Option<u32>,
-    ///  The character in `line`.
+    /// The character in `line`.
     #[prost(uint32, optional, tag="4")]
     pub column: ::core::option::Option<u32>,
 }
-///  Unique identifier for metadata.
+/// Unique identifier for metadata.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MetaId {
-    ///  The unique identifier's concrete value.
+    /// The unique identifier's concrete value.
     #[prost(uint64, tag="1")]
     pub id: u64,
 }
-///  Unique identifier for spans.
+/// Unique identifier for spans.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpanId {
-    ///  The unique identifier's concrete value.
+    /// The unique identifier's concrete value.
     #[prost(uint64, tag="1")]
     pub id: u64,
 }
-///  A message representing a key-value pair of data associated with a `Span`
+/// A message representing a key-value pair of data associated with a `Span`
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Field {
-    ///  Metadata for the task span that the field came from.
+    /// Metadata for the task span that the field came from.
     #[prost(message, optional, tag="8")]
     pub metadata_id: ::core::option::Option<MetaId>,
-    ///  The key of the key-value pair.
+    /// The key of the key-value pair.
     ///
-    ///  This is either represented as a string, or as an index into a `Metadata`'s 
-    ///  array of field name strings.
+    /// This is either represented as a string, or as an index into a `Metadata`'s 
+    /// array of field name strings.
     #[prost(oneof="field::Name", tags="1, 2")]
     pub name: ::core::option::Option<field::Name>,
-    ///  The value of the key-value pair.
+    /// The value of the key-value pair.
     #[prost(oneof="field::Value", tags="3, 4, 5, 6, 7")]
     pub value: ::core::option::Option<field::Value>,
 }
 /// Nested message and enum types in `Field`.
 pub mod field {
-    ///  The key of the key-value pair.
+    /// The key of the key-value pair.
     ///
-    ///  This is either represented as a string, or as an index into a `Metadata`'s 
-    ///  array of field name strings.
+    /// This is either represented as a string, or as an index into a `Metadata`'s 
+    /// array of field name strings.
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Name {
-        ///  The string representation of the name.
+        /// The string representation of the name.
         #[prost(string, tag="1")]
         StrName(::prost::alloc::string::String),
-        ///  An index position into the `Metadata.field_names` of the metadata
-        ///  for the task span that the field came from.
+        /// An index position into the `Metadata.field_names` of the metadata
+        /// for the task span that the field came from.
         #[prost(uint64, tag="2")]
         NameIdx(u64),
     }
-    ///  The value of the key-value pair.
+    /// The value of the key-value pair.
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
-        ///  A value serialized to a string using `fmt::Debug`.
+        /// A value serialized to a string using `fmt::Debug`.
         #[prost(string, tag="3")]
         DebugVal(::prost::alloc::string::String),
-        ///  A string value.
+        /// A string value.
         #[prost(string, tag="4")]
         StrVal(::prost::alloc::string::String),
-        ///  An unsigned integer value.
+        /// An unsigned integer value.
         #[prost(uint64, tag="5")]
         U64Val(u64),
-        ///  A signed integer value.
+        /// A signed integer value.
         #[prost(sint64, tag="6")]
         I64Val(i64),
-        ///  A boolean value.
+        /// A boolean value.
         #[prost(bool, tag="7")]
         BoolVal(bool),
     }
 }
-///  Represents a period of time in which a program was executing in a particular context.
+/// Represents a period of time in which a program was executing in a particular context.
 ///
-///  Corresponds to `Span` in the `tracing` crate.
+/// Corresponds to `Span` in the `tracing` crate.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Span {
-    ///  An Id that uniquely identifies it in relation to other spans.
+    /// An Id that uniquely identifies it in relation to other spans.
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<SpanId>,
-    ///  Identifier for metadata describing static characteristics of all spans originating
-    ///  from that callsite, such as its name, source code location, verbosity level, and
-    ///  the names of its fields.
+    /// Identifier for metadata describing static characteristics of all spans originating
+    /// from that callsite, such as its name, source code location, verbosity level, and
+    /// the names of its fields.
     #[prost(message, optional, tag="2")]
     pub metadata_id: ::core::option::Option<MetaId>,
-    ///  User-defined key-value pairs of arbitrary data that describe the context the span represents,
+    /// User-defined key-value pairs of arbitrary data that describe the context the span represents,
     #[prost(message, repeated, tag="3")]
     pub fields: ::prost::alloc::vec::Vec<Field>,
-    ///  Timestamp for the span.
+    /// Timestamp for the span.
     #[prost(message, optional, tag="4")]
     pub at: ::core::option::Option<::prost_types::Timestamp>,
 }
-///  Any new metadata that was registered since the last update.
+/// Any new metadata that was registered since the last update.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterMetadata {
-    ///  The new metadata that was registered since the last update.
+    /// The new metadata that was registered since the last update.
     #[prost(message, repeated, tag="1")]
     pub metadata: ::prost::alloc::vec::Vec<register_metadata::NewMetadata>,
 }
 /// Nested message and enum types in `RegisterMetadata`.
 pub mod register_metadata {
-    ///  One metadata element registered since the last update.
+    /// One metadata element registered since the last update.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NewMetadata {
-        ///  Unique identifier for `metadata`.
+        /// Unique identifier for `metadata`.
         #[prost(message, optional, tag="1")]
         pub id: ::core::option::Option<super::MetaId>,
-        ///  The metadata payload.
+        /// The metadata payload.
         #[prost(message, optional, tag="2")]
         pub metadata: ::core::option::Option<super::Metadata>,
     }
 }
-///  Metadata associated with a span or event.
+/// Metadata associated with a span or event.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Metadata {
-    ///  The name of the span or event.
+    /// The name of the span or event.
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
-    ///  Describes the part of the system where the span or event that this
-    ///  metadata describes occurred.
+    /// Describes the part of the system where the span or event that this
+    /// metadata describes occurred.
     #[prost(string, tag="2")]
     pub target: ::prost::alloc::string::String,
-    ///  The path to the Rust module where the span occurred.
+    /// The path to the Rust module where the span occurred.
     #[prost(string, tag="3")]
     pub module_path: ::prost::alloc::string::String,
-    ///  The Rust source location associated with the span or event.
+    /// The Rust source location associated with the span or event.
     #[prost(message, optional, tag="4")]
     pub location: ::core::option::Option<Location>,
-    ///  Indicates whether metadata is associated with a span or with an event.
+    /// Indicates whether metadata is associated with a span or with an event.
     #[prost(enumeration="metadata::Kind", tag="5")]
     pub kind: i32,
-    ///  Describes the level of verbosity of a span or event.
+    /// Describes the level of verbosity of a span or event.
     #[prost(enumeration="metadata::Level", tag="6")]
     pub level: i32,
-    ///  The names of the key-value fields attached to the
-    ///  span or event this metadata is associated with.
+    /// The names of the key-value fields attached to the
+    /// span or event this metadata is associated with.
     #[prost(string, repeated, tag="7")]
     pub field_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `Metadata`.
 pub mod metadata {
-    ///  Indicates whether metadata is associated with a span or with an event.
+    /// Indicates whether metadata is associated with a span or with an event.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Kind {
-        ///  Indicates metadata is associated with a span.
+        /// Indicates metadata is associated with a span.
         Span = 0,
-        ///  Indicates metadata is associated with an event.
+        /// Indicates metadata is associated with an event.
         Event = 1,
     }
     impl Kind {
@@ -177,30 +177,30 @@ pub mod metadata {
             }
         }
     }
-    ///  Describes the level of verbosity of a span or event.
+    /// Describes the level of verbosity of a span or event.
     ///
-    ///  Corresponds to `Level` in the `tracing` crate.
+    /// Corresponds to `Level` in the `tracing` crate.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Level {
-        ///  The "error" level.
+        /// The "error" level.
         ///
-        ///  Designates very serious errors.
+        /// Designates very serious errors.
         Error = 0,
-        ///  The "warn" level.
+        /// The "warn" level.
         ///
-        ///  Designates hazardous situations.
+        /// Designates hazardous situations.
         Warn = 1,
-        ///  The "info" level.
-        ///  Designates useful information.
+        /// The "info" level.
+        /// Designates useful information.
         Info = 2,
-        ///  The "debug" level.
+        /// The "debug" level.
         ///
-        ///  Designates lower priority information.
+        /// Designates lower priority information.
         Debug = 3,
-        ///  The "trace" level.
+        /// The "trace" level.
         ///
-        ///  Designates very low priority, often extremely verbose, information.
+        /// Designates very low priority, often extremely verbose, information.
         Trace = 4,
     }
     impl Level {
@@ -219,61 +219,61 @@ pub mod metadata {
         }
     }
 }
-///  Contains stats about objects that can be polled. Currently these can be:
-///  - tasks that have been spawned
-///  - async operations on resources that are performed within the context of a task
+/// Contains stats about objects that can be polled. Currently these can be:
+/// - tasks that have been spawned
+/// - async operations on resources that are performed within the context of a task
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PollStats {
-    ///  The total number of times this object has been polled.
+    /// The total number of times this object has been polled.
     #[prost(uint64, tag="1")]
     pub polls: u64,
-    ///  The timestamp of the first time this object was polled.
+    /// The timestamp of the first time this object was polled.
     ///
-    ///  If this is `None`, the object has not yet been polled.
+    /// If this is `None`, the object has not yet been polled.
     ///
-    ///  Subtracting this timestamp from `created_at` can be used to calculate the
-    ///  time to first poll for this object, a measurement of executor latency.
+    /// Subtracting this timestamp from `created_at` can be used to calculate the
+    /// time to first poll for this object, a measurement of executor latency.
     #[prost(message, optional, tag="3")]
     pub first_poll: ::core::option::Option<::prost_types::Timestamp>,
-    ///  The timestamp of the most recent time this objects's poll method was invoked.
+    /// The timestamp of the most recent time this objects's poll method was invoked.
     ///
-    ///  If this is `None`, the object has not yet been polled.
+    /// If this is `None`, the object has not yet been polled.
     ///
-    ///  If the object has only been polled a single time, then this value may be
-    ///  equal to the `first_poll` timestamp.
+    /// If the object has only been polled a single time, then this value may be
+    /// equal to the `first_poll` timestamp.
     ///
     #[prost(message, optional, tag="4")]
     pub last_poll_started: ::core::option::Option<::prost_types::Timestamp>,
-    ///  The timestamp of the most recent time this objects's poll method finished execution.
+    /// The timestamp of the most recent time this objects's poll method finished execution.
     ///
-    ///  If this is `None`, the object has not yet been polled or is currently being polled.
+    /// If this is `None`, the object has not yet been polled or is currently being polled.
     ///
-    ///  If the object does not exist anymore, then this is the time the final invocation of
-    ///  its poll method has completed.
+    /// If the object does not exist anymore, then this is the time the final invocation of
+    /// its poll method has completed.
     #[prost(message, optional, tag="5")]
     pub last_poll_ended: ::core::option::Option<::prost_types::Timestamp>,
-    ///  The total duration this object was being *actively polled*, summed across
-    ///  all polls. Note that this includes only polls that have completed and is
-    ///  not reflecting any inprogress polls. Subtracting `busy_time` from the
-    ///  total lifetime of the polled object results in the amount of time it
-    ///  has spent *waiting* to be polled.
+    /// The total duration this object was being *actively polled*, summed across
+    /// all polls. Note that this includes only polls that have completed and is
+    /// not reflecting any inprogress polls. Subtracting `busy_time` from the
+    /// total lifetime of the polled object results in the amount of time it
+    /// has spent *waiting* to be polled.
     #[prost(message, optional, tag="6")]
     pub busy_time: ::core::option::Option<::prost_types::Duration>,
 }
-///  State attributes of an entity. These are dependent on the type of the entity.
+/// State attributes of an entity. These are dependent on the type of the entity.
 ///
-///  For example, a timer resource will have a duration, while a semaphore resource may
-///  have a permit count. Likewise, the async ops of a semaphore may have attributes
-///  indicating how many permits they are trying to acquire vs how many are acquired.
-///  These values may change over time. Therefore, they live in the runtime stats rather
-///  than the static data describing the entity.
+/// For example, a timer resource will have a duration, while a semaphore resource may
+/// have a permit count. Likewise, the async ops of a semaphore may have attributes
+/// indicating how many permits they are trying to acquire vs how many are acquired.
+/// These values may change over time. Therefore, they live in the runtime stats rather
+/// than the static data describing the entity.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Attribute {
-    ///  The key-value pair for the attribute
+    /// The key-value pair for the attribute
     #[prost(message, optional, tag="1")]
     pub field: ::core::option::Option<Field>,
-    ///  Some values carry a unit of measurement. For example, a duration
-    ///  carries an associated unit of time, such as "ms" for milliseconds.
+    /// Some values carry a unit of measurement. For example, a duration
+    /// carries an associated unit of time, such as "ms" for milliseconds.
     #[prost(string, optional, tag="2")]
     pub unit: ::core::option::Option<::prost::alloc::string::String>,
 }

--- a/console-api/src/generated/rs.tokio.console.common.rs
+++ b/console-api/src/generated/rs.tokio.console.common.rs
@@ -1,252 +1,279 @@
-/// Unique identifier for each task.
+///  Unique identifier for each task.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Id {
-    /// The unique identifier's concrete value.
+    ///  The unique identifier's concrete value.
     #[prost(uint64, tag="1")]
     pub id: u64,
 }
-/// A Rust source code location.
+///  A Rust source code location.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Location {
-    /// The file path
+    ///  The file path
     #[prost(string, optional, tag="1")]
     pub file: ::core::option::Option<::prost::alloc::string::String>,
-    /// The Rust module path
+    ///  The Rust module path
     #[prost(string, optional, tag="2")]
     pub module_path: ::core::option::Option<::prost::alloc::string::String>,
-    /// The line number in the source code file.
+    ///  The line number in the source code file.
     #[prost(uint32, optional, tag="3")]
     pub line: ::core::option::Option<u32>,
-    /// The character in `line`.
+    ///  The character in `line`.
     #[prost(uint32, optional, tag="4")]
     pub column: ::core::option::Option<u32>,
 }
-/// Unique identifier for metadata.
+///  Unique identifier for metadata.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MetaId {
-    /// The unique identifier's concrete value.
+    ///  The unique identifier's concrete value.
     #[prost(uint64, tag="1")]
     pub id: u64,
 }
-/// Unique identifier for spans.
+///  Unique identifier for spans.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpanId {
-    /// The unique identifier's concrete value.
+    ///  The unique identifier's concrete value.
     #[prost(uint64, tag="1")]
     pub id: u64,
 }
-/// A message representing a key-value pair of data associated with a `Span`
+///  A message representing a key-value pair of data associated with a `Span`
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Field {
-    /// Metadata for the task span that the field came from.
+    ///  Metadata for the task span that the field came from.
     #[prost(message, optional, tag="8")]
     pub metadata_id: ::core::option::Option<MetaId>,
-    /// The key of the key-value pair.
+    ///  The key of the key-value pair.
     ///
-    /// This is either represented as a string, or as an index into a `Metadata`'s 
-    /// array of field name strings.
+    ///  This is either represented as a string, or as an index into a `Metadata`'s 
+    ///  array of field name strings.
     #[prost(oneof="field::Name", tags="1, 2")]
     pub name: ::core::option::Option<field::Name>,
-    /// The value of the key-value pair.
+    ///  The value of the key-value pair.
     #[prost(oneof="field::Value", tags="3, 4, 5, 6, 7")]
     pub value: ::core::option::Option<field::Value>,
 }
 /// Nested message and enum types in `Field`.
 pub mod field {
-    /// The key of the key-value pair.
+    ///  The key of the key-value pair.
     ///
-    /// This is either represented as a string, or as an index into a `Metadata`'s 
-    /// array of field name strings.
+    ///  This is either represented as a string, or as an index into a `Metadata`'s 
+    ///  array of field name strings.
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Name {
-        /// The string representation of the name.
+        ///  The string representation of the name.
         #[prost(string, tag="1")]
         StrName(::prost::alloc::string::String),
-        /// An index position into the `Metadata.field_names` of the metadata
-        /// for the task span that the field came from.
+        ///  An index position into the `Metadata.field_names` of the metadata
+        ///  for the task span that the field came from.
         #[prost(uint64, tag="2")]
         NameIdx(u64),
     }
-    /// The value of the key-value pair.
+    ///  The value of the key-value pair.
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
-        /// A value serialized to a string using `fmt::Debug`.
+        ///  A value serialized to a string using `fmt::Debug`.
         #[prost(string, tag="3")]
         DebugVal(::prost::alloc::string::String),
-        /// A string value.
+        ///  A string value.
         #[prost(string, tag="4")]
         StrVal(::prost::alloc::string::String),
-        /// An unsigned integer value.
+        ///  An unsigned integer value.
         #[prost(uint64, tag="5")]
         U64Val(u64),
-        /// A signed integer value.
+        ///  A signed integer value.
         #[prost(sint64, tag="6")]
         I64Val(i64),
-        /// A boolean value.
+        ///  A boolean value.
         #[prost(bool, tag="7")]
         BoolVal(bool),
     }
 }
-/// Represents a period of time in which a program was executing in a particular context.
+///  Represents a period of time in which a program was executing in a particular context.
 ///
-/// Corresponds to `Span` in the `tracing` crate.
+///  Corresponds to `Span` in the `tracing` crate.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Span {
-    /// An Id that uniquely identifies it in relation to other spans.
+    ///  An Id that uniquely identifies it in relation to other spans.
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<SpanId>,
-    /// Identifier for metadata describing static characteristics of all spans originating
-    /// from that callsite, such as its name, source code location, verbosity level, and
-    /// the names of its fields.
+    ///  Identifier for metadata describing static characteristics of all spans originating
+    ///  from that callsite, such as its name, source code location, verbosity level, and
+    ///  the names of its fields.
     #[prost(message, optional, tag="2")]
     pub metadata_id: ::core::option::Option<MetaId>,
-    /// User-defined key-value pairs of arbitrary data that describe the context the span represents,
+    ///  User-defined key-value pairs of arbitrary data that describe the context the span represents,
     #[prost(message, repeated, tag="3")]
     pub fields: ::prost::alloc::vec::Vec<Field>,
-    /// Timestamp for the span.
+    ///  Timestamp for the span.
     #[prost(message, optional, tag="4")]
     pub at: ::core::option::Option<::prost_types::Timestamp>,
 }
-/// Any new metadata that was registered since the last update.
+///  Any new metadata that was registered since the last update.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterMetadata {
-    /// The new metadata that was registered since the last update.
+    ///  The new metadata that was registered since the last update.
     #[prost(message, repeated, tag="1")]
     pub metadata: ::prost::alloc::vec::Vec<register_metadata::NewMetadata>,
 }
 /// Nested message and enum types in `RegisterMetadata`.
 pub mod register_metadata {
-    /// One metadata element registered since the last update.
+    ///  One metadata element registered since the last update.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NewMetadata {
-        /// Unique identifier for `metadata`.
+        ///  Unique identifier for `metadata`.
         #[prost(message, optional, tag="1")]
         pub id: ::core::option::Option<super::MetaId>,
-        /// The metadata payload.
+        ///  The metadata payload.
         #[prost(message, optional, tag="2")]
         pub metadata: ::core::option::Option<super::Metadata>,
     }
 }
-/// Metadata associated with a span or event.
+///  Metadata associated with a span or event.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Metadata {
-    /// The name of the span or event.
+    ///  The name of the span or event.
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
-    /// Describes the part of the system where the span or event that this
-    /// metadata describes occurred.
+    ///  Describes the part of the system where the span or event that this
+    ///  metadata describes occurred.
     #[prost(string, tag="2")]
     pub target: ::prost::alloc::string::String,
-    /// The path to the Rust module where the span occurred.
+    ///  The path to the Rust module where the span occurred.
     #[prost(string, tag="3")]
     pub module_path: ::prost::alloc::string::String,
-    /// The Rust source location associated with the span or event.
+    ///  The Rust source location associated with the span or event.
     #[prost(message, optional, tag="4")]
     pub location: ::core::option::Option<Location>,
-    /// Indicates whether metadata is associated with a span or with an event.
+    ///  Indicates whether metadata is associated with a span or with an event.
     #[prost(enumeration="metadata::Kind", tag="5")]
     pub kind: i32,
-    /// Describes the level of verbosity of a span or event.
+    ///  Describes the level of verbosity of a span or event.
     #[prost(enumeration="metadata::Level", tag="6")]
     pub level: i32,
-    /// The names of the key-value fields attached to the
-    /// span or event this metadata is associated with.
+    ///  The names of the key-value fields attached to the
+    ///  span or event this metadata is associated with.
     #[prost(string, repeated, tag="7")]
     pub field_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `Metadata`.
 pub mod metadata {
-    /// Indicates whether metadata is associated with a span or with an event.
+    ///  Indicates whether metadata is associated with a span or with an event.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Kind {
-        /// Indicates metadata is associated with a span.
+        ///  Indicates metadata is associated with a span.
         Span = 0,
-        /// Indicates metadata is associated with an event.
+        ///  Indicates metadata is associated with an event.
         Event = 1,
     }
-    /// Describes the level of verbosity of a span or event.
+    impl Kind {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Kind::Span => "SPAN",
+                Kind::Event => "EVENT",
+            }
+        }
+    }
+    ///  Describes the level of verbosity of a span or event.
     ///
-    /// Corresponds to `Level` in the `tracing` crate.
+    ///  Corresponds to `Level` in the `tracing` crate.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Level {
-        /// The "error" level.
+        ///  The "error" level.
         ///
-        /// Designates very serious errors.
+        ///  Designates very serious errors.
         Error = 0,
-        /// The "warn" level.
+        ///  The "warn" level.
         ///
-        /// Designates hazardous situations.
+        ///  Designates hazardous situations.
         Warn = 1,
-        /// The "info" level.
-        /// Designates useful information.
+        ///  The "info" level.
+        ///  Designates useful information.
         Info = 2,
-        /// The "debug" level.
+        ///  The "debug" level.
         ///
-        /// Designates lower priority information.
+        ///  Designates lower priority information.
         Debug = 3,
-        /// The "trace" level.
+        ///  The "trace" level.
         ///
-        /// Designates very low priority, often extremely verbose, information.
+        ///  Designates very low priority, often extremely verbose, information.
         Trace = 4,
     }
+    impl Level {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Level::Error => "ERROR",
+                Level::Warn => "WARN",
+                Level::Info => "INFO",
+                Level::Debug => "DEBUG",
+                Level::Trace => "TRACE",
+            }
+        }
+    }
 }
-/// Contains stats about objects that can be polled. Currently these can be:
-/// - tasks that have been spawned
-/// - async operations on resources that are performed within the context of a task
+///  Contains stats about objects that can be polled. Currently these can be:
+///  - tasks that have been spawned
+///  - async operations on resources that are performed within the context of a task
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PollStats {
-    /// The total number of times this object has been polled.
+    ///  The total number of times this object has been polled.
     #[prost(uint64, tag="1")]
     pub polls: u64,
-    /// The timestamp of the first time this object was polled.
+    ///  The timestamp of the first time this object was polled.
     ///
-    /// If this is `None`, the object has not yet been polled.
+    ///  If this is `None`, the object has not yet been polled.
     ///
-    /// Subtracting this timestamp from `created_at` can be used to calculate the
-    /// time to first poll for this object, a measurement of executor latency.
+    ///  Subtracting this timestamp from `created_at` can be used to calculate the
+    ///  time to first poll for this object, a measurement of executor latency.
     #[prost(message, optional, tag="3")]
     pub first_poll: ::core::option::Option<::prost_types::Timestamp>,
-    /// The timestamp of the most recent time this objects's poll method was invoked.
+    ///  The timestamp of the most recent time this objects's poll method was invoked.
     ///
-    /// If this is `None`, the object has not yet been polled.
+    ///  If this is `None`, the object has not yet been polled.
     ///
-    /// If the object has only been polled a single time, then this value may be
-    /// equal to the `first_poll` timestamp.
+    ///  If the object has only been polled a single time, then this value may be
+    ///  equal to the `first_poll` timestamp.
     ///
     #[prost(message, optional, tag="4")]
     pub last_poll_started: ::core::option::Option<::prost_types::Timestamp>,
-    /// The timestamp of the most recent time this objects's poll method finished execution.
+    ///  The timestamp of the most recent time this objects's poll method finished execution.
     ///
-    /// If this is `None`, the object has not yet been polled or is currently being polled.
+    ///  If this is `None`, the object has not yet been polled or is currently being polled.
     ///
-    /// If the object does not exist anymore, then this is the time the final invocation of
-    /// its poll method has completed.
+    ///  If the object does not exist anymore, then this is the time the final invocation of
+    ///  its poll method has completed.
     #[prost(message, optional, tag="5")]
     pub last_poll_ended: ::core::option::Option<::prost_types::Timestamp>,
-    /// The total duration this object was being *actively polled*, summed across
-    /// all polls. Note that this includes only polls that have completed and is
-    /// not reflecting any inprogress polls. Subtracting `busy_time` from the
-    /// total lifetime of the polled object results in the amount of time it
-    /// has spent *waiting* to be polled.
+    ///  The total duration this object was being *actively polled*, summed across
+    ///  all polls. Note that this includes only polls that have completed and is
+    ///  not reflecting any inprogress polls. Subtracting `busy_time` from the
+    ///  total lifetime of the polled object results in the amount of time it
+    ///  has spent *waiting* to be polled.
     #[prost(message, optional, tag="6")]
     pub busy_time: ::core::option::Option<::prost_types::Duration>,
 }
-/// State attributes of an entity. These are dependent on the type of the entity.
+///  State attributes of an entity. These are dependent on the type of the entity.
 ///
-/// For example, a timer resource will have a duration, while a semaphore resource may
-/// have a permit count. Likewise, the async ops of a semaphore may have attributes
-/// indicating how many permits they are trying to acquire vs how many are acquired.
-/// These values may change over time. Therefore, they live in the runtime stats rather
-/// than the static data describing the entity.
+///  For example, a timer resource will have a duration, while a semaphore resource may
+///  have a permit count. Likewise, the async ops of a semaphore may have attributes
+///  indicating how many permits they are trying to acquire vs how many are acquired.
+///  These values may change over time. Therefore, they live in the runtime stats rather
+///  than the static data describing the entity.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Attribute {
-    /// The key-value pair for the attribute
+    ///  The key-value pair for the attribute
     #[prost(message, optional, tag="1")]
     pub field: ::core::option::Option<Field>,
-    /// Some values carry a unit of measurement. For example, a duration
-    /// carries an associated unit of time, such as "ms" for milliseconds.
+    ///  Some values carry a unit of measurement. For example, a duration
+    ///  carries an associated unit of time, such as "ms" for milliseconds.
     #[prost(string, optional, tag="2")]
     pub unit: ::core::option::Option<::prost::alloc::string::String>,
 }

--- a/console-api/src/generated/rs.tokio.console.instrument.rs
+++ b/console-api/src/generated/rs.tokio.console.instrument.rs
@@ -1,62 +1,62 @@
-/// InstrumentRequest requests the stream of updates
-/// to observe the async runtime state over time.
+///  InstrumentRequest requests the stream of updates
+///  to observe the async runtime state over time.
 ///
-/// TODO: In the future allow for the request to specify
-/// only the data that the caller cares about (i.e. only
-/// tasks but no resources)
+///  TODO: In the future allow for the request to specify
+///  only the data that the caller cares about (i.e. only
+///  tasks but no resources)
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstrumentRequest {
 }
-/// TaskDetailsRequest requests the stream of updates about
-/// the specific task identified in the request.
+///  TaskDetailsRequest requests the stream of updates about
+///  the specific task identified in the request.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskDetailsRequest {
-    /// Identifies the task for which details were requested.
+    ///  Identifies the task for which details were requested.
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<super::common::Id>,
 }
-/// PauseRequest requests the stream of updates to pause.
+///  PauseRequest requests the stream of updates to pause.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PauseRequest {
 }
-/// ResumeRequest requests the stream of updates to resume after a pause.
+///  ResumeRequest requests the stream of updates to resume after a pause.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResumeRequest {
 }
-/// Update carries all information regarding tasks, resources, async operations
-/// and resource operations in one message. There are a couple of reasons to combine all
-/// of these into a single message:
+///  Update carries all information regarding tasks, resources, async operations
+///  and resource operations in one message. There are a couple of reasons to combine all
+///  of these into a single message:
 ///
-/// - we can use one single timestamp for all the data
-/// - we can have all the new_metadata in one place
-/// - things such as async ops and resource ops do not make sense
-///   on their own as they have relations to tasks and resources
+///  - we can use one single timestamp for all the data
+///  - we can have all the new_metadata in one place
+///  - things such as async ops and resource ops do not make sense
+///    on their own as they have relations to tasks and resources
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Update {
-    /// The system time when this update was recorded.
+    ///  The system time when this update was recorded.
     ///
-    /// This is the timestamp any durations in the included `Stats` were
-    /// calculated relative to.
+    ///  This is the timestamp any durations in the included `Stats` were
+    ///  calculated relative to.
     #[prost(message, optional, tag="1")]
     pub now: ::core::option::Option<::prost_types::Timestamp>,
-    /// Task state update.
+    ///  Task state update.
     #[prost(message, optional, tag="2")]
     pub task_update: ::core::option::Option<super::tasks::TaskUpdate>,
-    /// Resource state update.
+    ///  Resource state update.
     #[prost(message, optional, tag="3")]
     pub resource_update: ::core::option::Option<super::resources::ResourceUpdate>,
-    /// Async operations state update
+    ///  Async operations state update
     #[prost(message, optional, tag="4")]
     pub async_op_update: ::core::option::Option<super::async_ops::AsyncOpUpdate>,
-    /// Any new span metadata that was registered since the last update.
+    ///  Any new span metadata that was registered since the last update.
     #[prost(message, optional, tag="5")]
     pub new_metadata: ::core::option::Option<super::common::RegisterMetadata>,
 }
-/// `PauseResponse` is the value returned after a pause request.
+///  `PauseResponse` is the value returned after a pause request.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PauseResponse {
 }
-/// `ResumeResponse` is the value returned after a resume request.
+///  `ResumeResponse` is the value returned after a resume request.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResumeResponse {
 }
@@ -64,6 +64,7 @@ pub struct ResumeResponse {
 pub mod instrument_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// `InstrumentServer<T>` implements `Instrument` as a service.
     #[derive(Debug, Clone)]
     pub struct InstrumentClient<T> {
@@ -84,11 +85,15 @@ pub mod instrument_client {
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
-        T::ResponseBody: Default + Body<Data = Bytes> + Send + 'static,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
         pub fn with_interceptor<F>(
@@ -97,6 +102,7 @@ pub mod instrument_client {
         ) -> InstrumentClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
                 Response = http::Response<
@@ -109,19 +115,19 @@ pub mod instrument_client {
         {
             InstrumentClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Produces a stream of updates representing the behavior of the instrumented async runtime.
@@ -258,8 +264,8 @@ pub mod instrument_server {
     #[derive(Debug)]
     pub struct InstrumentServer<T: Instrument> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Instrument> InstrumentServer<T> {
@@ -282,6 +288,18 @@ pub mod instrument_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for InstrumentServer<T>
@@ -491,7 +509,7 @@ pub mod instrument_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: Instrument> tonic::transport::NamedService for InstrumentServer<T> {
+    impl<T: Instrument> tonic::server::NamedService for InstrumentServer<T> {
         const NAME: &'static str = "rs.tokio.console.instrument.Instrument";
     }
 }

--- a/console-api/src/generated/rs.tokio.console.instrument.rs
+++ b/console-api/src/generated/rs.tokio.console.instrument.rs
@@ -1,62 +1,62 @@
-///  InstrumentRequest requests the stream of updates
-///  to observe the async runtime state over time.
+/// InstrumentRequest requests the stream of updates
+/// to observe the async runtime state over time.
 ///
-///  TODO: In the future allow for the request to specify
-///  only the data that the caller cares about (i.e. only
-///  tasks but no resources)
+/// TODO: In the future allow for the request to specify
+/// only the data that the caller cares about (i.e. only
+/// tasks but no resources)
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstrumentRequest {
 }
-///  TaskDetailsRequest requests the stream of updates about
-///  the specific task identified in the request.
+/// TaskDetailsRequest requests the stream of updates about
+/// the specific task identified in the request.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskDetailsRequest {
-    ///  Identifies the task for which details were requested.
+    /// Identifies the task for which details were requested.
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<super::common::Id>,
 }
-///  PauseRequest requests the stream of updates to pause.
+/// PauseRequest requests the stream of updates to pause.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PauseRequest {
 }
-///  ResumeRequest requests the stream of updates to resume after a pause.
+/// ResumeRequest requests the stream of updates to resume after a pause.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResumeRequest {
 }
-///  Update carries all information regarding tasks, resources, async operations
-///  and resource operations in one message. There are a couple of reasons to combine all
-///  of these into a single message:
+/// Update carries all information regarding tasks, resources, async operations
+/// and resource operations in one message. There are a couple of reasons to combine all
+/// of these into a single message:
 ///
-///  - we can use one single timestamp for all the data
-///  - we can have all the new_metadata in one place
-///  - things such as async ops and resource ops do not make sense
+/// - we can use one single timestamp for all the data
+/// - we can have all the new_metadata in one place
+/// - things such as async ops and resource ops do not make sense
 ///    on their own as they have relations to tasks and resources
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Update {
-    ///  The system time when this update was recorded.
+    /// The system time when this update was recorded.
     ///
-    ///  This is the timestamp any durations in the included `Stats` were
-    ///  calculated relative to.
+    /// This is the timestamp any durations in the included `Stats` were
+    /// calculated relative to.
     #[prost(message, optional, tag="1")]
     pub now: ::core::option::Option<::prost_types::Timestamp>,
-    ///  Task state update.
+    /// Task state update.
     #[prost(message, optional, tag="2")]
     pub task_update: ::core::option::Option<super::tasks::TaskUpdate>,
-    ///  Resource state update.
+    /// Resource state update.
     #[prost(message, optional, tag="3")]
     pub resource_update: ::core::option::Option<super::resources::ResourceUpdate>,
-    ///  Async operations state update
+    /// Async operations state update
     #[prost(message, optional, tag="4")]
     pub async_op_update: ::core::option::Option<super::async_ops::AsyncOpUpdate>,
-    ///  Any new span metadata that was registered since the last update.
+    /// Any new span metadata that was registered since the last update.
     #[prost(message, optional, tag="5")]
     pub new_metadata: ::core::option::Option<super::common::RegisterMetadata>,
 }
-///  `PauseResponse` is the value returned after a pause request.
+/// `PauseResponse` is the value returned after a pause request.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PauseResponse {
 }
-///  `ResumeResponse` is the value returned after a resume request.
+/// `ResumeResponse` is the value returned after a resume request.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResumeResponse {
 }

--- a/console-api/src/generated/rs.tokio.console.resources.rs
+++ b/console-api/src/generated/rs.tokio.console.resources.rs
@@ -1,138 +1,149 @@
-/// A resource state update.
+///  A resource state update.
 ///
-/// Each `ResourceUpdate` contains any resource data that has changed since the last
-/// update. This includes:
-/// - any new resources that were created since the last update
-/// - the current stats for any resource whose stats changed since the last update
-/// - any new poll ops that have been invoked on a resource
+///  Each `ResourceUpdate` contains any resource data that has changed since the last
+///  update. This includes:
+///  - any new resources that were created since the last update
+///  - the current stats for any resource whose stats changed since the last update
+///  - any new poll ops that have been invoked on a resource
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceUpdate {
-    /// A list of new resources that were created since the last `ResourceUpdate` was
-    /// sent.
+    ///  A list of new resources that were created since the last `ResourceUpdate` was
+    ///  sent.
     #[prost(message, repeated, tag="1")]
     pub new_resources: ::prost::alloc::vec::Vec<Resource>,
-    /// Any resource stats that have changed since the last update.
+    ///  Any resource stats that have changed since the last update.
     #[prost(map="uint64, message", tag="2")]
     pub stats_update: ::std::collections::HashMap<u64, Stats>,
-    /// A list of all new poll ops that have been invoked on resources since the last update.
+    ///  A list of all new poll ops that have been invoked on resources since the last update.
     #[prost(message, repeated, tag="3")]
     pub new_poll_ops: ::prost::alloc::vec::Vec<PollOp>,
-    /// A count of how many resource events (e.g. polls, creation, etc) were not
-    /// recorded because the application's event buffer was at capacity.
+    ///  A count of how many resource events (e.g. polls, creation, etc) were not
+    ///  recorded because the application's event buffer was at capacity.
     ///
-    /// If everything is working normally, this should be 0. If it is greater
-    /// than 0, that may indicate that some data is missing from this update, and
-    /// it may be necessary to increase the number of events buffered by the
-    /// application to ensure that data loss is avoided.
+    ///  If everything is working normally, this should be 0. If it is greater
+    ///  than 0, that may indicate that some data is missing from this update, and
+    ///  it may be necessary to increase the number of events buffered by the
+    ///  application to ensure that data loss is avoided.
     ///
-    /// If the application's instrumentation ensures reliable delivery of events,
-    /// this will always be 0.
+    ///  If the application's instrumentation ensures reliable delivery of events,
+    ///  this will always be 0.
     #[prost(uint64, tag="4")]
     pub dropped_events: u64,
 }
-/// Static data recorded when a new resource is created.
+///  Static data recorded when a new resource is created.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Resource {
-    /// The resources's ID.
+    ///  The resources's ID.
     ///
-    /// This uniquely identifies this resource across all *currently live*
-    /// resources. This is also the primary way any operations on a resource
-    /// are associated with it
+    ///  This uniquely identifies this resource across all *currently live*
+    ///  resources. This is also the primary way any operations on a resource
+    ///  are associated with it
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<super::common::Id>,
-    /// The numeric ID of the resources's `Metadata`.
+    ///  The numeric ID of the resources's `Metadata`.
     #[prost(message, optional, tag="2")]
     pub metadata: ::core::option::Option<super::common::MetaId>,
-    /// The resources's concrete rust type.
+    ///  The resources's concrete rust type.
     #[prost(string, tag="3")]
     pub concrete_type: ::prost::alloc::string::String,
-    /// The kind of resource (e.g timer, mutex)
+    ///  The kind of resource (e.g timer, mutex)
     #[prost(message, optional, tag="4")]
     pub kind: ::core::option::Option<resource::Kind>,
-    /// The location in code where the resource was created.
+    ///  The location in code where the resource was created.
     #[prost(message, optional, tag="5")]
     pub location: ::core::option::Option<super::common::Location>,
-    /// The ID of the parent resource.
+    ///  The ID of the parent resource.
     #[prost(message, optional, tag="6")]
     pub parent_resource_id: ::core::option::Option<super::common::Id>,
-    /// Is the resource an internal component of another resource?
+    ///  Is the resource an internal component of another resource?
     ///
-    /// For example, a `tokio::time::Interval` resource might contain a 
-    /// `tokio::time::Sleep` resource internally.
+    ///  For example, a `tokio::time::Interval` resource might contain a 
+    ///  `tokio::time::Sleep` resource internally.
     #[prost(bool, tag="7")]
     pub is_internal: bool,
 }
 /// Nested message and enum types in `Resource`.
 pub mod resource {
-    /// The kind of resource (e.g. timer, mutex).
+    ///  The kind of resource (e.g. timer, mutex).
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Kind {
-        /// Every resource is either a known kind or an other (unknown) kind.
+        ///  Every resource is either a known kind or an other (unknown) kind.
         #[prost(oneof="kind::Kind", tags="1, 2")]
         pub kind: ::core::option::Option<kind::Kind>,
     }
     /// Nested message and enum types in `Kind`.
     pub mod kind {
-        /// `Known` collects the kinds of resources that are known in this version of the API.
+        ///  `Known` collects the kinds of resources that are known in this version of the API.
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
         #[repr(i32)]
         pub enum Known {
-            /// `TIMER` signals that this is a timer resource, e.g. waiting for a sleep to finish.
+            ///  `TIMER` signals that this is a timer resource, e.g. waiting for a sleep to finish.
             Timer = 0,
         }
-        /// Every resource is either a known kind or an other (unknown) kind.
+        impl Known {
+            /// String value of the enum field names used in the ProtoBuf definition.
+            ///
+            /// The values are not transformed in any way and thus are considered stable
+            /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+            pub fn as_str_name(&self) -> &'static str {
+                match self {
+                    Known::Timer => "TIMER",
+                }
+            }
+        }
+        ///  Every resource is either a known kind or an other (unknown) kind.
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Kind {
-            /// `known` signals that this kind of resource is known to the console API.
+            ///  `known` signals that this kind of resource is known to the console API.
             #[prost(enumeration="Known", tag="1")]
             Known(i32),
-            /// `other` signals that this kind of resource is unknown to the console API.
+            ///  `other` signals that this kind of resource is unknown to the console API.
             #[prost(string, tag="2")]
             Other(::prost::alloc::string::String),
         }
     }
 }
-/// Task runtime stats of a resource.
+///  Task runtime stats of a resource.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Stats {
-    /// Timestamp of when the resource was created.
+    ///  Timestamp of when the resource was created.
     #[prost(message, optional, tag="1")]
     pub created_at: ::core::option::Option<::prost_types::Timestamp>,
-    /// Timestamp of when the resource was dropped.
+    ///  Timestamp of when the resource was dropped.
     #[prost(message, optional, tag="2")]
     pub dropped_at: ::core::option::Option<::prost_types::Timestamp>,
-    /// State attributes of the resource. These are dependent on the type of the resource.
-    /// For example, a timer resource will have a duration while a semaphore resource may
-    /// have permits as an attribute. These values may change over time as the state of
-    /// the resource changes. Therefore, they live in the runtime stats rather than the
-    /// static data describing the resource.
+    ///  State attributes of the resource. These are dependent on the type of the resource.
+    ///  For example, a timer resource will have a duration while a semaphore resource may
+    ///  have permits as an attribute. These values may change over time as the state of
+    ///  the resource changes. Therefore, they live in the runtime stats rather than the
+    ///  static data describing the resource.
     #[prost(message, repeated, tag="3")]
     pub attributes: ::prost::alloc::vec::Vec<super::common::Attribute>,
 }
-/// A `PollOp` describes each poll operation that completes within the async
-/// application.
+///  A `PollOp` describes each poll operation that completes within the async
+///  application.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PollOp {
-    /// The numeric ID of the op's `Metadata`.
+    ///  The numeric ID of the op's `Metadata`.
     ///
-    /// This identifies the `Metadata` that describes the `tracing` span
-    /// corresponding to this op. The metadata for this ID will have been sent
-    /// in a prior `RegisterMetadata` message.
+    ///  This identifies the `Metadata` that describes the `tracing` span
+    ///  corresponding to this op. The metadata for this ID will have been sent
+    ///  in a prior `RegisterMetadata` message.
     #[prost(message, optional, tag="2")]
     pub metadata: ::core::option::Option<super::common::MetaId>,
-    /// The resources's ID.
+    ///  The resources's ID.
     #[prost(message, optional, tag="3")]
     pub resource_id: ::core::option::Option<super::common::Id>,
-    /// the name of this op (e.g. poll_elapsed, new_timeout, reset, etc.)
+    ///  the name of this op (e.g. poll_elapsed, new_timeout, reset, etc.)
     #[prost(string, tag="4")]
     pub name: ::prost::alloc::string::String,
-    /// Identifies the task context that this poll op has been called from.
+    ///  Identifies the task context that this poll op has been called from.
     #[prost(message, optional, tag="5")]
     pub task_id: ::core::option::Option<super::common::Id>,
-    /// Identifies the async op ID that this poll op is part of.
+    ///  Identifies the async op ID that this poll op is part of.
     #[prost(message, optional, tag="6")]
     pub async_op_id: ::core::option::Option<super::common::Id>,
-    /// Whether this poll op has returned with ready or pending.
+    ///  Whether this poll op has returned with ready or pending.
     #[prost(bool, tag="7")]
     pub is_ready: bool,
 }

--- a/console-api/src/generated/rs.tokio.console.resources.rs
+++ b/console-api/src/generated/rs.tokio.console.resources.rs
@@ -1,83 +1,83 @@
-///  A resource state update.
+/// A resource state update.
 ///
-///  Each `ResourceUpdate` contains any resource data that has changed since the last
-///  update. This includes:
-///  - any new resources that were created since the last update
-///  - the current stats for any resource whose stats changed since the last update
-///  - any new poll ops that have been invoked on a resource
+/// Each `ResourceUpdate` contains any resource data that has changed since the last
+/// update. This includes:
+/// - any new resources that were created since the last update
+/// - the current stats for any resource whose stats changed since the last update
+/// - any new poll ops that have been invoked on a resource
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceUpdate {
-    ///  A list of new resources that were created since the last `ResourceUpdate` was
-    ///  sent.
+    /// A list of new resources that were created since the last `ResourceUpdate` was
+    /// sent.
     #[prost(message, repeated, tag="1")]
     pub new_resources: ::prost::alloc::vec::Vec<Resource>,
-    ///  Any resource stats that have changed since the last update.
+    /// Any resource stats that have changed since the last update.
     #[prost(map="uint64, message", tag="2")]
     pub stats_update: ::std::collections::HashMap<u64, Stats>,
-    ///  A list of all new poll ops that have been invoked on resources since the last update.
+    /// A list of all new poll ops that have been invoked on resources since the last update.
     #[prost(message, repeated, tag="3")]
     pub new_poll_ops: ::prost::alloc::vec::Vec<PollOp>,
-    ///  A count of how many resource events (e.g. polls, creation, etc) were not
-    ///  recorded because the application's event buffer was at capacity.
+    /// A count of how many resource events (e.g. polls, creation, etc) were not
+    /// recorded because the application's event buffer was at capacity.
     ///
-    ///  If everything is working normally, this should be 0. If it is greater
-    ///  than 0, that may indicate that some data is missing from this update, and
-    ///  it may be necessary to increase the number of events buffered by the
-    ///  application to ensure that data loss is avoided.
+    /// If everything is working normally, this should be 0. If it is greater
+    /// than 0, that may indicate that some data is missing from this update, and
+    /// it may be necessary to increase the number of events buffered by the
+    /// application to ensure that data loss is avoided.
     ///
-    ///  If the application's instrumentation ensures reliable delivery of events,
-    ///  this will always be 0.
+    /// If the application's instrumentation ensures reliable delivery of events,
+    /// this will always be 0.
     #[prost(uint64, tag="4")]
     pub dropped_events: u64,
 }
-///  Static data recorded when a new resource is created.
+/// Static data recorded when a new resource is created.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Resource {
-    ///  The resources's ID.
+    /// The resources's ID.
     ///
-    ///  This uniquely identifies this resource across all *currently live*
-    ///  resources. This is also the primary way any operations on a resource
-    ///  are associated with it
+    /// This uniquely identifies this resource across all *currently live*
+    /// resources. This is also the primary way any operations on a resource
+    /// are associated with it
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<super::common::Id>,
-    ///  The numeric ID of the resources's `Metadata`.
+    /// The numeric ID of the resources's `Metadata`.
     #[prost(message, optional, tag="2")]
     pub metadata: ::core::option::Option<super::common::MetaId>,
-    ///  The resources's concrete rust type.
+    /// The resources's concrete rust type.
     #[prost(string, tag="3")]
     pub concrete_type: ::prost::alloc::string::String,
-    ///  The kind of resource (e.g timer, mutex)
+    /// The kind of resource (e.g timer, mutex)
     #[prost(message, optional, tag="4")]
     pub kind: ::core::option::Option<resource::Kind>,
-    ///  The location in code where the resource was created.
+    /// The location in code where the resource was created.
     #[prost(message, optional, tag="5")]
     pub location: ::core::option::Option<super::common::Location>,
-    ///  The ID of the parent resource.
+    /// The ID of the parent resource.
     #[prost(message, optional, tag="6")]
     pub parent_resource_id: ::core::option::Option<super::common::Id>,
-    ///  Is the resource an internal component of another resource?
+    /// Is the resource an internal component of another resource?
     ///
-    ///  For example, a `tokio::time::Interval` resource might contain a 
-    ///  `tokio::time::Sleep` resource internally.
+    /// For example, a `tokio::time::Interval` resource might contain a 
+    /// `tokio::time::Sleep` resource internally.
     #[prost(bool, tag="7")]
     pub is_internal: bool,
 }
 /// Nested message and enum types in `Resource`.
 pub mod resource {
-    ///  The kind of resource (e.g. timer, mutex).
+    /// The kind of resource (e.g. timer, mutex).
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Kind {
-        ///  Every resource is either a known kind or an other (unknown) kind.
+        /// Every resource is either a known kind or an other (unknown) kind.
         #[prost(oneof="kind::Kind", tags="1, 2")]
         pub kind: ::core::option::Option<kind::Kind>,
     }
     /// Nested message and enum types in `Kind`.
     pub mod kind {
-        ///  `Known` collects the kinds of resources that are known in this version of the API.
+        /// `Known` collects the kinds of resources that are known in this version of the API.
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
         #[repr(i32)]
         pub enum Known {
-            ///  `TIMER` signals that this is a timer resource, e.g. waiting for a sleep to finish.
+            /// `TIMER` signals that this is a timer resource, e.g. waiting for a sleep to finish.
             Timer = 0,
         }
         impl Known {
@@ -91,59 +91,59 @@ pub mod resource {
                 }
             }
         }
-        ///  Every resource is either a known kind or an other (unknown) kind.
+        /// Every resource is either a known kind or an other (unknown) kind.
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Kind {
-            ///  `known` signals that this kind of resource is known to the console API.
+            /// `known` signals that this kind of resource is known to the console API.
             #[prost(enumeration="Known", tag="1")]
             Known(i32),
-            ///  `other` signals that this kind of resource is unknown to the console API.
+            /// `other` signals that this kind of resource is unknown to the console API.
             #[prost(string, tag="2")]
             Other(::prost::alloc::string::String),
         }
     }
 }
-///  Task runtime stats of a resource.
+/// Task runtime stats of a resource.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Stats {
-    ///  Timestamp of when the resource was created.
+    /// Timestamp of when the resource was created.
     #[prost(message, optional, tag="1")]
     pub created_at: ::core::option::Option<::prost_types::Timestamp>,
-    ///  Timestamp of when the resource was dropped.
+    /// Timestamp of when the resource was dropped.
     #[prost(message, optional, tag="2")]
     pub dropped_at: ::core::option::Option<::prost_types::Timestamp>,
-    ///  State attributes of the resource. These are dependent on the type of the resource.
-    ///  For example, a timer resource will have a duration while a semaphore resource may
-    ///  have permits as an attribute. These values may change over time as the state of
-    ///  the resource changes. Therefore, they live in the runtime stats rather than the
-    ///  static data describing the resource.
+    /// State attributes of the resource. These are dependent on the type of the resource.
+    /// For example, a timer resource will have a duration while a semaphore resource may
+    /// have permits as an attribute. These values may change over time as the state of
+    /// the resource changes. Therefore, they live in the runtime stats rather than the
+    /// static data describing the resource.
     #[prost(message, repeated, tag="3")]
     pub attributes: ::prost::alloc::vec::Vec<super::common::Attribute>,
 }
-///  A `PollOp` describes each poll operation that completes within the async
-///  application.
+/// A `PollOp` describes each poll operation that completes within the async
+/// application.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PollOp {
-    ///  The numeric ID of the op's `Metadata`.
+    /// The numeric ID of the op's `Metadata`.
     ///
-    ///  This identifies the `Metadata` that describes the `tracing` span
-    ///  corresponding to this op. The metadata for this ID will have been sent
-    ///  in a prior `RegisterMetadata` message.
+    /// This identifies the `Metadata` that describes the `tracing` span
+    /// corresponding to this op. The metadata for this ID will have been sent
+    /// in a prior `RegisterMetadata` message.
     #[prost(message, optional, tag="2")]
     pub metadata: ::core::option::Option<super::common::MetaId>,
-    ///  The resources's ID.
+    /// The resources's ID.
     #[prost(message, optional, tag="3")]
     pub resource_id: ::core::option::Option<super::common::Id>,
-    ///  the name of this op (e.g. poll_elapsed, new_timeout, reset, etc.)
+    /// the name of this op (e.g. poll_elapsed, new_timeout, reset, etc.)
     #[prost(string, tag="4")]
     pub name: ::prost::alloc::string::String,
-    ///  Identifies the task context that this poll op has been called from.
+    /// Identifies the task context that this poll op has been called from.
     #[prost(message, optional, tag="5")]
     pub task_id: ::core::option::Option<super::common::Id>,
-    ///  Identifies the async op ID that this poll op is part of.
+    /// Identifies the async op ID that this poll op is part of.
     #[prost(message, optional, tag="6")]
     pub async_op_id: ::core::option::Option<super::common::Id>,
-    ///  Whether this poll op has returned with ready or pending.
+    /// Whether this poll op has returned with ready or pending.
     #[prost(bool, tag="7")]
     pub is_ready: bool,
 }

--- a/console-api/src/generated/rs.tokio.console.tasks.rs
+++ b/console-api/src/generated/rs.tokio.console.tasks.rs
@@ -1,174 +1,186 @@
-/// A task state update.
+///  A task state update.
 ///
-/// Each `TaskUpdate` contains any task data that has changed since the last
-/// update. This includes:
-/// - any new tasks that were spawned since the last update
-/// - the current stats for any task whose stats changed since the last update
+///  Each `TaskUpdate` contains any task data that has changed since the last
+///  update. This includes:
+///  - any new tasks that were spawned since the last update
+///  - the current stats for any task whose stats changed since the last update
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskUpdate {
-    /// A list of new tasks that were spawned since the last `TaskUpdate` was
-    /// sent.
+    ///  A list of new tasks that were spawned since the last `TaskUpdate` was
+    ///  sent.
     ///
-    /// If this is empty, no new tasks were spawned.
+    ///  If this is empty, no new tasks were spawned.
     #[prost(message, repeated, tag="1")]
     pub new_tasks: ::prost::alloc::vec::Vec<Task>,
-    /// Any task stats that have changed since the last update.
+    ///  Any task stats that have changed since the last update.
     ///
-    /// This is a map of task IDs (64-bit unsigned integers) to task stats. If a
-    /// task's ID is not included in this map, then its stats have *not* changed
-    /// since the last `TaskUpdate` in which they were present. If a task's ID
-    /// *is* included in this map, the corresponding value represents a complete
-    /// snapshot of that task's stats at in the current time window.
+    ///  This is a map of task IDs (64-bit unsigned integers) to task stats. If a
+    ///  task's ID is not included in this map, then its stats have *not* changed
+    ///  since the last `TaskUpdate` in which they were present. If a task's ID
+    ///  *is* included in this map, the corresponding value represents a complete
+    ///  snapshot of that task's stats at in the current time window.
     #[prost(map="uint64, message", tag="3")]
     pub stats_update: ::std::collections::HashMap<u64, Stats>,
-    /// A count of how many task events (e.g. polls, spawns, etc) were not
-    /// recorded because the application's event buffer was at capacity.
+    ///  A count of how many task events (e.g. polls, spawns, etc) were not
+    ///  recorded because the application's event buffer was at capacity.
     ///
-    /// If everything is working normally, this should be 0. If it is greater
-    /// than 0, that may indicate that some data is missing from this update, and
-    /// it may be necessary to increase the number of events buffered by the
-    /// application to ensure that data loss is avoided.
+    ///  If everything is working normally, this should be 0. If it is greater
+    ///  than 0, that may indicate that some data is missing from this update, and
+    ///  it may be necessary to increase the number of events buffered by the
+    ///  application to ensure that data loss is avoided.
     ///
-    /// If the application's instrumentation ensures reliable delivery of events,
-    /// this will always be 0.
+    ///  If the application's instrumentation ensures reliable delivery of events,
+    ///  this will always be 0.
     #[prost(uint64, tag="4")]
     pub dropped_events: u64,
 }
-/// A task details update
+///  A task details update
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskDetails {
-    /// The task's ID which the details belong to.
+    ///  The task's ID which the details belong to.
     #[prost(message, optional, tag="1")]
     pub task_id: ::core::option::Option<super::common::Id>,
-    /// The timestamp for when the update to the task took place.
+    ///  The timestamp for when the update to the task took place.
     #[prost(message, optional, tag="2")]
     pub now: ::core::option::Option<::prost_types::Timestamp>,
-    /// A histogram of task poll durations.
+    ///  A histogram of task poll durations.
     ///
-    /// This is either:
-    /// - the raw binary representation of a HdrHistogram.rs `Histogram`
-    ///   serialized to binary in the V2 format (legacy)
-    /// - a binary histogram plus details on outliers (current)
+    ///  This is either:
+    ///  - the raw binary representation of a HdrHistogram.rs `Histogram`
+    ///    serialized to binary in the V2 format (legacy)
+    ///  - a binary histogram plus details on outliers (current)
     #[prost(oneof="task_details::PollTimesHistogram", tags="3, 4")]
     pub poll_times_histogram: ::core::option::Option<task_details::PollTimesHistogram>,
 }
 /// Nested message and enum types in `TaskDetails`.
 pub mod task_details {
-    /// A histogram of task poll durations.
+    ///  A histogram of task poll durations.
     ///
-    /// This is either:
-    /// - the raw binary representation of a HdrHistogram.rs `Histogram`
-    ///   serialized to binary in the V2 format (legacy)
-    /// - a binary histogram plus details on outliers (current)
+    ///  This is either:
+    ///  - the raw binary representation of a HdrHistogram.rs `Histogram`
+    ///    serialized to binary in the V2 format (legacy)
+    ///  - a binary histogram plus details on outliers (current)
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PollTimesHistogram {
-        /// HdrHistogram.rs `Histogram` serialized to binary in the V2 format
+        ///  HdrHistogram.rs `Histogram` serialized to binary in the V2 format
         #[prost(bytes, tag="3")]
         LegacyHistogram(::prost::alloc::vec::Vec<u8>),
-        /// A histogram plus additional data.
+        ///  A histogram plus additional data.
         #[prost(message, tag="4")]
         Histogram(super::DurationHistogram),
     }
 }
-/// Data recorded when a new task is spawned.
+///  Data recorded when a new task is spawned.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Task {
-    /// The task's ID.
+    ///  The task's ID.
     ///
-    /// This uniquely identifies this task across all *currently live* tasks.
-    /// When the task's stats change, or when the task completes, it will be
-    /// identified by this ID; if the client requires additional information
-    /// included in the `Task` message, it should store that data and access it
-    /// by ID.
+    ///  This uniquely identifies this task across all *currently live* tasks.
+    ///  When the task's stats change, or when the task completes, it will be
+    ///  identified by this ID; if the client requires additional information
+    ///  included in the `Task` message, it should store that data and access it
+    ///  by ID.
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<super::common::Id>,
-    /// The numeric ID of the task's `Metadata`.
+    ///  The numeric ID of the task's `Metadata`.
     ///
-    /// This identifies the `Metadata` that describes the `tracing` span
-    /// corresponding to this task. The metadata for this ID will have been sent
-    /// in a prior `RegisterMetadata` message.
+    ///  This identifies the `Metadata` that describes the `tracing` span
+    ///  corresponding to this task. The metadata for this ID will have been sent
+    ///  in a prior `RegisterMetadata` message.
     #[prost(message, optional, tag="2")]
     pub metadata: ::core::option::Option<super::common::MetaId>,
-    /// The category of task this task belongs to.
+    ///  The category of task this task belongs to.
     #[prost(enumeration="task::Kind", tag="3")]
     pub kind: i32,
-    /// A list of `Field` objects attached to this task.
+    ///  A list of `Field` objects attached to this task.
     #[prost(message, repeated, tag="4")]
     pub fields: ::prost::alloc::vec::Vec<super::common::Field>,
-    /// An ordered list of span IDs corresponding to the `tracing` span context
-    /// in which this task was spawned.
+    ///  An ordered list of span IDs corresponding to the `tracing` span context
+    ///  in which this task was spawned.
     ///
-    /// The first span ID in this list is the immediate parent, followed by that
-    /// span's parent, and so on. The final ID is the root span of the current
-    /// trace.
+    ///  The first span ID in this list is the immediate parent, followed by that
+    ///  span's parent, and so on. The final ID is the root span of the current
+    ///  trace.
     ///
-    /// If this is empty, there were *no* active spans when the task was spawned.
+    ///  If this is empty, there were *no* active spans when the task was spawned.
     ///
-    /// These IDs may correspond to `tracing` spans which are *not* tasks, if
-    /// additional trace data is being collected.
+    ///  These IDs may correspond to `tracing` spans which are *not* tasks, if
+    ///  additional trace data is being collected.
     #[prost(message, repeated, tag="5")]
     pub parents: ::prost::alloc::vec::Vec<super::common::SpanId>,
-    /// The location in code where the task was spawned.
+    ///  The location in code where the task was spawned.
     #[prost(message, optional, tag="6")]
     pub location: ::core::option::Option<super::common::Location>,
 }
 /// Nested message and enum types in `Task`.
 pub mod task {
-    /// The category of task this task belongs to.
+    ///  The category of task this task belongs to.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Kind {
-        /// A task spawned using a runtime's standard asynchronous task spawning
-        /// operation (such as `tokio::task::spawn`).
+        ///  A task spawned using a runtime's standard asynchronous task spawning
+        ///  operation (such as `tokio::task::spawn`).
         Spawn = 0,
-        /// A task spawned via a runtime's blocking task spawning operation
-        /// (such as `tokio::task::spawn_blocking`).
+        ///  A task spawned via a runtime's blocking task spawning operation
+        ///  (such as `tokio::task::spawn_blocking`).
         Blocking = 1,
     }
+    impl Kind {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Kind::Spawn => "SPAWN",
+                Kind::Blocking => "BLOCKING",
+            }
+        }
+    }
 }
-/// Task performance statistics.
+///  Task performance statistics.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Stats {
-    /// Timestamp of when the task was spawned.
+    ///  Timestamp of when the task was spawned.
     #[prost(message, optional, tag="1")]
     pub created_at: ::core::option::Option<::prost_types::Timestamp>,
-    /// Timestamp of when the task was dropped.
+    ///  Timestamp of when the task was dropped.
     #[prost(message, optional, tag="2")]
     pub dropped_at: ::core::option::Option<::prost_types::Timestamp>,
-    /// The total number of times this task has been woken over its lifetime.
+    ///  The total number of times this task has been woken over its lifetime.
     #[prost(uint64, tag="3")]
     pub wakes: u64,
-    /// The total number of times this task's waker has been cloned.
+    ///  The total number of times this task's waker has been cloned.
     #[prost(uint64, tag="4")]
     pub waker_clones: u64,
-    /// The total number of times this task's waker has been dropped.
+    ///  The total number of times this task's waker has been dropped.
     #[prost(uint64, tag="5")]
     pub waker_drops: u64,
-    /// The timestamp of the most recent time this task has been woken.
+    ///  The timestamp of the most recent time this task has been woken.
     ///
-    /// If this is `None`, the task has not yet been woken.
+    ///  If this is `None`, the task has not yet been woken.
     #[prost(message, optional, tag="6")]
     pub last_wake: ::core::option::Option<::prost_types::Timestamp>,
-    /// Contains task poll statistics.
+    ///  Contains task poll statistics.
     #[prost(message, optional, tag="7")]
     pub poll_stats: ::core::option::Option<super::common::PollStats>,
-    /// The total number of times this task has woken itself.
+    ///  The total number of times this task has woken itself.
     #[prost(uint64, tag="8")]
     pub self_wakes: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DurationHistogram {
-    /// HdrHistogram.rs `Histogram` serialized to binary in the V2 format
+    ///  HdrHistogram.rs `Histogram` serialized to binary in the V2 format
     #[prost(bytes="vec", tag="1")]
     pub raw_histogram: ::prost::alloc::vec::Vec<u8>,
-    /// The histogram's maximum value.
+    ///  The histogram's maximum value.
     #[prost(uint64, tag="2")]
     pub max_value: u64,
-    /// The number of outliers which have exceeded the histogram's maximum value.
+    ///  The number of outliers which have exceeded the histogram's maximum value.
     #[prost(uint64, tag="3")]
     pub high_outliers: u64,
-    /// The highest recorded outlier. This is only present if `high_outliers` is
-    /// greater than zero.
+    ///  The highest recorded outlier. This is only present if `high_outliers` is
+    ///  greater than zero.
     #[prost(uint64, optional, tag="4")]
     pub highest_outlier: ::core::option::Option<u64>,
 }

--- a/console-api/src/generated/rs.tokio.console.tasks.rs
+++ b/console-api/src/generated/rs.tokio.console.tasks.rs
@@ -1,128 +1,128 @@
-///  A task state update.
+/// A task state update.
 ///
-///  Each `TaskUpdate` contains any task data that has changed since the last
-///  update. This includes:
-///  - any new tasks that were spawned since the last update
-///  - the current stats for any task whose stats changed since the last update
+/// Each `TaskUpdate` contains any task data that has changed since the last
+/// update. This includes:
+/// - any new tasks that were spawned since the last update
+/// - the current stats for any task whose stats changed since the last update
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskUpdate {
-    ///  A list of new tasks that were spawned since the last `TaskUpdate` was
-    ///  sent.
+    /// A list of new tasks that were spawned since the last `TaskUpdate` was
+    /// sent.
     ///
-    ///  If this is empty, no new tasks were spawned.
+    /// If this is empty, no new tasks were spawned.
     #[prost(message, repeated, tag="1")]
     pub new_tasks: ::prost::alloc::vec::Vec<Task>,
-    ///  Any task stats that have changed since the last update.
+    /// Any task stats that have changed since the last update.
     ///
-    ///  This is a map of task IDs (64-bit unsigned integers) to task stats. If a
-    ///  task's ID is not included in this map, then its stats have *not* changed
-    ///  since the last `TaskUpdate` in which they were present. If a task's ID
-    ///  *is* included in this map, the corresponding value represents a complete
-    ///  snapshot of that task's stats at in the current time window.
+    /// This is a map of task IDs (64-bit unsigned integers) to task stats. If a
+    /// task's ID is not included in this map, then its stats have *not* changed
+    /// since the last `TaskUpdate` in which they were present. If a task's ID
+    /// *is* included in this map, the corresponding value represents a complete
+    /// snapshot of that task's stats at in the current time window.
     #[prost(map="uint64, message", tag="3")]
     pub stats_update: ::std::collections::HashMap<u64, Stats>,
-    ///  A count of how many task events (e.g. polls, spawns, etc) were not
-    ///  recorded because the application's event buffer was at capacity.
+    /// A count of how many task events (e.g. polls, spawns, etc) were not
+    /// recorded because the application's event buffer was at capacity.
     ///
-    ///  If everything is working normally, this should be 0. If it is greater
-    ///  than 0, that may indicate that some data is missing from this update, and
-    ///  it may be necessary to increase the number of events buffered by the
-    ///  application to ensure that data loss is avoided.
+    /// If everything is working normally, this should be 0. If it is greater
+    /// than 0, that may indicate that some data is missing from this update, and
+    /// it may be necessary to increase the number of events buffered by the
+    /// application to ensure that data loss is avoided.
     ///
-    ///  If the application's instrumentation ensures reliable delivery of events,
-    ///  this will always be 0.
+    /// If the application's instrumentation ensures reliable delivery of events,
+    /// this will always be 0.
     #[prost(uint64, tag="4")]
     pub dropped_events: u64,
 }
-///  A task details update
+/// A task details update
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskDetails {
-    ///  The task's ID which the details belong to.
+    /// The task's ID which the details belong to.
     #[prost(message, optional, tag="1")]
     pub task_id: ::core::option::Option<super::common::Id>,
-    ///  The timestamp for when the update to the task took place.
+    /// The timestamp for when the update to the task took place.
     #[prost(message, optional, tag="2")]
     pub now: ::core::option::Option<::prost_types::Timestamp>,
-    ///  A histogram of task poll durations.
+    /// A histogram of task poll durations.
     ///
-    ///  This is either:
-    ///  - the raw binary representation of a HdrHistogram.rs `Histogram`
+    /// This is either:
+    /// - the raw binary representation of a HdrHistogram.rs `Histogram`
     ///    serialized to binary in the V2 format (legacy)
-    ///  - a binary histogram plus details on outliers (current)
+    /// - a binary histogram plus details on outliers (current)
     #[prost(oneof="task_details::PollTimesHistogram", tags="3, 4")]
     pub poll_times_histogram: ::core::option::Option<task_details::PollTimesHistogram>,
 }
 /// Nested message and enum types in `TaskDetails`.
 pub mod task_details {
-    ///  A histogram of task poll durations.
+    /// A histogram of task poll durations.
     ///
-    ///  This is either:
-    ///  - the raw binary representation of a HdrHistogram.rs `Histogram`
+    /// This is either:
+    /// - the raw binary representation of a HdrHistogram.rs `Histogram`
     ///    serialized to binary in the V2 format (legacy)
-    ///  - a binary histogram plus details on outliers (current)
+    /// - a binary histogram plus details on outliers (current)
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PollTimesHistogram {
-        ///  HdrHistogram.rs `Histogram` serialized to binary in the V2 format
+        /// HdrHistogram.rs `Histogram` serialized to binary in the V2 format
         #[prost(bytes, tag="3")]
         LegacyHistogram(::prost::alloc::vec::Vec<u8>),
-        ///  A histogram plus additional data.
+        /// A histogram plus additional data.
         #[prost(message, tag="4")]
         Histogram(super::DurationHistogram),
     }
 }
-///  Data recorded when a new task is spawned.
+/// Data recorded when a new task is spawned.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Task {
-    ///  The task's ID.
+    /// The task's ID.
     ///
-    ///  This uniquely identifies this task across all *currently live* tasks.
-    ///  When the task's stats change, or when the task completes, it will be
-    ///  identified by this ID; if the client requires additional information
-    ///  included in the `Task` message, it should store that data and access it
-    ///  by ID.
+    /// This uniquely identifies this task across all *currently live* tasks.
+    /// When the task's stats change, or when the task completes, it will be
+    /// identified by this ID; if the client requires additional information
+    /// included in the `Task` message, it should store that data and access it
+    /// by ID.
     #[prost(message, optional, tag="1")]
     pub id: ::core::option::Option<super::common::Id>,
-    ///  The numeric ID of the task's `Metadata`.
+    /// The numeric ID of the task's `Metadata`.
     ///
-    ///  This identifies the `Metadata` that describes the `tracing` span
-    ///  corresponding to this task. The metadata for this ID will have been sent
-    ///  in a prior `RegisterMetadata` message.
+    /// This identifies the `Metadata` that describes the `tracing` span
+    /// corresponding to this task. The metadata for this ID will have been sent
+    /// in a prior `RegisterMetadata` message.
     #[prost(message, optional, tag="2")]
     pub metadata: ::core::option::Option<super::common::MetaId>,
-    ///  The category of task this task belongs to.
+    /// The category of task this task belongs to.
     #[prost(enumeration="task::Kind", tag="3")]
     pub kind: i32,
-    ///  A list of `Field` objects attached to this task.
+    /// A list of `Field` objects attached to this task.
     #[prost(message, repeated, tag="4")]
     pub fields: ::prost::alloc::vec::Vec<super::common::Field>,
-    ///  An ordered list of span IDs corresponding to the `tracing` span context
-    ///  in which this task was spawned.
+    /// An ordered list of span IDs corresponding to the `tracing` span context
+    /// in which this task was spawned.
     ///
-    ///  The first span ID in this list is the immediate parent, followed by that
-    ///  span's parent, and so on. The final ID is the root span of the current
-    ///  trace.
+    /// The first span ID in this list is the immediate parent, followed by that
+    /// span's parent, and so on. The final ID is the root span of the current
+    /// trace.
     ///
-    ///  If this is empty, there were *no* active spans when the task was spawned.
+    /// If this is empty, there were *no* active spans when the task was spawned.
     ///
-    ///  These IDs may correspond to `tracing` spans which are *not* tasks, if
-    ///  additional trace data is being collected.
+    /// These IDs may correspond to `tracing` spans which are *not* tasks, if
+    /// additional trace data is being collected.
     #[prost(message, repeated, tag="5")]
     pub parents: ::prost::alloc::vec::Vec<super::common::SpanId>,
-    ///  The location in code where the task was spawned.
+    /// The location in code where the task was spawned.
     #[prost(message, optional, tag="6")]
     pub location: ::core::option::Option<super::common::Location>,
 }
 /// Nested message and enum types in `Task`.
 pub mod task {
-    ///  The category of task this task belongs to.
+    /// The category of task this task belongs to.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Kind {
-        ///  A task spawned using a runtime's standard asynchronous task spawning
-        ///  operation (such as `tokio::task::spawn`).
+        /// A task spawned using a runtime's standard asynchronous task spawning
+        /// operation (such as `tokio::task::spawn`).
         Spawn = 0,
-        ///  A task spawned via a runtime's blocking task spawning operation
-        ///  (such as `tokio::task::spawn_blocking`).
+        /// A task spawned via a runtime's blocking task spawning operation
+        /// (such as `tokio::task::spawn_blocking`).
         Blocking = 1,
     }
     impl Kind {
@@ -138,49 +138,49 @@ pub mod task {
         }
     }
 }
-///  Task performance statistics.
+/// Task performance statistics.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Stats {
-    ///  Timestamp of when the task was spawned.
+    /// Timestamp of when the task was spawned.
     #[prost(message, optional, tag="1")]
     pub created_at: ::core::option::Option<::prost_types::Timestamp>,
-    ///  Timestamp of when the task was dropped.
+    /// Timestamp of when the task was dropped.
     #[prost(message, optional, tag="2")]
     pub dropped_at: ::core::option::Option<::prost_types::Timestamp>,
-    ///  The total number of times this task has been woken over its lifetime.
+    /// The total number of times this task has been woken over its lifetime.
     #[prost(uint64, tag="3")]
     pub wakes: u64,
-    ///  The total number of times this task's waker has been cloned.
+    /// The total number of times this task's waker has been cloned.
     #[prost(uint64, tag="4")]
     pub waker_clones: u64,
-    ///  The total number of times this task's waker has been dropped.
+    /// The total number of times this task's waker has been dropped.
     #[prost(uint64, tag="5")]
     pub waker_drops: u64,
-    ///  The timestamp of the most recent time this task has been woken.
+    /// The timestamp of the most recent time this task has been woken.
     ///
-    ///  If this is `None`, the task has not yet been woken.
+    /// If this is `None`, the task has not yet been woken.
     #[prost(message, optional, tag="6")]
     pub last_wake: ::core::option::Option<::prost_types::Timestamp>,
-    ///  Contains task poll statistics.
+    /// Contains task poll statistics.
     #[prost(message, optional, tag="7")]
     pub poll_stats: ::core::option::Option<super::common::PollStats>,
-    ///  The total number of times this task has woken itself.
+    /// The total number of times this task has woken itself.
     #[prost(uint64, tag="8")]
     pub self_wakes: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DurationHistogram {
-    ///  HdrHistogram.rs `Histogram` serialized to binary in the V2 format
+    /// HdrHistogram.rs `Histogram` serialized to binary in the V2 format
     #[prost(bytes="vec", tag="1")]
     pub raw_histogram: ::prost::alloc::vec::Vec<u8>,
-    ///  The histogram's maximum value.
+    /// The histogram's maximum value.
     #[prost(uint64, tag="2")]
     pub max_value: u64,
-    ///  The number of outliers which have exceeded the histogram's maximum value.
+    /// The number of outliers which have exceeded the histogram's maximum value.
     #[prost(uint64, tag="3")]
     pub high_outliers: u64,
-    ///  The highest recorded outlier. This is only present if `high_outliers` is
-    ///  greater than zero.
+    /// The highest recorded outlier. This is only present if `high_outliers` is
+    /// greater than zero.
     #[prost(uint64, optional, tag="4")]
     pub highest_outlier: ::core::option::Option<u64>,
 }

--- a/console-api/src/generated/rs.tokio.console.trace.rs
+++ b/console-api/src/generated/rs.tokio.console.trace.rs
@@ -1,81 +1,81 @@
-/// Start watching trace events with the provided filter.
+///  Start watching trace events with the provided filter.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WatchRequest {
-    /// Specifies which trace events should be streamed.
+    ///  Specifies which trace events should be streamed.
     #[prost(string, tag="1")]
     pub filter: ::prost::alloc::string::String,
 }
-/// A trace event
+///  A trace event
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TraceEvent {
-    /// A trace event
+    ///  A trace event
     #[prost(oneof="trace_event::Event", tags="1, 2, 3, 4, 5, 6")]
     pub event: ::core::option::Option<trace_event::Event>,
 }
 /// Nested message and enum types in `TraceEvent`.
 pub mod trace_event {
-    /// `RegisterThreads` signals that a new thread was registered.
+    ///  `RegisterThreads` signals that a new thread was registered.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RegisterThreads {
-        /// `names` maps the registered thread id's to their associated name.
+        ///  `names` maps the registered thread id's to their associated name.
         #[prost(map="uint64, string", tag="1")]
         pub names: ::std::collections::HashMap<u64, ::prost::alloc::string::String>,
     }
-    /// `Enter` signals that a span was entered.
+    ///  `Enter` signals that a span was entered.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Enter {
-        /// `span_id` identifies the span that was entered.
+        ///  `span_id` identifies the span that was entered.
         #[prost(message, optional, tag="1")]
         pub span_id: ::core::option::Option<super::super::common::SpanId>,
-        /// `thread_id` identifies who entered the span.
+        ///  `thread_id` identifies who entered the span.
         #[prost(uint64, tag="2")]
         pub thread_id: u64,
-        /// `at` identifies when the span was entered.
+        ///  `at` identifies when the span was entered.
         #[prost(message, optional, tag="3")]
         pub at: ::core::option::Option<::prost_types::Timestamp>,
     }
-    /// `Exit` signals that a span was exited.
+    ///  `Exit` signals that a span was exited.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Exit {
-        /// `span_id` identifies the span that was exited.
+        ///  `span_id` identifies the span that was exited.
         #[prost(message, optional, tag="1")]
         pub span_id: ::core::option::Option<super::super::common::SpanId>,
-        /// `thread_id` identifies who exited the span.
+        ///  `thread_id` identifies who exited the span.
         #[prost(uint64, tag="2")]
         pub thread_id: u64,
-        /// `at` identifies when the span was exited.
+        ///  `at` identifies when the span was exited.
         #[prost(message, optional, tag="3")]
         pub at: ::core::option::Option<::prost_types::Timestamp>,
     }
-    /// `Close` signals that a span was closed.
+    ///  `Close` signals that a span was closed.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Close {
-        /// `span_id` identifies the span that was closed.
+        ///  `span_id` identifies the span that was closed.
         #[prost(message, optional, tag="1")]
         pub span_id: ::core::option::Option<super::super::common::SpanId>,
-        /// `at` identifies when the span was closed.
+        ///  `at` identifies when the span was closed.
         #[prost(message, optional, tag="2")]
         pub at: ::core::option::Option<::prost_types::Timestamp>,
     }
-    /// A trace event
+    ///  A trace event
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
-        /// A new thread was registered.
+        ///  A new thread was registered.
         #[prost(message, tag="1")]
         RegisterThread(RegisterThreads),
-        /// A new span metadata was registered.
+        ///  A new span metadata was registered.
         #[prost(message, tag="2")]
         RegisterMetadata(super::super::common::RegisterMetadata),
-        /// A span was created.
+        ///  A span was created.
         #[prost(message, tag="3")]
         NewSpan(super::super::common::Span),
-        /// A span was entered.
+        ///  A span was entered.
         #[prost(message, tag="4")]
         EnterSpan(Enter),
-        /// A span was exited.
+        ///  A span was exited.
         #[prost(message, tag="5")]
         ExitSpan(Exit),
-        /// A span was closed.
+        ///  A span was closed.
         #[prost(message, tag="6")]
         CloseSpan(Close),
     }
@@ -84,6 +84,7 @@ pub mod trace_event {
 pub mod trace_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Allows observers to stream trace events for a given `WatchRequest` filter.
     #[derive(Debug, Clone)]
     pub struct TraceClient<T> {
@@ -104,11 +105,15 @@ pub mod trace_client {
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
-        T::ResponseBody: Default + Body<Data = Bytes> + Send + 'static,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
         pub fn with_interceptor<F>(
@@ -117,6 +122,7 @@ pub mod trace_client {
         ) -> TraceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
                 Response = http::Response<
@@ -129,19 +135,19 @@ pub mod trace_client {
         {
             TraceClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Produces a stream of trace events for the given filter.
@@ -192,8 +198,8 @@ pub mod trace_server {
     #[derive(Debug)]
     pub struct TraceServer<T: Trace> {
         inner: _Inner<T>,
-        accept_compression_encodings: (),
-        send_compression_encodings: (),
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: Trace> TraceServer<T> {
@@ -216,6 +222,18 @@ pub mod trace_server {
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
         }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for TraceServer<T>
@@ -310,7 +328,7 @@ pub mod trace_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: Trace> tonic::transport::NamedService for TraceServer<T> {
+    impl<T: Trace> tonic::server::NamedService for TraceServer<T> {
         const NAME: &'static str = "rs.tokio.console.trace.Trace";
     }
 }

--- a/console-api/src/generated/rs.tokio.console.trace.rs
+++ b/console-api/src/generated/rs.tokio.console.trace.rs
@@ -1,81 +1,81 @@
-///  Start watching trace events with the provided filter.
+/// Start watching trace events with the provided filter.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WatchRequest {
-    ///  Specifies which trace events should be streamed.
+    /// Specifies which trace events should be streamed.
     #[prost(string, tag="1")]
     pub filter: ::prost::alloc::string::String,
 }
-///  A trace event
+/// A trace event
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TraceEvent {
-    ///  A trace event
+    /// A trace event
     #[prost(oneof="trace_event::Event", tags="1, 2, 3, 4, 5, 6")]
     pub event: ::core::option::Option<trace_event::Event>,
 }
 /// Nested message and enum types in `TraceEvent`.
 pub mod trace_event {
-    ///  `RegisterThreads` signals that a new thread was registered.
+    /// `RegisterThreads` signals that a new thread was registered.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RegisterThreads {
-        ///  `names` maps the registered thread id's to their associated name.
+        /// `names` maps the registered thread id's to their associated name.
         #[prost(map="uint64, string", tag="1")]
         pub names: ::std::collections::HashMap<u64, ::prost::alloc::string::String>,
     }
-    ///  `Enter` signals that a span was entered.
+    /// `Enter` signals that a span was entered.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Enter {
-        ///  `span_id` identifies the span that was entered.
+        /// `span_id` identifies the span that was entered.
         #[prost(message, optional, tag="1")]
         pub span_id: ::core::option::Option<super::super::common::SpanId>,
-        ///  `thread_id` identifies who entered the span.
+        /// `thread_id` identifies who entered the span.
         #[prost(uint64, tag="2")]
         pub thread_id: u64,
-        ///  `at` identifies when the span was entered.
+        /// `at` identifies when the span was entered.
         #[prost(message, optional, tag="3")]
         pub at: ::core::option::Option<::prost_types::Timestamp>,
     }
-    ///  `Exit` signals that a span was exited.
+    /// `Exit` signals that a span was exited.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Exit {
-        ///  `span_id` identifies the span that was exited.
+        /// `span_id` identifies the span that was exited.
         #[prost(message, optional, tag="1")]
         pub span_id: ::core::option::Option<super::super::common::SpanId>,
-        ///  `thread_id` identifies who exited the span.
+        /// `thread_id` identifies who exited the span.
         #[prost(uint64, tag="2")]
         pub thread_id: u64,
-        ///  `at` identifies when the span was exited.
+        /// `at` identifies when the span was exited.
         #[prost(message, optional, tag="3")]
         pub at: ::core::option::Option<::prost_types::Timestamp>,
     }
-    ///  `Close` signals that a span was closed.
+    /// `Close` signals that a span was closed.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Close {
-        ///  `span_id` identifies the span that was closed.
+        /// `span_id` identifies the span that was closed.
         #[prost(message, optional, tag="1")]
         pub span_id: ::core::option::Option<super::super::common::SpanId>,
-        ///  `at` identifies when the span was closed.
+        /// `at` identifies when the span was closed.
         #[prost(message, optional, tag="2")]
         pub at: ::core::option::Option<::prost_types::Timestamp>,
     }
-    ///  A trace event
+    /// A trace event
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
-        ///  A new thread was registered.
+        /// A new thread was registered.
         #[prost(message, tag="1")]
         RegisterThread(RegisterThreads),
-        ///  A new span metadata was registered.
+        /// A new span metadata was registered.
         #[prost(message, tag="2")]
         RegisterMetadata(super::super::common::RegisterMetadata),
-        ///  A span was created.
+        /// A span was created.
         #[prost(message, tag="3")]
         NewSpan(super::super::common::Span),
-        ///  A span was entered.
+        /// A span was entered.
         #[prost(message, tag="4")]
         EnterSpan(Enter),
-        ///  A span was exited.
+        /// A span was exited.
         #[prost(message, tag="5")]
         ExitSpan(Exit),
-        ///  A span was closed.
+        /// A span was closed.
         #[prost(message, tag="6")]
         CloseSpan(Close),
     }

--- a/console-api/tests/bootstrap.rs
+++ b/console-api/tests/bootstrap.rs
@@ -1,38 +1,49 @@
-use std::{path::PathBuf, process::Command};
+use std::{fs, path::PathBuf, process::Command};
 
 #[test]
 fn bootstrap() {
-    let iface_files = &[
-        "proto/trace.proto",
-        "proto/common.proto",
-        "proto/tasks.proto",
-        "proto/instrument.proto",
-        "proto/resources.proto",
-        "proto/async_ops.proto",
-    ];
-    let dirs = &["proto"];
+    let root_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
+    let proto_dir = root_dir.join("proto");
+    let proto_files = fs::read_dir(&proto_dir).and_then(|dir| {
+        dir.filter_map(|entry| {
+            (|| {
+                let entry = entry?;
+                if entry.file_type()?.is_dir() {
+                    return Ok(None);
+                }
+                Ok(Some(entry.path()))
+            })()
+            .transpose()
+        })
+        .collect::<Result<Vec<_>, _>>()
+    });
+    let proto_files = match proto_files {
+        Ok(files) => files,
+        Err(error) => panic!("failed to list proto files: {}", error),
+    };
 
-    let out_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"))
-        .join("src")
-        .join("generated");
+    let out_dir = root_dir.join("src").join("generated");
 
-    tonic_build::configure()
+    if let Err(error) = tonic_build::configure()
         .build_client(true)
         .build_server(true)
+        .emit_rerun_if_changed(false)
         .protoc_arg("--experimental_allow_proto3_optional")
-        .out_dir(format!("{}", out_dir.display()))
-        .compile(iface_files, dirs)
-        .unwrap();
+        .out_dir(&out_dir)
+        .compile(&proto_files[..], &[proto_dir])
+    {
+        panic!("failed to compile `console-api` protobuf: {}", error);
+    }
 
     let status = Command::new("git")
         .arg("diff")
         .arg("--exit-code")
         .arg("--")
-        .arg(format!("{}", out_dir.display()))
-        .status()
-        .unwrap();
-
-    if !status.success() {
-        panic!("You should commit the protobuf files");
+        .arg(out_dir)
+        .status();
+    match status {
+        Ok(status) if !status.success() => panic!("You should commit the protobuf files"),
+        Err(error) => panic!("failed to run `git diff`: {}", error),
+        Ok(_) => {}
     }
 }

--- a/console-api/tests/bootstrap.rs
+++ b/console-api/tests/bootstrap.rs
@@ -4,6 +4,7 @@ use std::{fs, path::PathBuf, process::Command};
 fn bootstrap() {
     let root_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
     let proto_dir = root_dir.join("proto");
+    let proto_ext = std::ffi::OsStr::new("proto");
     let proto_files = fs::read_dir(&proto_dir).and_then(|dir| {
         dir.filter_map(|entry| {
             (|| {
@@ -11,7 +12,13 @@ fn bootstrap() {
                 if entry.file_type()?.is_dir() {
                     return Ok(None);
                 }
-                Ok(Some(entry.path()))
+
+                let path = entry.path();
+                if path.extension() != Some(proto_ext) {
+                    return Ok(None);
+                }
+
+                Ok(Some(path))
             })()
             .transpose()
         })

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -35,8 +35,8 @@ crossbeam-utils = "0.8.7"
 tokio = { version = "^1.15", features = ["sync", "time", "macros", "tracing"] }
 tokio-stream = "0.1"
 thread_local = "1.1.3"
-console-api = { version = "0.3.0", path = "../console-api", features = ["transport"] }
-tonic = { version = "0.7", features = ["transport"] }
+console-api = { version = "0.4.0", path = "../console-api", features = ["transport"] }
+tonic = { version = "0.8", features = ["transport"] }
 tracing-core = "0.1.24"
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["fmt", "registry"] }
@@ -46,7 +46,7 @@ hdrhistogram = { version = "7.3.0", default-features = false, features = ["seria
 # feature to also enable `tracing-subscriber`'s parking_lot feature flag.
 parking_lot_crate = { package = "parking_lot", version = "0.11", optional = true }
 humantime = "2.1.0"
-prost-types = "0.10.0"
+prost-types = "0.11.0"
 
 # Required for recording:
 serde = { version = "1", features = ["derive"] }

--- a/console-subscriber/src/stats.rs
+++ b/console-subscriber/src/stats.rs
@@ -532,7 +532,13 @@ impl<H> ToProto for PollStats<H> {
             last_poll_ended: timestamps
                 .last_poll_ended
                 .map(|at| base_time.to_timestamp(at)),
-            busy_time: Some(timestamps.busy_time.into()),
+            busy_time: Some(timestamps.busy_time.try_into().unwrap_or_else(|error| {
+                eprintln!(
+                    "failed to convert busy time to protobuf duration: {}",
+                    error
+                );
+                Default::default()
+            })),
         }
     }
 }

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -27,16 +27,16 @@ keywords = [
 
 [dependencies]
 atty = "0.2"
-console-api = { version = "0.3.0", path = "../console-api", features = ["transport"] }
+console-api = { version = "0.4.0", path = "../console-api", features = ["transport"] }
 clap = { version = "3", features = ["cargo", "derive", "env"] }
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
-tonic = { version = "0.7", features = ["transport"] }
+tonic = { version = "0.8", features = ["transport"] }
 futures = "0.3"
 tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 tracing-journald = { version = "0.2", optional = true }
-prost-types = "0.10"
+prost-types = "0.11"
 crossterm = { version = "0.20", features = ["event-stream"] }
 color-eyre = { version = "0.5", features = ["issue-url"] }
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,3 +11,4 @@ tonic-build = { version = "0.8", default-features = false, features = [
     "prost", "transport"
 ] }
 clap = { version = "3", features = ["derive"] }
+color-eyre = "0.5"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+license = "MIT"
+edition = "2021"
+rust-version = "1.56.0"
+publish = false
+
+[dependencies]
+tonic-build = { version = "0.8", default-features = false, features = [
+    "prost", "transport"
+] }
+clap = { version = "3", features = ["derive"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -59,6 +59,5 @@ fn gen_proto() -> Result<(), Box<dyn std::error::Error>> {
         .compile(iface_files, &[proto_dir])?;
 
     eprintln!("protos regenerated!");
-
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,9 @@
 use clap::Parser;
+use color_eyre::{
+    eyre::{ensure, WrapErr},
+    Result,
+};
 use std::{fs, path::PathBuf};
-use color_eyre::{Result, eyre::{ensure, WrapErr}};
 
 /// tokio-console dev tasks
 #[derive(Debug, clap::Parser)]
@@ -39,7 +42,13 @@ fn gen_proto() -> Result<()> {
 
     let proto_dir = api_dir.join("proto");
     let proto_ext = std::ffi::OsStr::new("proto");
-    let proto_files = fs::read_dir(&proto_dir).with_context(|| format!("failed to read protobuf directory `{}`", proto_dir.display()))?
+    let proto_files = fs::read_dir(&proto_dir)
+        .with_context(|| {
+            format!(
+                "failed to read protobuf directory `{}`",
+                proto_dir.display()
+            )
+        })?
         .filter_map(|entry| {
             (|| {
                 let entry = entry?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -38,6 +38,7 @@ fn gen_proto() -> Result<()> {
     };
 
     let proto_dir = api_dir.join("proto");
+    let proto_ext = std::ffi::OsStr::new("proto");
     let proto_files = fs::read_dir(&proto_dir).with_context(|| format!("failed to read protobuf directory `{}`", proto_dir.display()))?
         .filter_map(|entry| {
             (|| {
@@ -45,7 +46,13 @@ fn gen_proto() -> Result<()> {
                 if entry.file_type()?.is_dir() {
                     return Ok(None);
                 }
-                Ok(Some(entry.path()))
+
+                let path = entry.path();
+                if path.extension() != Some(proto_ext) {
+                    return Ok(None);
+                }
+
+                Ok(Some(path))
             })()
             .transpose()
         })
@@ -55,7 +62,7 @@ fn gen_proto() -> Result<()> {
 
     tonic_build::configure()
         .build_client(true)
-        .build_server(true)git
+        .build_server(true)
         .emit_rerun_if_changed(false)
         .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir(&out_dir)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,64 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+/// tokio-console dev tasks
+#[derive(Debug, clap::Parser)]
+struct Args {
+    #[clap(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum Command {
+    /// Generate `console-api` protobuf bindings.
+    GenProto,
+}
+
+fn main() {
+    let args = Args::parse();
+    if let Err(error) = args.cmd.run() {
+        eprintln!("{error}");
+        std::process::exit(1)
+    }
+}
+
+impl Command {
+    fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        match self {
+            Self::GenProto => gen_proto(),
+        }
+    }
+}
+
+fn gen_proto() -> Result<(), Box<dyn std::error::Error>> {
+    eprintln!("generating `console-api` protos...");
+
+    let api_dir = {
+        let mut mydir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
+        assert!(mydir.pop(), "manifest path should not be relative!");
+        mydir.join("console-api")
+    };
+
+    let proto_dir = api_dir.join("proto");
+    let out_dir = api_dir.join("src").join("generated");
+
+    let iface_files = &[
+        proto_dir.join("trace.proto"),
+        proto_dir.join("common.proto"),
+        proto_dir.join("tasks.proto"),
+        proto_dir.join("instrument.proto"),
+        proto_dir.join("resources.proto"),
+        proto_dir.join("async_ops.proto"),
+    ];
+
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .out_dir(format!("{}", out_dir.display()))
+        .compile(iface_files, &[proto_dir])?;
+
+    eprintln!("protos regenerated!");
+
+    Ok(())
+}


### PR DESCRIPTION
This branch updates the console crates' dependency on `tonic` to v0.8.0
and `prost` to 0.11.0.

In addition, I've added a [`cargo xtask`][xtask] command for manually
regenerating the generated protobuf bindings.

This is necessary as the current approach, regenerating the bindings in
an integration test, does not work when the protos fail to compile
(which they do after the Tonic update). Since running the crate's tests
requires compiling the crate, if the proto bindings don't compile, we
can't re-run the test.

[xtask]: https://github.com/matklad/cargo-xtask