### PR TITLE
Remove futures dependency from console-subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
  "futures",
+ "futures-task",
  "hdrhistogram",
  "humantime",
  "parking_lot",

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -40,7 +40,7 @@ tonic = { version = "0.9", features = ["transport"] }
 tracing-core = "0.1.24"
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["fmt", "registry"] }
-futures = { version = "0.3", default-features = false }
+futures-task = { version = "0.3", default-features = false }
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
 # The parking_lot dependency is renamed, because we want our `parking_lot`
 # feature to also enable `tracing-subscriber`'s parking_lot feature flag.


### PR DESCRIPTION
I noticed that `console-subscriber` was my only dependency pulling in the `futures` top-level library so I decided to try my hand at removing that dependency. This still relies on `futures-task` for an optimized `NoopWaker`