### PR TITLE
chore: updates for Rust 1.72.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
 name = "console-api"
 version = "0.5.0"
 dependencies = [
+ "futures-core",
  "prost",
  "prost-build",
  "prost-types",

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -93,7 +93,7 @@ impl State {
         mut self,
         linters: impl IntoIterator<Item = Linter<Task>>,
     ) -> Self {
-        self.tasks_state.linters.extend(linters.into_iter());
+        self.tasks_state.linters.extend(linters);
         self
     }
 
@@ -505,7 +505,7 @@ fn truncate_registry_path(s: String) -> String {
 
     static REGEX: OnceCell<Regex> = OnceCell::new();
     let regex = REGEX.get_or_init(|| {
-        Regex::new(r#".*/\.cargo(/registry/src/[^/]*/|/git/checkouts/)"#)
+        Regex::new(r".*/\.cargo(/registry/src/[^/]*/|/git/checkouts/)")
             .expect("failed to compile regex")
     });
 

--- a/tokio-console/src/state/store.rs
+++ b/tokio-console/src/state/store.rs
@@ -191,10 +191,7 @@ impl<T> fmt::Debug for Ids<T> {
 impl<T> Clone for Id<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self {
-            id: self.id,
-            _ty: PhantomData,
-        }
+        *self
     }
 }
 


### PR DESCRIPTION
Clippy was complaining about 3 new things in 1.72.0. Two new lints and
one updated one.

When `futures-core` was added as an explicit dependency on `console-api`
in #453, it was only added to the `console-api` Cargo.toml file. It
wasn't added to the Cargo.lock file shared by the workspace.

Since Rust 1.72.0, Cargo is adding this dependency to Cargo.lock
locally, so it makes sense to check in that change.