### PR TITLE
Make clippy happy

### DIFF
--- a/console-subscriber/src/stats.rs
+++ b/console-subscriber/src/stats.rs
@@ -312,7 +312,7 @@ impl AsyncOpStats {
     pub(crate) fn task_id(&self) -> Option<u64> {
         let id = self.task_id.load();
         if id > 0 {
-            Some(id as u64)
+            Some(id)
         } else {
             None
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -74,7 +74,7 @@ fn gen_proto() -> Result<()> {
         .build_server(true)
         .emit_rerun_if_changed(false)
         .protoc_arg("--experimental_allow_proto3_optional")
-        .out_dir(&out_dir)
+        .out_dir(out_dir)
         .compile(&proto_files[..], &[proto_dir])
         .context("failed to compile protobuf files")
 }


### PR DESCRIPTION
`cargo clippy` to see:
```shell
warning: the borrowed expression implements the required traits
  --> xtask/src/main.rs:77:18
   |
77 |         .out_dir(&out_dir)
   |                  ^^^^^^^^ help: change this to: `out_dir`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default

warning: `xtask` (bin "xtask") generated 1 warning
    Checking tokio-console v0.1.7 (/Users/hi-rustin/vsc/console/tokio-console)
    Checking console-subscriber v0.1.8 (/Users/hi-rustin/vsc/console/console-subscriber)
warning: casting to the same type is unnecessary (`u64` -> `u64`)
   --> console-subscriber/src/stats.rs:315:18
    |
315 |             Some(id as u64)
    |                  ^^^^^^^^^ help: try: `id`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
    = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: `console-subscriber` (lib) generated 1 warning
```