### PR TITLE
fix(tokio-console): Make `retain_for` default to 6s if not specfied

### DIFF
--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -326,9 +326,7 @@ impl Config {
     }
 
     pub(crate) fn retain_for(&self) -> Option<Duration> {
-        self.retain_for
-            .unwrap_or_default()
-            .0
+        self.retain_for.unwrap_or_default().0
     }
 
     pub(crate) fn target_addr(&self) -> Uri {

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -121,6 +121,12 @@ pub enum OptionalCmd {
 #[derive(Debug, Clone, Copy, Deserialize)]
 struct RetainFor(Option<Duration>);
 
+impl Default for RetainFor {
+    fn default() -> Self {
+        Self(Some(Duration::from_secs(6)))
+    }
+}
+
 impl fmt::Display for RetainFor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
@@ -320,7 +326,9 @@ impl Config {
     }
 
     pub(crate) fn retain_for(&self) -> Option<Duration> {
-        self.retain_for.as_ref().and_then(|value| value.0)
+        self.retain_for
+            .unwrap_or_default()
+            .0
     }
 
     pub(crate) fn target_addr(&self) -> Uri {
@@ -390,7 +398,7 @@ impl Default for Config {
             target_addr: Some(default_target_addr()),
             env_filter: Some(tracing_subscriber::EnvFilter::new("off")),
             log_directory: Some(default_log_directory()),
-            retain_for: Some(RetainFor(Some(Duration::from_secs(6)))),
+            retain_for: Some(RetainFor::default()),
             view_options: ViewOptions::default(),
             subcmd: None,
         }


### PR DESCRIPTION
closes #382