### PR TITLE
feat(console): Add way to inspect details of task from resource view

### DIFF
--- a/tokio-console/src/view/mod.rs
+++ b/tokio-console/src/view/mod.rs
@@ -167,6 +167,31 @@ impl View {
                         self.state = ResourcesList;
                         update_kind = UpdateKind::Other;
                     }
+                    key!(Enter) => {
+                        if let Some(op) = view.async_ops_table.selected_item().upgrade() {
+                            if let Some(task_id) = op.borrow().task_id() {
+                                let task: u64 = task_id.to_string().parse().unwrap();
+                                let item = self
+                                    .tasks_list
+                                    .sorted_items
+                                    .iter()
+                                    .filter_map(|i| i.upgrade())
+                                    .find(|t| {
+                                        let task_id: u64 =
+                                            t.borrow().id().to_string().parse().unwrap();
+                                        task_id == task
+                                    });
+
+                                if let Some(t) = item {
+                                    update_kind = UpdateKind::SelectTask(t.borrow().span_id());
+                                    self.state = TaskInstance(self::task::TaskView::new(
+                                        t,
+                                        state.task_details_ref(),
+                                    ));
+                                }
+                            }
+                        }
+                    }
                     _ => {
                         // otherwise pass on to view
                         view.update_input(event);

--- a/tokio-console/src/view/mod.rs
+++ b/tokio-console/src/view/mod.rs
@@ -170,22 +170,17 @@ impl View {
                     key!(Enter) => {
                         if let Some(op) = view.async_ops_table.selected_item().upgrade() {
                             if let Some(task_id) = op.borrow().task_id() {
-                                let task: u64 = task_id.to_string().parse().unwrap();
-                                let item = self
+                                let task = self
                                     .tasks_list
                                     .sorted_items
                                     .iter()
                                     .filter_map(|i| i.upgrade())
-                                    .find(|t| {
-                                        let task_id: u64 =
-                                            t.borrow().id().to_string().parse().unwrap();
-                                        task_id == task
-                                    });
+                                    .find(|t| task_id == t.borrow().id());
 
-                                if let Some(t) = item {
-                                    update_kind = UpdateKind::SelectTask(t.borrow().span_id());
+                                if let Some(task) = task {
+                                    update_kind = UpdateKind::SelectTask(task.borrow().span_id());
                                     self.state = TaskInstance(self::task::TaskView::new(
-                                        t,
+                                        task,
                                         state.task_details_ref(),
                                     ));
                                 }

--- a/tokio-console/src/view/resource.rs
+++ b/tokio-console/src/view/resource.rs
@@ -21,7 +21,7 @@ use std::{cell::RefCell, rc::Rc};
 
 pub(crate) struct ResourceView {
     resource: Rc<RefCell<Resource>>,
-    async_ops_table: TableListState<AsyncOpsTable, 9>,
+    pub async_ops_table: TableListState<AsyncOpsTable, 9>,
     initial_render: bool,
 }
 

--- a/tokio-console/src/view/resource.rs
+++ b/tokio-console/src/view/resource.rs
@@ -21,7 +21,7 @@ use std::{cell::RefCell, rc::Rc};
 
 pub(crate) struct ResourceView {
     resource: Rc<RefCell<Resource>>,
-    pub async_ops_table: TableListState<AsyncOpsTable, 9>,
+    pub(crate) async_ops_table: TableListState<AsyncOpsTable, 9>,
     initial_render: bool,
 }
 


### PR DESCRIPTION
Now it is possible while navigate in `async_ops_table` to go directly to
details of the task that you are pointing on the list.

This closes #448
