### PR TITLE
fix(console): fix `ViewOptions` default lang

### DIFF
--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -498,7 +498,7 @@ impl Default for ViewOptions {
     fn default() -> Self {
         Self {
             no_colors: false,
-            lang: Some("en_us.UTF8".to_string()),
+            lang: Some("en_us.UTF-8".to_string()),
             ascii_only: Some(false),
             truecolor: Some(true),
             palette: Some(Palette::All),


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/console/issues/393