### PR TITLE
fix(console): fix calculation of busy time during poll

### DIFF
--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -329,17 +329,6 @@ impl Task {
             }
         }
         self.stats.busy
-        // let busy_time_in_poll = |started| {
-        //     // in this case the task is being polled at the moment
-        //     let current_time_in_poll = since.duration_since(started).unwrap_or_default();
-        //     self.stats.busy + current_time_in_poll
-        // };
-
-        // match (self.stats.last_poll_started, self.stats.last_poll_ended) {
-        //     (Some(started), Some(ended)) if started > ended => busy_time_in_poll(started),
-        //     (Some(started), _) => busy_time_in_poll(started),
-        //     _ => self.stats.busy,
-        // }
     }
 
     pub(crate) fn idle(&self, since: SystemTime) -> Duration {

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -321,17 +321,25 @@ impl Task {
     }
 
     pub(crate) fn busy(&self, since: SystemTime) -> Duration {
-        let busy_time_in_poll = |started| {
-            // in this case the task is being polled at the moment
-            let current_time_in_poll = since.duration_since(started).unwrap_or_default();
-            self.stats.busy + current_time_in_poll
-        };
-
-        match (self.stats.last_poll_started, self.stats.last_poll_ended) {
-            (Some(started), Some(ended)) if started > ended => busy_time_in_poll(started),
-            (Some(started), _) => busy_time_in_poll(started),
-            _ => self.stats.busy,
+        if let Some(started) = self.stats.last_poll_started {
+            if self.stats.last_poll_started > self.stats.last_poll_ended {
+                // in this case the task is being polled at the moment
+                let current_time_in_poll = since.duration_since(started).unwrap_or_default();
+                return self.stats.busy + current_time_in_poll;
+            }
         }
+        self.stats.busy
+        // let busy_time_in_poll = |started| {
+        //     // in this case the task is being polled at the moment
+        //     let current_time_in_poll = since.duration_since(started).unwrap_or_default();
+        //     self.stats.busy + current_time_in_poll
+        // };
+
+        // match (self.stats.last_poll_started, self.stats.last_poll_ended) {
+        //     (Some(started), Some(ended)) if started > ended => busy_time_in_poll(started),
+        //     (Some(started), _) => busy_time_in_poll(started),
+        //     _ => self.stats.busy,
+        // }
     }
 
     pub(crate) fn idle(&self, since: SystemTime) -> Duration {


### PR DESCRIPTION
The Console API specifies sending task busy duration only for completed
polls, it doesn't include the time spent in the current poll if the task
is active.

Tokio Console then calculates the busy time including the time spent in
the current poll - based on the last poll start and poll end times sent
by the Console Subscriber.

However, there was an error in the logic which determined when a task is
being polled for the purpose of calculating the busy time. The logic
only considered the first poll, when there was no recorded end poll time
at all.

This change adapts the logic so that it also considers the case where
the last recorded poll start is later than the last recorded poll end.
This indicates that the task is being polled.

## PR Notes

You can see the current behavior by creating a task which blocks for a
long time (say `std::thread::sleep` for 5 seconds) in a loop, yielding
in between. Setting the console subscriber interval to 100ms makes
it easier to see.

In console we see the **Total Time** going up gradually, but the
**Busy** time stays the same for 5 seconds and then jump up. The
busy percentage jumps up and down as the busy time is incorrect.

Here's a GIF!

![long-sleep-busy-jump](https://user-images.githubusercontent.com/89589/228893769-e5a8e16f-6df9-494c-80dd-a5a1ef1f4301.gif)

After the fix, both times move smoothly and the busy percentage
remains constant as it should.

Another GIF!

![long-sleep-fixed](https://user-images.githubusercontent.com/89589/228893910-27f3337b-7136-4f50-a735-fc096c824427.gif)