### PR TITLE
feat(console): help view modal

### DIFF
--- a/tokio-console/src/input.rs
+++ b/tokio-console/src/input.rs
@@ -33,3 +33,23 @@ pub(crate) fn is_space(input: &Event) -> bool {
         })
     )
 }
+
+pub(crate) fn is_help_toggle(event: &Event) -> bool {
+    matches!(
+        event,
+        Event::Key(KeyEvent {
+            code: KeyCode::Char('?'),
+            ..
+        })
+    )
+}
+
+pub(crate) fn is_esc(event: &Event) -> bool {
+    matches!(
+        event,
+        Event::Key(KeyEvent {
+            code: KeyCode::Esc,
+            ..
+        })
+    )
+}

--- a/tokio-console/src/view/async_ops.rs
+++ b/tokio-console/src/view/async_ops.rs
@@ -1,3 +1,4 @@
+pub(crate) use crate::view::table::view_controls;
 use crate::{
     state::{
         async_ops::{AsyncOp, SortBy},
@@ -6,7 +7,8 @@ use crate::{
     },
     view::{
         self, bold,
-        table::{self, TableList, TableListState},
+        controls::Controls,
+        table::{TableList, TableListState},
         DUR_LEN, DUR_TABLE_PRECISION,
     },
 };
@@ -197,11 +199,11 @@ impl TableList<9> for AsyncOpsTable {
             .direction(layout::Direction::Vertical)
             .margin(0);
 
-        let controls = table::Controls::for_area(&area, styles);
+        let controls = Controls::new(view_controls(), &area, styles);
         let chunks = layout
             .constraints(
                 [
-                    layout::Constraint::Length(controls.height),
+                    layout::Constraint::Length(controls.height()),
                     layout::Constraint::Max(area.height),
                 ]
                 .as_ref(),
@@ -232,7 +234,7 @@ impl TableList<9> for AsyncOpsTable {
             .highlight_style(Style::default().add_modifier(style::Modifier::BOLD));
 
         frame.render_stateful_widget(table, async_ops_area, &mut table_list_state.table_state);
-        frame.render_widget(controls.paragraph, controls_area);
+        frame.render_widget(controls.into_widget(), controls_area);
 
         table_list_state
             .sorted_items

--- a/tokio-console/src/view/controls.rs
+++ b/tokio-console/src/view/controls.rs
@@ -1,0 +1,175 @@
+use crate::view::{self, bold};
+
+use ratatui::{
+    layout,
+    text::{Span, Spans, Text},
+    widgets::{Paragraph, Widget},
+};
+
+/// Construct a widget to display the controls available to the user in the
+/// current view.
+pub(crate) struct Controls {
+    paragraph: Paragraph<'static>,
+    height: u16,
+}
+
+impl Controls {
+    pub(in crate::view) fn new(
+        view_controls: &'static [ControlDisplay],
+        area: &layout::Rect,
+        styles: &view::Styles,
+    ) -> Self {
+        let universal_controls = universal_controls();
+
+        let mut spans_controls = Vec::with_capacity(view_controls.len() + universal_controls.len());
+
+        spans_controls.extend(view_controls.iter().map(|c| c.to_spans(styles, 0)));
+        spans_controls.extend(universal_controls.iter().map(|c| c.to_spans(styles, 0)));
+
+        let mut lines = vec![Spans::from(vec![Span::from("controls: ")])];
+        let mut current_line = lines.last_mut().expect("This vector is never empty");
+        let separator = Span::from(", ");
+
+        let controls_count: usize = spans_controls.len();
+        for (idx, spans) in spans_controls.into_iter().enumerate() {
+            // If this is the first item on this line - or first item on the
+            // first line, then always include it - even if it goes beyond the
+            // line width, not much we can do anyway.
+            if idx == 0 || current_line.width() == 0 {
+                current_line.0.extend(spans.0);
+                continue;
+            }
+
+            // Include the width of our separator in the current item if we
+            // aren't placing the last item. This is the separator after the
+            // new element.
+            let needed_trailing_separator_width = if idx == controls_count + 1 {
+                separator.width()
+            } else {
+                0
+            };
+
+            let total_width = current_line.width()
+                + separator.width()
+                + spans.width()
+                + needed_trailing_separator_width;
+
+            // If the current item fits on this line, append it.
+            // Otherwise, append only the separator - we accounted for its
+            // width in the previous loop iteration - and then create a new
+            // line for the current item.
+            if total_width <= area.width as usize {
+                current_line.0.push(separator.clone());
+                current_line.0.extend(spans.0);
+            } else {
+                current_line.0.push(separator.clone());
+                lines.push(spans);
+                current_line = lines.last_mut().expect("This vector is never empty");
+            }
+        }
+
+        let height = lines.len() as u16;
+        let text = Text::from(lines);
+
+        Self {
+            paragraph: Paragraph::new(text),
+            height,
+        }
+    }
+
+    pub(crate) fn height(&self) -> u16 {
+        self.height
+    }
+
+    pub(crate) fn into_widget(self) -> impl Widget {
+        self.paragraph
+    }
+}
+
+pub(crate) fn controls_paragraph<'a>(
+    view_controls: &[ControlDisplay],
+    styles: &view::Styles,
+) -> Paragraph<'a> {
+    let universal_controls = universal_controls();
+
+    let mut spans = Vec::with_capacity(1 + view_controls.len() + universal_controls.len());
+    spans.push(Spans::from(vec![Span::raw("controls:")]));
+    spans.extend(view_controls.iter().map(|c| c.to_spans(styles, 2)));
+    spans.extend(universal_controls.iter().map(|c| c.to_spans(styles, 2)));
+
+    Paragraph::new(spans)
+}
+
+/// Construct span to display a control.
+///
+/// A control is made up of an action and one or more keys that will trigger
+/// that action.
+#[derive(Clone)]
+pub(crate) struct ControlDisplay {
+    pub(crate) action: &'static str,
+    pub(crate) keys: &'static [KeyDisplay],
+}
+
+/// A key or keys which will be displayed to the user as part of spans
+/// constructed by `ControlDisplay`.
+///
+/// The `base` description of the key should be ASCII only, more advanced
+/// descriptions can be supplied for that key in the `utf8` field. This
+/// allows the application to pick the best one to display at runtime
+/// based on the termainal being used.
+#[derive(Clone)]
+pub(crate) struct KeyDisplay {
+    pub(crate) base: &'static str,
+    pub(crate) utf8: Option<&'static str>,
+}
+
+impl ControlDisplay {
+    pub(crate) fn to_spans(&self, styles: &view::Styles, indent: usize) -> Spans<'static> {
+        let mut spans = Vec::new();
+
+        spans.push(Span::from(" ".repeat(indent)));
+        spans.push(Span::from(self.action));
+        spans.push(Span::from(" = "));
+        for (idx, key_display) in self.keys.iter().enumerate() {
+            if idx > 0 {
+                spans.push(Span::from(" or "))
+            }
+
+            spans.push(bold(match key_display.utf8 {
+                Some(utf8) => styles.if_utf8(utf8, key_display.base),
+                None => key_display.base,
+            }));
+        }
+
+        Spans::from(spans)
+    }
+
+    // pub(crate) fn into_paragraph()
+}
+
+/// Returns a list of controls which are available in all views.
+const fn universal_controls() -> &'static [ControlDisplay] {
+    &[
+        ControlDisplay {
+            action: "toggle pause",
+            keys: &[KeyDisplay {
+                base: "space",
+                utf8: None,
+            }],
+        },
+        ControlDisplay {
+            action: "toggle help",
+            keys: &[KeyDisplay {
+                base: "?",
+                utf8: None,
+            }],
+        },
+        ControlDisplay {
+            action: "quit",
+            keys: &[KeyDisplay {
+                base: "q",
+                utf8: None,
+            }],
+        },
+    ]
+}

