### PR TITLE
console_subscriber: remove clock skew warning in start_poll

### DIFF
--- a/console-subscriber/src/stats.rs
+++ b/console-subscriber/src/stats.rs
@@ -518,17 +518,8 @@ impl<H: RecordDuration> PollStats<H> {
             None => return, // Async operations record polls, but not wakes
         };
 
-        let elapsed = match at.checked_duration_since(scheduled) {
-            Some(elapsed) => elapsed,
-            None => {
-                eprintln!(
-                    "possible Instant clock skew detected: a poll's start timestamp \
-                    was before the wake time/last poll end timestamp\nwake = {:?}\n  start = {:?}",
-                    scheduled, at
-                );
-                return;
-            }
-        };
+        // `at < scheduled` is possible when a task switches threads between polls.
+        let elapsed = at.saturating_duration_since(scheduled);
 
         // if we have a scheduled time histogram, add the timestamp
         timestamps.scheduled_histogram.record_duration(elapsed);


### PR DESCRIPTION
Remove "possible Instant clock skew" message in start_poll. This warning could occur when a task switches threads between 2 polls. Replaced the code to use saturating_duration_since, which clamps the elapsed time to 0, if the starting poll time is less than the scheduled time.

Fixes #433