### PR TITLE
fix(console): make long locations readable

### DIFF
--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -522,7 +522,7 @@ fn format_location(loc: Option<proto::Location>) -> String {
             let truncated = truncate_registry_path(file);
             l.file = Some(truncated);
         }
-        format!("{} ", l)
+        format!("{}", l)
     })
     .unwrap_or_else(|| "<unknown location>".to_string())
 }

--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -155,10 +155,17 @@ impl TaskView {
             Span::raw(task.target()),
         ]));
 
-        overview.push(Spans::from(vec![
-            bold("Location: "),
-            Span::raw(task.location()),
-        ]));
+        let title = "Location: ";
+        let location_max_width = stats_area[0].width as usize - 2 - title.len(); // NOTE: -2 for the border
+        let location = if task.location().len() > location_max_width {
+            let ellipsis = styles.if_utf8("\u{2026}", "...");
+            let start = task.location().len() - location_max_width + ellipsis.chars().count();
+            format!("{}{}", ellipsis, &task.location()[start..])
+        } else {
+            task.location().to_string()
+        };
+
+        overview.push(Spans::from(vec![bold(title), Span::raw(location)]));
 
         let total = task.total(now);
 


### PR DESCRIPTION
This closes #411.

This is how it looks like.

<img width="514" alt="Screenshot 2023-07-03 at 12 22 24 PM" src="https://github.com/tokio-rs/console/assets/41150432/878a43e6-1512-49c0-85fd-0e245cc6ee04">
