### PR TITLE
feat(console): use tokio task ids in task views

### DIFF
--- a/console-api/src/common.rs
+++ b/console-api/src/common.rs
@@ -210,7 +210,7 @@ impl From<&dyn std::fmt::Debug> for field::Value {
 // or vice versa. However, this is unavoidable here, because `prost` generates
 // a struct with `#[derive(PartialEq)]`, but we cannot add`#[derive(Hash)]` to the
 // generated code.
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for field::Name {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -271,6 +271,7 @@ impl Metadata {
 impl Field {
     const SPAWN_LOCATION: &'static str = "spawn.location";
     const NAME: &'static str = "task.name";
+    const TASK_ID: &'static str = "task.id";
 
     /// Converts a wire-format `Field` into an internal `Field` representation,
     /// using the provided `Metadata` for the task span that the field came

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -194,9 +194,11 @@ impl TasksState {
                 // remap the server's ID to a pretty, sequential task ID
                 let id = ids.id_for(span_id);
 
-                let short_desc = strings.string(match name.as_ref() {
-                    Some(name) => format!("{} ({})", id, name),
-                    None => format!("{}", id),
+                let short_desc = strings.string(match (task_id, name.as_ref()) {
+                    (Some(task_id), Some(name)) => format!("{} ({})", task_id, name),
+                    (Some(task_id), None) => format!("{}", task_id),
+                    (None, Some(name)) => format!("({})", name),
+                    (None, None) => "".to_owned(),
                 });
 
                 let mut task = Task {

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -77,14 +77,13 @@ pub(crate) struct Task {
     /// remote.
     id: Id<Task>,
     /// The `tokio::task::Id` in the remote tokio runtime.
-    ///
-    /// This Id may not be unique if there are multiple runtimes in the
-    /// remote process.
     task_id: Option<TaskId>,
     /// The `tracing::span::Id` on the remote process for this task's span.
     ///
     /// This is used when requesting a task details stream.
     span_id: SpanId,
+    /// A cached string representation of the Id for display purposes.
+    id_str: String,
     short_desc: InternedStr,
     formatted_fields: Vec<Vec<Span<'static>>>,
     stats: TaskStats,
@@ -197,7 +196,7 @@ impl TasksState {
                 let short_desc = strings.string(match (task_id, name.as_ref()) {
                     (Some(task_id), Some(name)) => format!("{task_id} ({name})"),
                     (Some(task_id), None) => task_id.to_string(),
-                    (None, Some(name)) => name.to_owned()
+                    (None, Some(name)) => name.as_ref().to_owned(),
                     (None, None) => "".to_owned(),
                 });
 
@@ -206,6 +205,7 @@ impl TasksState {
                     id,
                     task_id,
                     span_id,
+                    id_str: task_id.map(|id| id.to_string()).unwrap_or_default(),
                     short_desc,
                     formatted_fields,
                     stats,
@@ -268,12 +268,12 @@ impl Task {
         self.id
     }
 
-    pub(crate) fn task_id(&self) -> Option<TaskId> {
-        self.task_id
-    }
-
     pub(crate) fn span_id(&self) -> SpanId {
         self.span_id
+    }
+
+    pub(crate) fn id_str(&self) -> &str {
+        &self.id_str
     }
 
     pub(crate) fn target(&self) -> &str {

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -455,9 +455,9 @@ impl Default for SortBy {
 impl SortBy {
     pub fn sort(&self, now: SystemTime, tasks: &mut [Weak<RefCell<Task>>]) {
         match self {
-            Self::Tid => tasks.sort_unstable_by_key(|task| {
-                task.upgrade().map(|t| t.borrow().task_id)
-            }),
+            Self::Tid => {
+                tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().task_id))
+            }
             Self::Name => {
                 tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().name.clone()))
             }

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -456,7 +456,7 @@ impl SortBy {
     pub fn sort(&self, now: SystemTime, tasks: &mut [Weak<RefCell<Task>>]) {
         match self {
             Self::Tid => tasks.sort_unstable_by_key(|task| {
-                task.upgrade().map(|t| t.borrow().task_id.map(|id| id))
+                task.upgrade().map(|t| t.borrow().task_id)
             }),
             Self::Name => {
                 tasks.sort_unstable_by_key(|task| task.upgrade().map(|t| t.borrow().name.clone()))

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -195,9 +195,9 @@ impl TasksState {
                 let id = ids.id_for(span_id);
 
                 let short_desc = strings.string(match (task_id, name.as_ref()) {
-                    (Some(task_id), Some(name)) => format!("{} ({})", task_id, name),
-                    (Some(task_id), None) => format!("{}", task_id),
-                    (None, Some(name)) => format!("({})", name),
+                    (Some(task_id), Some(name)) => format!("{task_id} ({name})"),
+                    (Some(task_id), None) => task_id.to_string(),
+                    (None, Some(name)) => name.to_owned()
                     (None, None) => "".to_owned(),
                 });
 

--- a/tokio-console/src/view/tasks.rs
+++ b/tokio-console/src/view/tasks.rs
@@ -122,7 +122,7 @@ impl TableList<11> for TasksTable {
                         warnings,
                         Cell::from(id_width.update_str(format!(
                             "{:>width$}",
-                            task.id(),
+                            task.task_id().map(|id| id.to_string()).unwrap_or_default(),
                             width = id_width.chars() as usize
                         ))),
                         Cell::from(task.state().render(styles)),

--- a/tokio-console/src/view/tasks.rs
+++ b/tokio-console/src/view/tasks.rs
@@ -122,7 +122,7 @@ impl TableList<11> for TasksTable {
                         warnings,
                         Cell::from(id_width.update_str(format!(
                             "{:>width$}",
-                            task.task_id().map(|id| id.to_string()).unwrap_or_default(),
+                            task.id_str(),
                             width = id_width.chars() as usize
                         ))),
                         Cell::from(task.state().render(styles)),


### PR DESCRIPTION
Tokio Console generates its own sequential Id for internal tracking and
indexing of objects (tasks, resources, etc.). However, this Id will be
recreated if Console is restarted.

In order to provide more useful information to the user, the task Id
generated by Tokio can be used in the task list and task details screens
instead. If used in this way, the ID field in the task list and task
detail views will be stable across restarts of Console (assuming the
monitored application is not restarted).

This also frees up horizontal space, as the `task.id` attribute
doesn't need to be displayed separately.

The disadvantage of using Tokio's task Id is that it is not guaranteed
to be present by the type system.

To avoid problems with missing task Ids, the Tokio task Id is store in
addition to the `span::Id` (used to communicate with the
`console-subscriber`) and the sequential console `Id` (used in the
`store`). If a task is missing the `task.id` field for whatever reason
it will still appear, but with an empty ID. If multiple runtimes are
active, then duplicate ID values will appear.

Fixes: #385