### PR TITLE
feat(console) error handling improvements

### DIFF
--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -330,6 +330,42 @@ impl Config {
             .clone()
     }
 
+    pub(crate) fn add_issue_metadata(
+        &self,
+        mut builder: color_eyre::config::HookBuilder,
+    ) -> color_eyre::config::HookBuilder {
+        macro_rules! add_issue_metadata {
+            ($self:ident, $builder:ident =>
+                $(
+                    $($name:ident).+
+                ),+
+                $(,)?
+            ) => {
+                $(
+                    $builder = $builder.add_issue_metadata(concat!("config", $(".", stringify!($name)),+), format!("`{:?}`", $self$(.$name)+));
+                )*
+            }
+        }
+
+        add_issue_metadata! {
+            self, builder =>
+                subcmd,
+                target_addr,
+                env_filter,
+                log_directory,
+                retain_for,
+                view_options.no_colors,
+                view_options.lang,
+                view_options.ascii_only,
+                view_options.truecolor,
+                view_options.palette,
+                view_options.toggles.color_durations,
+                view_options.toggles.color_terminated,
+        }
+
+        builder
+    }
+
     fn from_path(config_path: ConfigPath) -> color_eyre::Result<Option<Self>> {
         ConfigFile::from_path(config_path)?
             .map(|config| config.try_into())

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> color_eyre::Result<()> {
     // initialize error handling first, in case panics occur while setting up
     // other stuff.
     let styles = view::Styles::from_config(args.view_options.clone());
-    styles.error_init()?;
+    styles.error_init(&args)?;
 
     args.trace_init()?;
     tracing::debug!(?args.target_addr, ?args.view_options);

--- a/tokio-console/src/view/styles.rs
+++ b/tokio-console/src/view/styles.rs
@@ -63,7 +63,13 @@ impl Styles {
                 // terminated by remote hosts.
                 ErrorKind::NonRecoverable(_) => true,
                 ErrorKind::Recoverable(_) => false,
-            });
+            })
+            // filter out `color-eyre`'s default set of frames to skip from
+            // backtraces.
+            //
+            // this includes `std::rt`, `color_eyre`'s own frames, and
+            // `tokio::runtime` & friends.
+            .add_default_filters();
 
         if self.palette == Palette::NoColors {
             // disable colors in error reports

--- a/tokio-console/src/view/styles.rs
+++ b/tokio-console/src/view/styles.rs
@@ -47,7 +47,7 @@ impl Styles {
         }
     }
 
-    pub fn error_init(&self) -> color_eyre::Result<()> {
+    pub fn error_init(&self, cfg: &crate::config::Config) -> color_eyre::Result<()> {
         use color_eyre::{
             config::{HookBuilder, Theme},
             ErrorKind,
@@ -55,7 +55,6 @@ impl Styles {
 
         let mut builder = HookBuilder::new()
             .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
-            .add_issue_metadata("version", env!("CARGO_PKG_VERSION"))
             .issue_filter(|kind| match kind {
                 // Only suggest reporting GitHub issues for panics, not for
                 // errors, so people don't open GitHub issues for stuff like not
@@ -69,7 +68,10 @@ impl Styles {
             //
             // this includes `std::rt`, `color_eyre`'s own frames, and
             // `tokio::runtime` & friends.
-            .add_default_filters();
+            .add_default_filters()
+            .add_issue_metadata("version", env!("CARGO_PKG_VERSION"));
+        // Add all the config values to the GitHub issue metadata
+        builder = cfg.add_issue_metadata(builder);
 
         if self.palette == Palette::NoColors {
             // disable colors in error reports

--- a/tokio-console/src/view/styles.rs
+++ b/tokio-console/src/view/styles.rs
@@ -48,11 +48,23 @@ impl Styles {
     }
 
     pub fn error_init(&self) -> color_eyre::Result<()> {
-        use color_eyre::config::{HookBuilder, Theme};
+        use color_eyre::{
+            config::{HookBuilder, Theme},
+            ErrorKind,
+        };
 
         let mut builder = HookBuilder::new()
             .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
-            .add_issue_metadata("version", env!("CARGO_PKG_VERSION"));
+            .add_issue_metadata("version", env!("CARGO_PKG_VERSION"))
+            .issue_filter(|kind| match kind {
+                // Only suggest reporting GitHub issues for panics, not for
+                // errors, so people don't open GitHub issues for stuff like not
+                // being able to find a config file or connections being
+                // terminated by remote hosts.
+                ErrorKind::NonRecoverable(_) => true,
+                ErrorKind::Recoverable(_) => false,
+            });
+
         if self.palette == Palette::NoColors {
             // disable colors in error reports
             builder = builder.theme(Theme::new());


### PR DESCRIPTION
This branch makes a number of small improvements to the
console CLI's error reporting:

* feat(console): only suggest opening issues for panics

* feat(console): init error handling before subcmds

  This way, if running a subcommand panics/errors, we still get nice
  `color-eyre` reports.

* feat(console): filter out boring frames in backtraces

* feat(console): include config options in autogenerated issues
  
  This adds a dump of all the console's config options to the issue
  metadata for GitHub issues generated using `color_eyre`'s GitHub issue
  generation on panics.
  
  <details>
  
  <summary>Example issue Markdown:</summary>
  
  ## Error
  ```
  lol
  ```
  
  ## Metadata
  |key|value|
  |--|--|
  |**version**|0.1.6|
  |**config.subcmd**|`None`|
  |**config.target_addr**|`Some(http://127.0.0.1:6669/)`|
  |**config.env_filter**|`None`|
  |**config.log_directory**|`Some("/tmp/tokio-console/logs")`|
  |**config.retain_for**|`None`|
  |**config.view_options.no_colors**|`false`|
  |**config.view_options.lang**|`Some("en_US.UTF-8")`|
  |**config.view_options.ascii_only**|`Some(false)`|
  |**config.view_options.truecolor**|`Some(true)`|
  |**config.view_options.palette**|`Some(All)`|
  |**config.view_options.toggles.color_durations**|`Some(false)`|
  |**config.view_options.toggles.color_terminated**|`Some(false)`|
  |**location**|tokio-console/src/main.rs:36:5|
  
  </summary>