### PR TITLE
chore: remove branch config from release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,6 @@ jobs:
           prefix: "(console-subscriber)|(console-api)|(tokio-console)"
           changelog: "$prefix/CHANGELOG.md"
           title: "$prefix $version"
-          branch: main
           draft: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This appears to be breaking it.