--- a/tokio-console/src/view/help.rs
+++ b/tokio-console/src/view/help.rs
@@ -1,0 +1,67 @@
+use ratatui::{
+    layout::{self, Constraint, Direction, Layout},
+    widgets::{Clear, Paragraph},
+};
+
+use crate::{state::State, view};
+
+pub(crate) trait HelpText {
+    fn render_help_content(&self, styles: &view::Styles) -> Paragraph<'static>;
+}
+
+/// Simple view for help popup
+pub(crate) struct HelpView<'a> {
+    help_text: Option<Paragraph<'a>>,
+}
+
+impl<'a> HelpView<'a> {
+    pub(super) fn new(help_text: Paragraph<'a>) -> Self {
+        HelpView {
+            help_text: Some(help_text),
+        }
+    }
+
+    pub(crate) fn render<B: ratatui::backend::Backend>(
+        &mut self,
+        styles: &view::Styles,
+        frame: &mut ratatui::terminal::Frame<B>,
+        _area: layout::Rect,
+        _state: &mut State,
+    ) {
+        let r = frame.size();
+        let content = self
+            .help_text
+            .take()
+            .expect("help_text should be initialized");
+
+        let popup_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(
+                [
+                    Constraint::Percentage(20),
+                    Constraint::Min(15),
+                    Constraint::Percentage(20),
+                ]
+                .as_ref(),
+            )
+            .split(r);
+
+        let popup_area = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(
+                [
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(60),
+                    Constraint::Percentage(20),
+                ]
+                .as_ref(),
+            )
+            .split(popup_layout[1])[1];
+
+        let display_text = content.block(styles.border_block().title("Help"));
+
+        // Clear the help block area and render the popup
+        frame.render_widget(Clear, popup_area);
+        frame.render_widget(display_text, popup_area);
+    }
+}

