### PR TITLE
fix(console): ignore key release events

### DIFF
--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -3,7 +3,7 @@ use console_api::tasks::TaskDetails;
 use state::State;
 
 use futures::{
-    future::ready,
+    future,
     stream::{StreamExt, TryStreamExt},
 };
 use ratatui::{
@@ -14,7 +14,10 @@ use ratatui::{
 };
 use tokio::sync::{mpsc, watch};
 
-use crate::view::{bold, UpdateKind};
+use crate::{
+    input::{Event, KeyEvent, KeyEventKind},
+    view::{bold, UpdateKind},
+};
 
 mod config;
 mod conn;
@@ -72,10 +75,10 @@ async fn main() -> color_eyre::Result<()> {
         ])
         .with_retain_for(retain_for);
     let mut input = Box::pin(input::EventStream::new().try_filter(|event| {
-        ready(!matches!(
+        future::ready(!matches!(
             event,
-            input::Event::Key(input::KeyEvent {
-                kind: input::KeyEventKind::Release,
+            Event::Key(KeyEvent {
+                kind: KeyEventKind::Release,
                 ..
             })
         ))


### PR DESCRIPTION
On supported platforms, a short key press generates two crossterm events: One for the initial press and another when the key is released again. The code was not checking the event kind, so it would treat a key release as a second key press. Filter out key releases entirely since they're not explicitly used for anything.