### PR TITLE
feat(console): add scheduled time per task

### DIFF
--- a/console-api/proto/common.proto
+++ b/console-api/proto/common.proto
@@ -161,6 +161,10 @@ message PollStats {
     // Subtracting this timestamp from `created_at` can be used to calculate the
     // time to first poll for this object, a measurement of executor latency.
     optional google.protobuf.Timestamp first_poll = 3;
+    // The timestamp of the most recent time this object was woken.
+    //
+    // If this is `None`, the object has not yet been woken.
+    optional google.protobuf.Timestamp last_wake = 7;
     // The timestamp of the most recent time this objects's poll method was invoked.
     //
     // If this is `None`, the object has not yet been polled.
@@ -180,8 +184,15 @@ message PollStats {
     // all polls. Note that this includes only polls that have completed and is
     // not reflecting any inprogress polls. Subtracting `busy_time` from the
     // total lifetime of the polled object results in the amount of time it
-    // has spent *waiting* to be polled.
+    // has spent *waiting* to be polled (including `scheduled_time`).
     google.protobuf.Duration busy_time = 6;
+    // The total duration this object was scheduled prior to being polled, summed
+    // across all poll cycles. Note that this includes only polls that have
+    // started and is not reflecting any scheduled state where the polling hasn't
+    // yet finished. Subtracting both `busy_time` and `scheduled_time` from the
+    // total lifetime of the polled object results in the amount of time it spent
+    // unable to progress because it was waiting on some resource.
+    google.protobuf.Duration scheduled_time = 8;
 }
 
 // State attributes of an entity. These are dependent on the type of the entity.

--- a/console-api/proto/common.proto
+++ b/console-api/proto/common.proto
@@ -161,10 +161,6 @@ message PollStats {
     // Subtracting this timestamp from `created_at` can be used to calculate the
     // time to first poll for this object, a measurement of executor latency.
     optional google.protobuf.Timestamp first_poll = 3;
-    // The timestamp of the most recent time this object was woken.
-    //
-    // If this is `None`, the object has not yet been woken.
-    optional google.protobuf.Timestamp last_wake = 7;
     // The timestamp of the most recent time this objects's poll method was invoked.
     //
     // If this is `None`, the object has not yet been polled.
@@ -186,13 +182,6 @@ message PollStats {
     // total lifetime of the polled object results in the amount of time it
     // has spent *waiting* to be polled (including `scheduled_time`).
     google.protobuf.Duration busy_time = 6;
-    // The total duration this object was scheduled prior to being polled, summed
-    // across all poll cycles. Note that this includes only polls that have
-    // started and is not reflecting any scheduled state where the polling hasn't
-    // yet finished. Subtracting both `busy_time` and `scheduled_time` from the
-    // total lifetime of the polled object results in the amount of time it spent
-    // unable to progress because it was waiting on some resource.
-    google.protobuf.Duration scheduled_time = 8;
 }
 
 // State attributes of an entity. These are dependent on the type of the entity.

--- a/console-api/proto/common.proto
+++ b/console-api/proto/common.proto
@@ -180,7 +180,8 @@ message PollStats {
     // all polls. Note that this includes only polls that have completed and is
     // not reflecting any inprogress polls. Subtracting `busy_time` from the
     // total lifetime of the polled object results in the amount of time it
-    // has spent *waiting* to be polled (including `scheduled_time`).
+    // has spent *waiting* to be polled (including `scheduled_time`, if
+    // this object is a task).
     google.protobuf.Duration busy_time = 6;
 }
 

--- a/console-api/proto/common.proto
+++ b/console-api/proto/common.proto
@@ -177,11 +177,13 @@ message PollStats {
     // its poll method has completed.
     optional google.protobuf.Timestamp last_poll_ended = 5;
     // The total duration this object was being *actively polled*, summed across
-    // all polls. Note that this includes only polls that have completed and is
-    // not reflecting any inprogress polls. Subtracting `busy_time` from the
+    // all polls.
+    //
+    // Note that this includes only polls that have completed, and does not
+    // reflect any in-progress polls. Subtracting `busy_time` from the
     // total lifetime of the polled object results in the amount of time it
-    // has spent *waiting* to be polled (including `scheduled_time`, if
-    // this object is a task).
+    // has spent *waiting* to be polled (including the `scheduled_time` value
+    // from `TaskStats`, if this is a task).
     google.protobuf.Duration busy_time = 6;
 }
 

--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -133,9 +133,10 @@ message Stats {
     // The total duration this task was scheduled prior to being polled, summed
     // across all poll cycles. Note that this includes only polls that have
     // started and is not reflecting any scheduled state where the task hasn't
-    // yet been polled. Subtracting both `busy_time` and `scheduled_time` from the
-    // total lifetime of the polled task results in the amount of time it spent
-    // unable to progress because it was waiting on some resource.
+    // yet been polled. Subtracting both `busy_time` (defined on
+    // `common::PollStats`) and `scheduled_time` from the total lifetime of the
+    // polled task results in the amount of time it spent unable to progress
+    // because it was waiting on some resource.
     google.protobuf.Duration scheduled_time = 9;
 }
 

--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -134,7 +134,7 @@ message Stats {
     // across all poll cycles. Note that this includes only polls that have
     // started and is not reflecting any scheduled state where the task hasn't
     // yet been polled. Subtracting both `busy_time` and `scheduled_time` from the
-    // total lifetime of the polled object results in the amount of time it spent
+    // total lifetime of the polled task results in the amount of time it spent
     // unable to progress because it was waiting on some resource.
     google.protobuf.Duration scheduled_time = 9;
 }

--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -135,7 +135,7 @@ message Stats {
     //
     // Note that this includes only polls that have started, and does not
     // reflect any scheduled state where the task hasn't yet been polled.
-    // Subtracting both `busy_time` (from the task's PollStats`) and
+    // Subtracting both `busy_time` (from the task's `PollStats`) and
     // `scheduled_time` from the total lifetime of the task results in the
     // amount of time it spent unable to progress because it was waiting on 
     // some resource.

--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -122,10 +122,6 @@ message Stats {
     uint64 waker_clones = 4;
     // The total number of times this task's waker has been dropped.
     uint64 waker_drops = 5;
-    // The timestamp of the most recent time this task has been woken.
-    //
-    // If this is `None`, the task has not yet been woken.
-    optional google.protobuf.Timestamp last_wake = 6;
     // Contains task poll statistics.
     common.PollStats poll_stats = 7;
     // The total number of times this task has woken itself.

--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -122,10 +122,21 @@ message Stats {
     uint64 waker_clones = 4;
     // The total number of times this task's waker has been dropped.
     uint64 waker_drops = 5;
+    // The timestamp of the most recent time this task has been woken.
+    //
+    // If this is `None`, the task has not yet been woken.
+    optional google.protobuf.Timestamp last_wake = 6;
     // Contains task poll statistics.
     common.PollStats poll_stats = 7;
     // The total number of times this task has woken itself.
     uint64 self_wakes = 8;
+    // The total duration this task was scheduled prior to being polled, summed
+    // across all poll cycles. Note that this includes only polls that have
+    // started and is not reflecting any scheduled state where the task hasn't
+    // yet been polled. Subtracting both `busy_time` and `scheduled_time` from the
+    // total lifetime of the polled object results in the amount of time it spent
+    // unable to progress because it was waiting on some resource.
+    google.protobuf.Duration scheduled_time = 9;
 }
 
 

--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -131,12 +131,14 @@ message Stats {
     // The total number of times this task has woken itself.
     uint64 self_wakes = 8;
     // The total duration this task was scheduled prior to being polled, summed
-    // across all poll cycles. Note that this includes only polls that have
-    // started and is not reflecting any scheduled state where the task hasn't
-    // yet been polled. Subtracting both `busy_time` (defined on
-    // `common::PollStats`) and `scheduled_time` from the total lifetime of the
-    // polled task results in the amount of time it spent unable to progress
-    // because it was waiting on some resource.
+    // across all poll cycles.
+    //
+    // Note that this includes only polls that have started, and does not
+    // reflect any scheduled state where the task hasn't yet been polled.
+    // Subtracting both `busy_time` (from the task's PollStats`) and
+    // `scheduled_time` from the total lifetime of the task results in the
+    // amount of time it spent unable to progress because it was waiting on 
+    // some resource.
     google.protobuf.Duration scheduled_time = 9;
 }
 

--- a/console-api/src/generated/rs.tokio.console.common.rs
+++ b/console-api/src/generated/rs.tokio.console.common.rs
@@ -253,11 +253,13 @@ pub struct PollStats {
     #[prost(message, optional, tag="5")]
     pub last_poll_ended: ::core::option::Option<::prost_types::Timestamp>,
     /// The total duration this object was being *actively polled*, summed across
-    /// all polls. Note that this includes only polls that have completed and is
-    /// not reflecting any inprogress polls. Subtracting `busy_time` from the
+    /// all polls.
+    ///
+    /// Note that this includes only polls that have completed, and does not
+    /// reflect any in-progress polls. Subtracting `busy_time` from the
     /// total lifetime of the polled object results in the amount of time it
-    /// has spent *waiting* to be polled (including `scheduled_time`, if
-    /// this object is a task).
+    /// has spent *waiting* to be polled (including the `scheduled_time` value
+    /// from `TaskStats`, if this is a task).
     #[prost(message, optional, tag="6")]
     pub busy_time: ::core::option::Option<::prost_types::Duration>,
 }

--- a/console-api/src/generated/rs.tokio.console.common.rs
+++ b/console-api/src/generated/rs.tokio.console.common.rs
@@ -256,7 +256,8 @@ pub struct PollStats {
     /// all polls. Note that this includes only polls that have completed and is
     /// not reflecting any inprogress polls. Subtracting `busy_time` from the
     /// total lifetime of the polled object results in the amount of time it
-    /// has spent *waiting* to be polled (including `scheduled_time`).
+    /// has spent *waiting* to be polled (including `scheduled_time`, if
+    /// this object is a task).
     #[prost(message, optional, tag="6")]
     pub busy_time: ::core::option::Option<::prost_types::Duration>,
 }

--- a/console-api/src/generated/rs.tokio.console.common.rs
+++ b/console-api/src/generated/rs.tokio.console.common.rs
@@ -235,6 +235,11 @@ pub struct PollStats {
     /// time to first poll for this object, a measurement of executor latency.
     #[prost(message, optional, tag="3")]
     pub first_poll: ::core::option::Option<::prost_types::Timestamp>,
+    /// The timestamp of the most recent time this object was woken.
+    ///
+    /// If this is `None`, the object has not yet been woken.
+    #[prost(message, optional, tag="7")]
+    pub last_wake: ::core::option::Option<::prost_types::Timestamp>,
     /// The timestamp of the most recent time this objects's poll method was invoked.
     ///
     /// If this is `None`, the object has not yet been polled.
@@ -256,9 +261,17 @@ pub struct PollStats {
     /// all polls. Note that this includes only polls that have completed and is
     /// not reflecting any inprogress polls. Subtracting `busy_time` from the
     /// total lifetime of the polled object results in the amount of time it
-    /// has spent *waiting* to be polled.
+    /// has spent *waiting* to be polled (including `scheduled_time`).
     #[prost(message, optional, tag="6")]
     pub busy_time: ::core::option::Option<::prost_types::Duration>,
+    /// The total duration this object was scheduled prior to being polled, summed
+    /// across all poll cycles. Note that this includes only polls that have
+    /// started and is not reflecting any scheduled state where the polling hasn't
+    /// yet finished. Subtracting both `busy_time` and `scheduled_time` from the
+    /// total lifetime of the polled object results in the amount of time it spent
+    /// unable to progress because it was waiting on some resource.
+    #[prost(message, optional, tag="8")]
+    pub scheduled_time: ::core::option::Option<::prost_types::Duration>,
 }
 /// State attributes of an entity. These are dependent on the type of the entity.
 ///

--- a/console-api/src/generated/rs.tokio.console.common.rs
+++ b/console-api/src/generated/rs.tokio.console.common.rs
@@ -235,11 +235,6 @@ pub struct PollStats {
     /// time to first poll for this object, a measurement of executor latency.
     #[prost(message, optional, tag="3")]
     pub first_poll: ::core::option::Option<::prost_types::Timestamp>,
-    /// The timestamp of the most recent time this object was woken.
-    ///
-    /// If this is `None`, the object has not yet been woken.
-    #[prost(message, optional, tag="7")]
-    pub last_wake: ::core::option::Option<::prost_types::Timestamp>,
     /// The timestamp of the most recent time this objects's poll method was invoked.
     ///
     /// If this is `None`, the object has not yet been polled.
@@ -264,14 +259,6 @@ pub struct PollStats {
     /// has spent *waiting* to be polled (including `scheduled_time`).
     #[prost(message, optional, tag="6")]
     pub busy_time: ::core::option::Option<::prost_types::Duration>,
-    /// The total duration this object was scheduled prior to being polled, summed
-    /// across all poll cycles. Note that this includes only polls that have
-    /// started and is not reflecting any scheduled state where the polling hasn't
-    /// yet finished. Subtracting both `busy_time` and `scheduled_time` from the
-    /// total lifetime of the polled object results in the amount of time it spent
-    /// unable to progress because it was waiting on some resource.
-    #[prost(message, optional, tag="8")]
-    pub scheduled_time: ::core::option::Option<::prost_types::Duration>,
 }
 /// State attributes of an entity. These are dependent on the type of the entity.
 ///

--- a/console-api/src/generated/rs.tokio.console.tasks.rs
+++ b/console-api/src/generated/rs.tokio.console.tasks.rs
@@ -156,11 +156,6 @@ pub struct Stats {
     /// The total number of times this task's waker has been dropped.
     #[prost(uint64, tag="5")]
     pub waker_drops: u64,
-    /// The timestamp of the most recent time this task has been woken.
-    ///
-    /// If this is `None`, the task has not yet been woken.
-    #[prost(message, optional, tag="6")]
-    pub last_wake: ::core::option::Option<::prost_types::Timestamp>,
     /// Contains task poll statistics.
     #[prost(message, optional, tag="7")]
     pub poll_stats: ::core::option::Option<super::common::PollStats>,

--- a/console-api/src/generated/rs.tokio.console.tasks.rs
+++ b/console-api/src/generated/rs.tokio.console.tasks.rs
@@ -156,12 +156,25 @@ pub struct Stats {
     /// The total number of times this task's waker has been dropped.
     #[prost(uint64, tag="5")]
     pub waker_drops: u64,
+    /// The timestamp of the most recent time this task has been woken.
+    ///
+    /// If this is `None`, the task has not yet been woken.
+    #[prost(message, optional, tag="6")]
+    pub last_wake: ::core::option::Option<::prost_types::Timestamp>,
     /// Contains task poll statistics.
     #[prost(message, optional, tag="7")]
     pub poll_stats: ::core::option::Option<super::common::PollStats>,
     /// The total number of times this task has woken itself.
     #[prost(uint64, tag="8")]
     pub self_wakes: u64,
+    /// The total duration this task was scheduled prior to being polled, summed
+    /// across all poll cycles. Note that this includes only polls that have
+    /// started and is not reflecting any scheduled state where the task hasn't
+    /// yet been polled. Subtracting both `busy_time` and `scheduled_time` from the
+    /// total lifetime of the polled object results in the amount of time it spent
+    /// unable to progress because it was waiting on some resource.
+    #[prost(message, optional, tag="9")]
+    pub scheduled_time: ::core::option::Option<::prost_types::Duration>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DurationHistogram {

--- a/console-api/src/generated/rs.tokio.console.tasks.rs
+++ b/console-api/src/generated/rs.tokio.console.tasks.rs
@@ -168,12 +168,14 @@ pub struct Stats {
     #[prost(uint64, tag="8")]
     pub self_wakes: u64,
     /// The total duration this task was scheduled prior to being polled, summed
-    /// across all poll cycles. Note that this includes only polls that have
-    /// started and is not reflecting any scheduled state where the task hasn't
-    /// yet been polled. Subtracting both `busy_time` (defined on
-    /// `common::PollStats`) and `scheduled_time` from the total lifetime of the
-    /// polled task results in the amount of time it spent unable to progress
-    /// because it was waiting on some resource.
+    /// across all poll cycles.
+    ///
+    /// Note that this includes only polls that have started, and does not
+    /// reflect any scheduled state where the task hasn't yet been polled.
+    /// Subtracting both `busy_time` (from the task's PollStats`) and
+    /// `scheduled_time` from the total lifetime of the task results in the
+    /// amount of time it spent unable to progress because it was waiting on 
+    /// some resource.
     #[prost(message, optional, tag="9")]
     pub scheduled_time: ::core::option::Option<::prost_types::Duration>,
 }

--- a/console-api/src/generated/rs.tokio.console.tasks.rs
+++ b/console-api/src/generated/rs.tokio.console.tasks.rs
@@ -170,9 +170,10 @@ pub struct Stats {
     /// The total duration this task was scheduled prior to being polled, summed
     /// across all poll cycles. Note that this includes only polls that have
     /// started and is not reflecting any scheduled state where the task hasn't
-    /// yet been polled. Subtracting both `busy_time` and `scheduled_time` from the
-    /// total lifetime of the polled object results in the amount of time it spent
-    /// unable to progress because it was waiting on some resource.
+    /// yet been polled. Subtracting both `busy_time` (defined on
+    /// `common::PollStats`) and `scheduled_time` from the total lifetime of the
+    /// polled task results in the amount of time it spent unable to progress
+    /// because it was waiting on some resource.
     #[prost(message, optional, tag="9")]
     pub scheduled_time: ::core::option::Option<::prost_types::Duration>,
 }

--- a/console-api/src/generated/rs.tokio.console.tasks.rs
+++ b/console-api/src/generated/rs.tokio.console.tasks.rs
@@ -172,7 +172,7 @@ pub struct Stats {
     ///
     /// Note that this includes only polls that have started, and does not
     /// reflect any scheduled state where the task hasn't yet been polled.
-    /// Subtracting both `busy_time` (from the task's PollStats`) and
+    /// Subtracting both `busy_time` (from the task's `PollStats`) and
     /// `scheduled_time` from the total lifetime of the task results in the
     /// amount of time it spent unable to progress because it was waiting on 
     /// some resource.

--- a/console-subscriber/examples/long_scheduled.rs
+++ b/console-subscriber/examples/long_scheduled.rs
@@ -11,6 +11,11 @@
 //! woken, but because there's only a single worker thread, it doesn't
 //! get polled until after the sender task has finished "working" and
 //! yields (via `tokio::time::sleep`).
+//!
+//! In the console, this is visible in the `rx` task, which has very
+//! high scheduled times - in the detail screen you will see that around
+//! it is scheduled around 98% of the time. The `tx` task, on the other
+//! hand, is busy most of the time.
 use std::time::Duration;
 
 use console_subscriber::ConsoleLayer;

--- a/console-subscriber/examples/long_scheduled.rs
+++ b/console-subscriber/examples/long_scheduled.rs
@@ -1,0 +1,73 @@
+//! Long scheduled time
+//!
+//! This example shows an application with a task that has an excessive
+//! time between being woken and being polled.
+//!
+//! It consists of a channel where a sender task sends a message
+//! through the channel and then immediately does a lot of work
+//! (simulated in this case by a call to `std::thread::sleep`).
+//!
+//! As soon as the sender task calls `send()` the receiver task gets
+//! woken, but because there's only a single worker thread, it doesn't
+//! get polled until after the sender task has finished "working" and
+//! yields (via `tokio::time::sleep`).
+use std::time::Duration;
+
+use console_subscriber::ConsoleLayer;
+use tokio::{sync::mpsc, task};
+use tracing::info;
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 1)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ConsoleLayer::builder()
+        .with_default_env()
+        .publish_interval(Duration::from_millis(100))
+        .init();
+
+    let (tx, rx) = mpsc::channel::<u32>(1);
+    let count = 10000;
+
+    let jh_rx = task::Builder::new()
+        .name("rx")
+        .spawn(receiver(rx, count))
+        .unwrap();
+    let jh_tx = task::Builder::new()
+        .name("tx")
+        .spawn(sender(tx, count))
+        .unwrap();
+
+    let res_tx = jh_tx.await;
+    let res_rx = jh_rx.await;
+    info!(
+        "main: Joined sender: {:?} and receiver: {:?}",
+        res_tx, res_rx,
+    );
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    Ok(())
+}
+
+async fn sender(tx: mpsc::Sender<u32>, count: u32) {
+    info!("tx: started");
+
+    for idx in 0..count {
+        let msg: u32 = idx;
+        let res = tx.send(msg).await;
+        info!("tx: sent msg '{}' result: {:?}", msg, res);
+
+        std::thread::sleep(Duration::from_millis(5000));
+        info!("tx: work done");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn receiver(mut rx: mpsc::Receiver<u32>, count: u32) {
+    info!("rx: started");
+
+    for _ in 0..count {
+        let msg = rx.recv().await;
+        info!("rx: Received message: '{:?}'", msg);
+    }
+}

--- a/console-subscriber/src/stats.rs
+++ b/console-subscriber/src/stats.rs
@@ -488,7 +488,7 @@ impl<H: RecordPoll> PollStats<H> {
         let scheduled = match std::cmp::max(timestamps.last_wake, timestamps.last_poll_ended) {
             Some(scheduled) => scheduled,
             None => return, // Async operations record polls, but not wakes
-        }
+        };
 
         let elapsed = match at.checked_duration_since(scheduled) {
             Some(elapsed) => elapsed,

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -454,17 +454,14 @@ impl From<proto::tasks::Stats> for TaskStats {
 
         let poll_stats = pb.poll_stats.expect("task should have poll stats");
         let busy = poll_stats.busy_time.map(pb_duration).unwrap_or_default();
-        let scheduled = poll_stats
-            .scheduled_time
-            .map(pb_duration)
-            .unwrap_or_default();
+        let scheduled = pb.scheduled_time.map(pb_duration).unwrap_or_default();
         let idle = total.map(|total| total.checked_sub(busy + scheduled).unwrap_or_default());
         Self {
             total,
             idle,
             scheduled,
             busy,
-            last_wake: poll_stats.last_wake.map(|v| v.try_into().unwrap()),
+            last_wake: pb.last_wake.map(|v| v.try_into().unwrap()),
             last_poll_started: poll_stats.last_poll_started.map(|v| v.try_into().unwrap()),
             last_poll_ended: poll_stats.last_poll_ended.map(|v| v.try_into().unwrap()),
             polls: poll_stats.polls,

--- a/tokio-console/src/view/mod.rs
+++ b/tokio-console/src/view/mod.rs
@@ -39,7 +39,7 @@ pub struct View {
     /// details view), we want to leave the task list's state the way we left it
     /// --- e.g., if the user previously selected a particular sorting, we want
     /// it to remain sorted that way when we return to it.
-    tasks_list: TableListState<TasksTable, 11>,
+    tasks_list: TableListState<TasksTable, 12>,
     resources_list: TableListState<ResourcesTable, 9>,
     state: ViewState,
     pub(crate) styles: Styles,
@@ -93,7 +93,7 @@ impl View {
     pub fn new(styles: Styles) -> Self {
         Self {
             state: ViewState::TasksList,
-            tasks_list: TableListState::<TasksTable, 11>::default(),
+            tasks_list: TableListState::<TasksTable, 12>::default(),
             resources_list: TableListState::<ResourcesTable, 9>::default(),
             styles,
         }

--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -69,7 +69,7 @@ impl TaskView {
                             // controls
                             layout::Constraint::Length(1),
                             // task stats
-                            layout::Constraint::Length(8),
+                            layout::Constraint::Length(10),
                             // poll duration
                             layout::Constraint::Length(9),
                             // fields
@@ -89,7 +89,7 @@ impl TaskView {
                             // warnings (add 2 for top and bottom borders)
                             layout::Constraint::Length(warnings.len() as u16 + 2),
                             // task stats
-                            layout::Constraint::Length(8),
+                            layout::Constraint::Length(10),
                             // poll duration
                             layout::Constraint::Length(9),
                             // fields
@@ -122,7 +122,7 @@ impl TaskView {
         ]);
 
         // Just preallocate capacity for ID, name, target, total, busy, and idle.
-        let mut overview = Vec::with_capacity(7);
+        let mut overview = Vec::with_capacity(8);
         overview.push(Spans::from(vec![
             bold("ID: "),
             Span::raw(format!("{} ", task.id())),
@@ -159,6 +159,7 @@ impl TaskView {
             styles.time_units(total, view::DUR_LIST_PRECISION, None),
         ]));
         overview.push(dur_percent("Busy: ", task.busy(now)));
+        overview.push(dur_percent("Scheduled: ", task.scheduled(now)));
         overview.push(dur_percent("Idle: ", task.idle(now)));
 
         let mut waker_stats = vec![Spans::from(vec![

--- a/tokio-console/src/view/tasks.rs
+++ b/tokio-console/src/view/tasks.rs
@@ -19,17 +19,17 @@ use tui::{
 #[derive(Debug, Default)]
 pub(crate) struct TasksTable {}
 
-impl TableList<11> for TasksTable {
+impl TableList<12> for TasksTable {
     type Row = Task;
     type Sort = SortBy;
     type Context = ();
 
-    const HEADER: &'static [&'static str; 11] = &[
-        "Warn", "ID", "State", "Name", "Total", "Busy", "Idle", "Polls", "Target", "Location",
-        "Fields",
+    const HEADER: &'static [&'static str; 12] = &[
+        "Warn", "ID", "State", "Name", "Total", "Busy", "Sched", "Idle", "Polls", "Target",
+        "Location", "Fields",
     ];
 
-    const WIDTHS: &'static [usize; 11] = &[
+    const WIDTHS: &'static [usize; 12] = &[
         Self::HEADER[0].len() + 1,
         Self::HEADER[1].len() + 1,
         Self::HEADER[2].len() + 1,
@@ -41,10 +41,11 @@ impl TableList<11> for TasksTable {
         Self::HEADER[8].len() + 1,
         Self::HEADER[9].len() + 1,
         Self::HEADER[10].len() + 1,
+        Self::HEADER[11].len() + 1,
     ];
 
     fn render<B: tui::backend::Backend>(
-        table_list_state: &mut TableListState<Self, 11>,
+        table_list_state: &mut TableListState<Self, 12>,
         styles: &view::Styles,
         frame: &mut tui::terminal::Frame<B>,
         area: layout::Rect,
@@ -129,6 +130,7 @@ impl TableList<11> for TasksTable {
                         Cell::from(name_width.update_str(task.name().unwrap_or("")).to_string()),
                         dur_cell(task.total(now)),
                         dur_cell(task.busy(now)),
+                        dur_cell(task.scheduled(now)),
                         dur_cell(task.idle(now)),
                         Cell::from(polls_width.update_str(task.total_polls().to_string())),
                         Cell::from(target_width.update_str(task.target()).to_owned()),
@@ -249,6 +251,7 @@ impl TableList<11> for TasksTable {
             id_width.constraint(),
             layout::Constraint::Length(state_len),
             name_width.constraint(),
+            layout::Constraint::Length(DUR_LEN as u16),
             layout::Constraint::Length(DUR_LEN as u16),
             layout::Constraint::Length(DUR_LEN as u16),
             layout::Constraint::Length(DUR_LEN as u16),


### PR DESCRIPTION
Each task displays the sum of the time it has been idle and busy, as
well as the total. The idle time includes the time between when a task
is woken, and when the runtime actually polls that task.

There are cases where a task may be scheduled for a long time after
being woken, before it is polled. Especially if many tasks are woken at
the same time and don't yield back to the runtime quickly.

To add visibility to this, the total time that a task is scheduled
before being polled has been added. Additionally, a new task state
`Scheduled` has been added. This is displayed in both the tasks table
and in the task detail view.

In the `console-api`, the `last_wake` time has been moved from
`tasks::Stats` to `common::PollStats`, where the total `scheduled_time`
for the task has also been added.

This is the first of two parts. In the second part (#409), a histogram for
scheduled time will be added, the equivalent of the poll time histogram
which is already available on the task detail screen.

To show a pathological case which may lead to needing to see the
scheduled time, a new example has been added to the `console-subscriber`
examples.

## Breaking wire format change

Just to be super clear, by moving `last_wake` from `tasks::Stats` to
`common::PollStats`, this is a breaking change to the wire format (at least
functionally). It's not stricly necessary, but leaving it as it is will make some
other things messier.

Of course, mess can be cleaned up later if we want a more polished upgrade
path than requiring that `console-subscriber` and `tokio-console` are
updated at the same time.

## PR Notes

This PR does something adjacent to what is described in #50, but not quite.

The unicode character used for a `SCHED` task is ⏫.

The second PR (#409) will record a scheduled time histogram the same as it
recorded for poll times. These two changes should go in together (and certainly
shouldn't be released separately). However, this PR is already quite big, so they'll
be separated out.

The idea is that this PR isn't merged until the next one has also been reviewed
and approved. It would be good to get some feedback at this stage though.

The task list view with the new column for `Sched` time:

<img width="1032" alt="a tasks table view for the long-scheduled example" src="https://user-images.githubusercontent.com/89589/232456977-2921f884-4673-420f-ba4f-3646627d44db.png">

The `Task` block in the task detail view showing the new `Scheduled` time entry.

<img width="510" alt="The task block on the task detail view for the rx task in the long-scheduled example" src="https://user-images.githubusercontent.com/89589/232457332-e455e086-9468-42c9-8fda-7965d8d1e6f8.png">