### PR TITLE
fix(subscriber): do not report excessive polling (#378)

### DIFF
--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -816,9 +816,6 @@ where
 
         if let Some(span) = cx.span(id) {
             if let Some(now) = update(&span, None) {
-                if let Some(parent) = span.parent() {
-                    update(&parent, Some(now));
-                }
                 self.current_spans
                     .get_or_default()
                     .borrow_mut()
@@ -860,9 +857,6 @@ where
 
         if let Some(span) = cx.span(id) {
             if let Some(now) = update(&span, None) {
-                if let Some(parent) = span.parent() {
-                    update(&parent, Some(now));
-                }
                 self.current_spans.get_or_default().borrow_mut().pop(id);
 
                 self.record(|| record::Event::Exit {

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -798,10 +798,10 @@ where
                 stats.start_poll(now);
             } else if let Some(stats) = exts.get::<Arc<stats::AsyncOpStats>>() {
                 stats.start_poll(now);
-            // otherwise, is the span a resource? in that case, we also want
-            // to enter it, although we don't care about recording poll
-            // stats.
             } else if exts.get::<Arc<stats::ResourceStats>>().is_some() {
+                // otherwise, is the span a resource? in that case, we also want
+                // to enter it, although we don't care about recording poll
+                // stats.
             } else {
                 return;
             };
@@ -828,10 +828,10 @@ where
                 stats.end_poll(now);
             } else if let Some(stats) = exts.get::<Arc<stats::AsyncOpStats>>() {
                 stats.end_poll(now);
-            // otherwise, is the span a resource? in that case, we also want
-            // to enter it, although we don't care about recording poll
-            // stats.
             } else if exts.get::<Arc<stats::ResourceStats>>().is_some() {
+                // otherwise, is the span a resource? in that case, we also want
+                // to enter it, although we don't care about recording poll
+                // stats.
             } else {
                 return;
             };


### PR DESCRIPTION
When entering and exiting a span the old code was also updating the parent
stats. This was causing excessive polling being reported for the parent tasks.
See issue #378 for more details. The regression was introduced by the refactor
in #238.
This fixes the issue by limiting updates to the current span.

Closes #378
