### PR TITLE
Add `console_without_tokio_unstable` to make `tokio_unstable` assertion optional

### DIFF
--- a/console-subscriber/README.md
+++ b/console-subscriber/README.md
@@ -206,6 +206,13 @@ tracing_subscriber::registry()
 [`tokio-console`]: https://github.com/tokio-rs/console
 [Tokio]: https://tokio.rs
 
+### Using other runtimes
+
+If you are using a custom runtime that supports tokio-console, you may not need
+to enable "tokio_unstable". In this case, you need to enable cfg
+`console_without_tokio_unstable` for console-subscriber to disable its check for
+`tokio_unstable`.
+
 ### Crate Feature Flags
 
 This crate provides the following feature flags and optional dependencies:

--- a/console-subscriber/README.md
+++ b/console-subscriber/README.md
@@ -209,7 +209,7 @@ tracing_subscriber::registry()
 ### Using other runtimes
 
 If you are using a custom runtime that supports tokio-console, you may not need
-to enable "tokio_unstable". In this case, you need to enable cfg
+to enable the `tokio_unstable` cfg flag. In this case, you need to enable cfg
 `console_without_tokio_unstable` for console-subscriber to disable its check for
 `tokio_unstable`.
 

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -267,7 +267,7 @@ impl ConsoleLayer {
         // depending on the build-time configuration...
         #![allow(clippy::assertions_on_constants)]
         assert!(
-            cfg!(tokio_unstable),
+            cfg!(any(tokio_unstable, console_without_tokio_unstable)),
             "task tracing requires Tokio to be built with RUSTFLAGS=\"--cfg tokio_unstable\"!"
         );
 


### PR DESCRIPTION
We add the same trace span in the runtime of our company project as tokio to support tokio-console, but we don't enable the `tokio_unstable` cfg. Removing this assertion allows us to stop using a forked console-subscriber.