### PR TITLE
chore: fix console-subscriber on tokio 1.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,16 +822,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -959,7 +957,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.34.0",
 ]
 
 [[package]]
@@ -1414,14 +1412,15 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.2",
+ "mio 0.8.4",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.0",
@@ -1864,11 +1863,24 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
 
 [[package]]
@@ -1878,10 +1890,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1890,16 +1914,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "xtask"

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "1"
 crossbeam-channel = "0.5"
 
 [dev-dependencies]
-tokio = { version = "^1.7", features = ["full", "rt-multi-thread"] }
+tokio = { version = "^1.21", features = ["full", "rt-multi-thread"] }
 futures = "0.3"
 
 [package.metadata.docs.rs]

--- a/console-subscriber/examples/app.rs
+++ b/console-subscriber/examples/app.rs
@@ -23,15 +23,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             "blocks" => {
                 tokio::task::Builder::new()
                     .name("blocks")
-                    .spawn(double_sleepy(1, 10));
+                    .spawn(double_sleepy(1, 10))
+                    .unwrap();
             }
             "coma" => {
                 tokio::task::Builder::new()
                     .name("coma")
-                    .spawn(std::future::pending::<()>());
+                    .spawn(std::future::pending::<()>())
+                    .unwrap();
             }
             "burn" => {
-                tokio::task::Builder::new().name("burn").spawn(burn(1, 10));
+                tokio::task::Builder::new()
+                    .name("burn")
+                    .spawn(burn(1, 10))
+                    .unwrap();
             }
             "help" | "-h" => {
                 eprintln!("{}", HELP);
@@ -47,10 +52,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let task1 = tokio::task::Builder::new()
         .name("task1")
-        .spawn(spawn_tasks(1, 10));
+        .spawn(spawn_tasks(1, 10))
+        .unwrap();
     let task2 = tokio::task::Builder::new()
         .name("task2")
-        .spawn(spawn_tasks(10, 30));
+        .spawn(spawn_tasks(10, 30))
+        .unwrap();
 
     let result = tokio::try_join! {
         task1,
@@ -66,7 +73,10 @@ async fn spawn_tasks(min: u64, max: u64) {
     loop {
         for i in min..max {
             tracing::trace!(i, "spawning wait task");
-            tokio::task::Builder::new().name("wait").spawn(wait(i));
+            tokio::task::Builder::new()
+                .name("wait")
+                .spawn(wait(i))
+                .unwrap();
 
             let sleep = Duration::from_secs(max) - Duration::from_secs(i);
             tracing::trace!(?sleep, "sleeping...");

--- a/console-subscriber/examples/barrier.rs
+++ b/console-subscriber/examples/barrier.rs
@@ -14,11 +14,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             for i in 0..30 {
                 let c = barrier.clone();
                 let task_name = format!("task-{}", i);
-                handles.push(task::Builder::default().name(&task_name).spawn(async move {
-                    tokio::time::sleep(Duration::from_secs(i)).await;
-                    let wait_result = c.wait().await;
-                    wait_result
-                }));
+                handles.push(
+                    task::Builder::default()
+                        .name(&task_name)
+                        .spawn(async move {
+                            tokio::time::sleep(Duration::from_secs(i)).await;
+                            let wait_result = c.wait().await;
+                            wait_result
+                        })
+                        .unwrap(),
+                );
             }
 
             // Will not resolve until all "after wait" messages have been printed
@@ -34,6 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             // Exactly one barrier will resolve as the "leader"
             assert_eq!(num_leaders, 1);
         })
+        .unwrap()
         .await?;
 
     Ok(())

--- a/console-subscriber/examples/mutex.rs
+++ b/console-subscriber/examples/mutex.rs
@@ -20,11 +20,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                             *lock += 1;
                             tokio::time::sleep(Duration::from_secs(1)).await;
                         }
-                    });
+                    })
+                    .unwrap();
             }
 
             while *count.lock().await < 50 {}
         })
+        .unwrap()
         .await?;
 
     Ok(())

--- a/console-subscriber/examples/rwlock.rs
+++ b/console-subscriber/examples/rwlock.rs
@@ -20,7 +20,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                             *lock += 1;
                             tokio::time::sleep(Duration::from_secs(1)).await;
                         }
-                    });
+                    })
+                    .unwrap();
             }
 
             loop {
@@ -31,6 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 }
             }
         })
+        .unwrap()
         .await?;
 
     Ok(())

--- a/console-subscriber/examples/semaphore.rs
+++ b/console-subscriber/examples/semaphore.rs
@@ -21,19 +21,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         .spawn(async move {
                             let _permit = acquire_sem.acquire_many(i).await.unwrap();
                             tokio::time::sleep(Duration::from_secs(i as u64 * 2)).await;
-                        }),
+                        })
+                        .unwrap(),
                 );
-                tasks.push(tokio::task::Builder::default().name(&add_task_name).spawn(
-                    async move {
-                        tokio::time::sleep(Duration::from_secs(i as u64 * 5)).await;
-                        add_sem.add_permits(i as usize);
-                    },
-                ));
+                tasks.push(
+                    tokio::task::Builder::default()
+                        .name(&add_task_name)
+                        .spawn(async move {
+                            tokio::time::sleep(Duration::from_secs(i as u64 * 5)).await;
+                            add_sem.add_permits(i as usize);
+                        })
+                        .unwrap(),
+                );
             }
 
             let all_tasks = futures::future::try_join_all(tasks);
             all_tasks.await.unwrap();
         })
+        .unwrap()
         .await?;
 
     Ok(())

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -1063,7 +1063,7 @@ where
     T: Send + 'static,
 {
     #[cfg(tokio_unstable)]
-    return tokio::task::Builder::new().name(_name).spawn(task);
+    return tokio::task::Builder::new().name(_name).spawn(task).unwrap();
 
     #[cfg(not(tokio_unstable))]
     tokio::spawn(task)


### PR DESCRIPTION
Fixes #373.

Due to a change in the unstable task builder APIs, this no longer compiles with the latest version of Tokio.

Fortunately, it's a simple fix.