--- a/tokio-console/src/view/resource.rs
+++ b/tokio-console/src/view/resource.rs
@@ -4,14 +4,18 @@ use crate::{
     state::State,
     view::{
         self,
-        async_ops::{AsyncOpsTable, AsyncOpsTableCtx},
-        bold, TableListState,
+        async_ops::{self, AsyncOpsTable, AsyncOpsTableCtx},
+        bold,
+        controls::{controls_paragraph, ControlDisplay, Controls, KeyDisplay},
+        help::HelpText,
+        TableListState,
     },
 };
+use once_cell::sync::OnceCell;
 use ratatui::{
     layout::{self, Layout},
     text::{Span, Spans, Text},
-    widgets::{Block, Paragraph},
+    widgets::Paragraph,
 };
 use std::{cell::RefCell, rc::Rc};
 
@@ -42,6 +46,7 @@ impl ResourceView {
         state: &mut State,
     ) {
         let resource = &*self.resource.borrow();
+        let controls = Controls::new(view_controls(), &area, styles);
 
         let (controls_area, stats_area, async_ops_area) = {
             let chunks = Layout::default()
@@ -49,7 +54,7 @@ impl ResourceView {
                 .constraints(
                     [
                         // controls
-                        layout::Constraint::Length(1),
+                        layout::Constraint::Length(controls.height()),
                         // resource stats
                         layout::Constraint::Length(8),
                         // async ops
@@ -71,14 +76,6 @@ impl ResourceView {
                 .as_ref(),
             )
             .split(stats_area);
-
-        let controls = Spans::from(vec![
-            Span::raw("controls: "),
-            bold(styles.if_utf8("\u{238B} esc", "esc")),
-            Span::raw(" = return to task list, "),
-            bold("q"),
-            Span::raw(" = quit"),
-        ]);
 
         let overview = vec![
             Spans::from(vec![bold("ID: "), Span::raw(resource.id_str())]),
@@ -107,7 +104,7 @@ impl ResourceView {
             Paragraph::new(overview).block(styles.border_block().title("Resource"));
         let fields_widget = Paragraph::new(fields).block(styles.border_block().title("Attributes"));
 
-        frame.render_widget(Block::default().title(controls), controls_area);
+        frame.render_widget(controls.into_widget(), controls_area);
         frame.render_widget(resource_widget, stats_area[0]);
         frame.render_widget(fields_widget, stats_area[1]);
         let ctx = AsyncOpsTableCtx {
@@ -118,4 +115,25 @@ impl ResourceView {
             .render(styles, frame, async_ops_area, state, ctx);
         self.initial_render = false;
     }
+}
+
+impl HelpText for ResourceView {
+    fn render_help_content(&self, styles: &view::Styles) -> Paragraph<'static> {
+        controls_paragraph(view_controls(), styles)
+    }
+}
+
+fn view_controls() -> &'static [ControlDisplay] {
+    static VIEW_CONTROLS: OnceCell<Vec<ControlDisplay>> = OnceCell::new();
+
+    VIEW_CONTROLS.get_or_init(|| {
+        let resource_controls = &[ControlDisplay {
+            action: "return to task list",
+            keys: &[KeyDisplay {
+                base: "esc",
+                utf8: Some("\u{238B} esc"),
+            }],
+        }];
+        [resource_controls, async_ops::view_controls()].concat()
+    })
 }

--- a/tokio-console/src/view/resources.rs
+++ b/tokio-console/src/view/resources.rs
@@ -5,7 +5,8 @@ use crate::{
     },
     view::{
         self, bold,
-        table::{self, TableList, TableListState},
+        controls::Controls,
+        table::{view_controls, TableList, TableListState},
         DUR_LEN, DUR_TABLE_PRECISION,
     },
 };
@@ -163,7 +164,7 @@ impl TableList<9> for ResourcesTable {
             table_list_state.len()
         ))]);
 
-        let controls = table::Controls::for_area(&area, styles);
+        let controls = Controls::new(view_controls(), &area, styles);
 
         let layout = layout::Layout::default()
             .direction(layout::Direction::Vertical)
@@ -172,7 +173,7 @@ impl TableList<9> for ResourcesTable {
         let chunks = layout
             .constraints(
                 [
-                    layout::Constraint::Length(controls.height),
+                    layout::Constraint::Length(controls.height()),
                     layout::Constraint::Max(area.height),
                 ]
                 .as_ref(),
@@ -202,7 +203,7 @@ impl TableList<9> for ResourcesTable {
             .highlight_style(Style::default().add_modifier(style::Modifier::BOLD));
 
         frame.render_stateful_widget(table, tasks_area, &mut table_list_state.table_state);
-        frame.render_widget(controls.paragraph, controls_area);
+        frame.render_widget(controls.into_widget(), controls_area);
 
         table_list_state
             .sorted_items

--- a/tokio-console/src/view/table.rs
+++ b/tokio-console/src/view/table.rs
@@ -1,11 +1,14 @@
 use crate::{
     input, state,
-    view::{self, bold},
+    view::{
+        self,
+        controls::{controls_paragraph, ControlDisplay, KeyDisplay},
+        help::HelpText,
+    },
 };
 use ratatui::{
     layout,
-    text::{self, Span, Spans, Text},
-    widgets::{Paragraph, TableState, Wrap},
+    widgets::{Paragraph, TableState},
 };
 use std::convert::TryFrom;
 
@@ -43,11 +46,6 @@ pub(crate) struct TableListState<T: TableList<N>, const N: usize> {
     pub(crate) table_state: TableState,
 
     last_key_event: Option<input::KeyEvent>,
-}
-
-pub(crate) struct Controls {
-    pub(crate) paragraph: Paragraph<'static>,
-    pub(crate) height: u16,
 }
 
 impl<T: TableList<N>, const N: usize> TableListState<T, N> {
@@ -201,52 +199,70 @@ where
     }
 }
 
-impl Controls {
-    pub(in crate::view) fn for_area(area: &layout::Rect, styles: &view::Styles) -> Self {
-        let text = Text::from(Spans::from(vec![
-            Span::raw("controls: "),
-            bold(styles.if_utf8("\u{2190}\u{2192}", "left, right")),
-            Span::raw(" or "),
-            bold("h, l"),
-            text::Span::raw(" = select column (sort), "),
-            bold(styles.if_utf8("\u{2191}\u{2193}", "up, down")),
-            Span::raw(" or "),
-            bold("k, j"),
-            text::Span::raw(" = scroll, "),
-            bold(styles.if_utf8("\u{21B5}", "enter")),
-            text::Span::raw(" = view details, "),
-            bold("i"),
-            text::Span::raw(" = invert sort (highest/lowest), "),
-            bold("q"),
-            text::Span::raw(" = quit "),
-            bold("gg"),
-            text::Span::raw(" = scroll to top, "),
-            bold("G"),
-            text::Span::raw(" = scroll to bottom"),
-        ]));
-
-        // how many lines do we need to display the controls?
-        let mut height = 1;
-
-        // if the area is narrower than the width of the controls text, we need
-        // to wrap the text across multiple lines.
-        let width = text.width() as u16;
-        if area.width < width {
-            height = width / area.width;
-
-            // if the text's width is not neatly divisible by the area's width
-            // (and it almost never will be), round up for the remaining text.
-            if width % area.width > 0 {
-                height += 1
-            };
-        }
-
-        Self {
-            // TODO(eliza): it would be nice if we could wrap this on commas,
-            // specifically, rather than whitespace...but that seems like a
-            // bunch of additional work...
-            paragraph: Paragraph::new(text).wrap(Wrap { trim: true }),
-            height,
-        }
+impl<T, const N: usize> HelpText for TableListState<T, N>
+where
+    T: TableList<N>,
+{
+    fn render_help_content(&self, styles: &view::Styles) -> Paragraph<'static> {
+        controls_paragraph(view_controls(), styles)
     }
+}
+
+pub(crate) const fn view_controls() -> &'static [ControlDisplay] {
+    &[
+        ControlDisplay {
+            action: "select column (sort)",
+            keys: &[
+                KeyDisplay {
+                    base: "left, right",
+                    utf8: Some("\u{2190}\u{2192}"),
+                },
+                KeyDisplay {
+                    base: "h, l",
+                    utf8: None,
+                },
+            ],
+        },
+        ControlDisplay {
+            action: "scroll",
+            keys: &[
+                KeyDisplay {
+                    base: "up, down",
+                    utf8: Some("\u{2191}\u{2193}"),
+                },
+                KeyDisplay {
+                    base: "k, j",
+                    utf8: None,
+                },
+            ],
+        },
+        ControlDisplay {
+            action: "view details",
+            keys: &[KeyDisplay {
+                base: "enter",
+                utf8: Some("\u{21B5}"),
+            }],
+        },
+        ControlDisplay {
+            action: "invert sort (highest/lowest)",
+            keys: &[KeyDisplay {
+                base: "i",
+                utf8: None,
+            }],
+        },
+        ControlDisplay {
+            action: "scroll to top",
+            keys: &[KeyDisplay {
+                base: "gg",
+                utf8: None,
+            }],
+        },
+        ControlDisplay {
+            action: "scroll to bottom",
+            keys: &[KeyDisplay {
+                base: "G",
+                utf8: None,
+            }],
+        },
+    ]
 }

--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -2,12 +2,17 @@ use crate::{
     input,
     state::{tasks::Task, DetailsRef},
     util::Percentage,
-    view::{self, bold, durations::Durations},
+    view::{
+        self, bold,
+        controls::{controls_paragraph, ControlDisplay, Controls, KeyDisplay},
+        durations::Durations,
+        help::HelpText,
+    },
 };
 use ratatui::{
     layout::{self, Layout},
     text::{Span, Spans, Text},
-    widgets::{Block, List, ListItem, Paragraph},
+    widgets::{List, ListItem, Paragraph},
 };
 use std::{
     cell::RefCell,
@@ -49,6 +54,8 @@ impl TaskView {
             .as_ref()
             .filter(|details| details.span_id() == task.span_id());
 
+        let controls = Controls::new(view_controls(), &area, styles);
+
         let warnings: Vec<_> = task
             .warnings()
             .iter()
@@ -74,7 +81,7 @@ impl TaskView {
                 .constraints(
                     [
                         // controls
-                        layout::Constraint::Length(1),
+                        layout::Constraint::Length(controls.height()),
                         // task stats
                         layout::Constraint::Length(10),
                         // poll duration
@@ -94,7 +101,7 @@ impl TaskView {
                 .constraints(
                     [
                         // controls
-                        layout::Constraint::Length(1),
+                        layout::Constraint::Length(controls.height()),
                         // warnings (add 2 for top and bottom borders)
                         layout::Constraint::Length(warnings.len() as u16 + 2),
                         // task stats
@@ -130,14 +137,6 @@ impl TaskView {
                 .as_ref(),
             )
             .split(stats_area);
-
-        let controls = Spans::from(vec![
-            Span::raw("controls: "),
-            bold(styles.if_utf8("\u{238B} esc", "esc")),
-            Span::raw(" = return to task list, "),
-            bold("q"),
-            Span::raw(" = quit"),
-        ]);
 
         // Just preallocate capacity for ID, name, target, total, busy, and idle.
         let mut overview = Vec::with_capacity(8);
@@ -246,11 +245,27 @@ impl TaskView {
 
         let fields_widget = Paragraph::new(fields).block(styles.border_block().title("Fields"));
 
-        frame.render_widget(Block::default().title(controls), controls_area);
+        frame.render_widget(controls.into_widget(), controls_area);
         frame.render_widget(task_widget, stats_area[0]);
         frame.render_widget(wakers_widget, stats_area[1]);
         frame.render_widget(poll_durations_widget, poll_dur_area);
         frame.render_widget(scheduled_durations_widget, scheduled_dur_area);
         frame.render_widget(fields_widget, fields_area);
     }
+}
+
+impl HelpText for TaskView {
+    fn render_help_content(&self, styles: &view::Styles) -> Paragraph<'static> {
+        controls_paragraph(view_controls(), styles)
+    }
+}
+
+const fn view_controls() -> &'static [ControlDisplay] {
+    &[ControlDisplay {
+        action: "return to task list",
+        keys: &[KeyDisplay {
+            base: "esc",
+            utf8: Some("\u{238B} esc"),
+        }],
+    }]
 }

--- a/tokio-console/src/view/tasks.rs
+++ b/tokio-console/src/view/tasks.rs
@@ -5,7 +5,8 @@ use crate::{
     },
     view::{
         self, bold,
-        table::{self, TableList, TableListState},
+        controls::Controls,
+        table::{view_controls, TableList, TableListState},
         DUR_LEN, DUR_TABLE_PRECISION,
     },
 };
@@ -212,13 +213,13 @@ impl TableList<12> for TasksTable {
             .direction(layout::Direction::Vertical)
             .margin(0);
 
-        let controls = table::Controls::for_area(&area, styles);
+        let controls = Controls::new(view_controls(), &area, styles);
 
         let (controls_area, tasks_area, warnings_area) = if warnings.is_empty() {
             let chunks = layout
                 .constraints(
                     [
-                        layout::Constraint::Length(controls.height),
+                        layout::Constraint::Length(controls.height()),
                         layout::Constraint::Max(area.height),
                     ]
                     .as_ref(),
@@ -230,7 +231,7 @@ impl TableList<12> for TasksTable {
             let chunks = layout
                 .constraints(
                     [
-                        layout::Constraint::Length(controls.height),
+                        layout::Constraint::Length(controls.height()),
                         layout::Constraint::Length(warnings_height),
                         layout::Constraint::Max(area.height),
                     ]
@@ -269,7 +270,7 @@ impl TableList<12> for TasksTable {
             .highlight_style(Style::default().add_modifier(style::Modifier::BOLD));
 
         frame.render_stateful_widget(table, tasks_area, &mut table_list_state.table_state);
-        frame.render_widget(controls.paragraph, controls_area);
+        frame.render_widget(controls.into_widget(), controls_area);
 
         if let Some(area) = warnings_area {
             let block = styles


### PR DESCRIPTION
Adds a help modal which is available on every view. The help help modal
can be accessed by pressing `?` and overlays the current view. To leave
the help modal, the user can press `?` or `Esc`.

This PR is based on #243 originally authored by @bIgBV. The previous PR
has been dormant for around a year.

Currently the help modal only displays a vertical list of controls. This
is the same information that is available in the controls widget on each
view.

Here is an example of the tasks view with the help view modal active:

```text
connection: http://localhost:6669/ (CONNECTED)
views: t = tasks, r = resources
controls: select column (sort) = ←→ or h, l, scroll = ↑↓ or k, j,
view details = ↵, invert sort (highest/lowest) = i, scroll to top = gg,
scroll to bottom╭Help──────────────────────────────────────────╮t = q
╭Warnings───────│controls:                                     │───────────────╮
│⚠ 1 tasks have │  select column (sort) = ←→ or h, l           │               │
╰───────────────│  scroll = ↑↓ or k, j                         │───────────────╯
╭Tasks (12) ▶ Ru│  view details = ↵                            │───────────────╮
│Warn  ID  State│  invert sort (highest/lowest) = i            │t      Location│
│       19 ▶    │  scroll to top = gg                          │::task console-│
│       22 ⏸    │  scroll to bottom = G                        │::task console-│
│⚠ 1    23 ⏸    │  toggle pause = space                        │::task console-│
│       24 ⏸    │  toggle help = ?                             │::task console-│
│       25 ⏸    │  quit = q                                    │::task console-│
│       74 ⏹    │                                              │::task console-│
│       75 ⏸    │                                              │::task console-│
│       77 ⏸    │                                              │::task console-│
│       78 ⏸    ╰──────────────────────────────────────────────╯::task console-│
│       79 ⏹      wait      11s    4ms   56µs    11s 2     tokio::task console-│
╰──────────────────────────────────────────────────────────────────────────────╯
```

However, the idea is that the help modal can provide contextual
information depending on the view and the state of the application being
observed. This will allow us to provide more details about any lints
which are currently triggering and also to reduce the height of the
current controls widget to just one line (perhaps optionally) as the
full list of controls can be accessed from the help view.

Co-authored-by: bIgBV <bhargav.voleti93@gmail.com>