### PR TITLE
Add an explicit dependency to futures-core to console-api to fix broken builds

### DIFF
--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -37,6 +37,7 @@ tonic = { version = "0.9", default-features = false, features = [
 prost = "0.11"
 prost-types = "0.11"
 tracing-core = "0.1.17"
+futures-core = "0.3"
 
 [dev-dependencies]
 tonic-build = { version = "0.9", default-features = false, features = [


### PR DESCRIPTION
This PR adds an explicit dependency to futures-core for `console-api` to fix broken builds. Without this fix I get the following errors:

```
error[E0433]: failed to resolve: use of undeclared crate or module `futures_core`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-6f17d22bba15001f/console-api-0.5.0/src/generated/rs.tokio.console.instrument.rs:275:34
    |
275 |         type WatchUpdatesStream: futures_core::Stream<
    |                                  ^^^^^^^^^^^^ use of undeclared crate or module `futures_core`

error[E0433]: failed to resolve: use of undeclared crate or module `futures_core`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-6f17d22bba15001f/console-api-0.5.0/src/generated/rs.tokio.console.instrument.rs:289:38
    |
289 |         type WatchTaskDetailsStream: futures_core::Stream<
    |                                      ^^^^^^^^^^^^ use of undeclared crate or module `futures_core`

error[E0433]: failed to resolve: use of undeclared crate or module `futures_core`
   --> /home/weiznich/.cargo/registry/src/index.crates.io-6f17d22bba15001f/console-api-0.5.0/src/generated/rs.tokio.console.trace.rs:212:27
    |
212 |         type WatchStream: futures_core::Stream<
    |                           ^^^^^^^^^^^^ use of undeclared crate or module `futures_core`

```

The somewhat funny thing is that only happened after I've updated some unrelated dependencies. It worked before, but after looking at the relevant code I'm really surprised that it ever compiled without error. 