### PR TITLE
chore: prepare to release console-subscriber v0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "console-api",
  "crossbeam-channel",

--- a/console-subscriber/CHANGELOG.md
+++ b/console-subscriber/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.1.7"></a>
+## 0.1.7 (2022-08-10)
+
+
+#### Features
+
+*  Update `tonic` to `0.8` (#364) ([40e2f6fd](40e2f6fd))
+*  Update `console-api` to `0.4` (#364) ([40e2f6fd](40e2f6fd))
+
+
 <a name="0.1.6"></a>
 ## 0.1.6 (2022-05-23)
 

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console-subscriber"
-version = "0.1.6"
+version = "0.1.7"
 license = "MIT"
 edition = "2021"
 rust-version = "1.58.0"


### PR DESCRIPTION
<a name="0.1.7"></a>
## 0.1.7 (2022-08-10)

#### Features

*  Update `tonic` to `0.8` (#364) ([40e2f6fd](40e2f6fd))
*  Update `console-api` to `0.4` (#364) ([40e2f6fd](40e2f6fd))