### PR TITLE
fix(subscriber): fix self wakes count

### DIFF
--- a/console-subscriber/src/stats.rs
+++ b/console-subscriber/src/stats.rs
@@ -217,7 +217,7 @@ impl TaskStats {
 
         self.wakes.fetch_add(1, Release);
         if self_wake {
-            self.wakes.fetch_add(1, Release);
+            self.self_wakes.fetch_add(1, Release);
         }
 
         self.make_dirty();


### PR DESCRIPTION
Self-wakes were not being detected and displayed in the console. The
`burn` task in the `app` example - which deliberately has many
self-wakes - was not registering any.

It appears that a logic error was present in the self-wake counting in
`console-subscriber` since it was added in #238. When a self wake was
detected, the `wakes` count was incremented a second time (the `wakes`
count is incremented for all wakes before checking for a self wake),
instead of increamenting the `self_wakes` count.

This PR fixes the logic so that when a self wake is detected, the
`self_wakes` count is incremented.

Fixes: #423