### PR TITLE
fix(console): remove trailing space from task/resource location

### DIFF
--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -522,7 +522,7 @@ fn format_location(loc: Option<proto::Location>) -> String {
             let truncated = truncate_registry_path(file);
             l.file = Some(truncated);
         }
-        format!("{} ", l)
+        format!("{}", l)
     })
     .unwrap_or_else(|| "<unknown location>".to_string())
 }

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -522,7 +522,7 @@ fn format_location(loc: Option<proto::Location>) -> String {
             let truncated = truncate_registry_path(file);
             l.file = Some(truncated);
         }
-        format!("{}", l)
+        l.to_string()
     })
     .unwrap_or_else(|| "<unknown location>".to_string())
 }


### PR DESCRIPTION
When a file location is formatted, an extra space is added at the end.
This appears to be the result of some refactoring from a case where we
needed the extra space at the end.

Currently, the extra space results in there being 2 spaces between the
Location column and the Fields column in the tasks list view, and the
same between the Location column and the Attributes column in the
resources list view.

It is also causing issues when attempting to truncate the first part of
the location in #441 (during which this extra space was discovered).