### PR TITLE
chore: Use fixed Rust version for clippy (and fmt)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,10 @@ env:
   RUSTUP_MAX_RETRIES: 10
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
+  # Use Rust 1.68.2 for Clippy (and fmt) because of an enhanced `almost_swapped`
+  # lint in 1.69.0 which affects clap 3 and can't be `allow`ed.
+  RUST_FMT_CLIPPY: 1.68.2
+
 
 jobs:
   check:
@@ -105,14 +109,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ env.rust_clippy }}
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v1
+          toolchain: ${{ env.rust_fmt_clippy }}
+          components: clippy, rustfmt
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,10 +109,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install Rust ${{ env.rust_clippy }}
+      - name: Install Rust ${{ env.RUST_FMT_CLIPPY }}
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.rust_fmt_clippy }}
+          toolchain: ${{ env.RUST_FMT_CLIPPY }}
           components: clippy, rustfmt
 
       - name: Run cargo fmt


### PR DESCRIPTION
In Rust 1.69.0, the `almost_swapped` lint was enhanced and now triggers
on the clap 3.x `Subcommand` derive macro. Unfortunately the macro
includes `#[deny(clippy::correctness)]` (which implies denying
`almost_swapped`), and so it can't be overridden.

This issue doesn't exist in clap 4.x, it was fixed already.

Until either the fix is backported to clap 3.x or we switch to clap
4.x., this change fixes the Rust version used for clippy (and by
extension fmt) to the previous version 1.68.2.