### PR TITLE
upgrade parking_lot to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "humantime",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "prost-types",
  "serde",
  "serde_json",

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -44,7 +44,7 @@ futures = { version = "0.3", default-features = false }
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
 # The parking_lot dependency is renamed, because we want our `parking_lot`
 # feature to also enable `tracing-subscriber`'s parking_lot feature flag.
-parking_lot_crate = { package = "parking_lot", version = "0.11", optional = true }
+parking_lot_crate = { package = "parking_lot", version = "0.12", optional = true }
 humantime = "2.1.0"
 prost-types = "0.11.0"
 


### PR DESCRIPTION
Hey I noticed this out of date in my `Cargo.lock`, and since I didn't see any PRs/issues open doing so already, figured I'd open one!