### PR TITLE
chore: update Swatinem/rust-cache action in GHA workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Run cargo check
         run: cargo check
 
@@ -66,7 +66,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
@@ -94,7 +94,7 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check


### PR DESCRIPTION
_(This pull request is follow-up on #436 which tackled a similar issue for other actions.)_

Using the outdated v1 of [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) will generate warnings in CI runs, for example in https://github.com/tokio-rs/console/actions/runs/5230280408:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: Swatinem/rust-cache@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `Swatinem/rust-cache`, because v2 uses Node.js 16.