### PR TITLE
Documented cargo-run in README no longer works, as now there are two binaries

### DIFF
--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 rust-version = "1.58.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>",]
 readme = "README.md"
+default-run = "tokio-console"
 homepage = "https://github.com/tokio-rs/console/tree/main/tokio-console" 
 description = """
 The Tokio console: a debugger for async Rust.


### PR DESCRIPTION
Suggesting to declare `tokio-console` as the [default-run](https://doc.rust-lang.org/cargo/reference/manifest.html#the-default-run-field), as the current `cargo run` command in the README fails with:

```bash
$ cargo run                         
error: `cargo run` could not determine which binary to run. Use the `--bin` option t
o specify a binary, or the `default-run` manifest key.                              
available binaries: tokio-console, xtask         
```

Alternatively, we can just update the README line with `cargo run --bin tokio-console`