### PR TITLE
chore(console): update Clap to v4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -209,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,29 +246,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.2",
+ "clap_derive",
 ]
 
 [[package]]
@@ -273,30 +262,18 @@ checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.5.1",
+ "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.1.4"
+version = "4.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
+checksum = "e3ae8ba90b9d8b007efe66e55e48fb936272f5ca00349b5b0e89877520d35ea7"
 dependencies = [
- "clap 3.2.25",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.90",
+ "clap",
 ]
 
 [[package]]
@@ -309,15 +286,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.33",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -433,7 +401,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "futures-core",
  "libc",
@@ -478,6 +446,27 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "eyre"
@@ -831,6 +820,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
+
+[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,12 +963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,30 +1059,6 @@ checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.33",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.90",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -1204,7 +1169,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cassowary",
  "crossterm",
  "unicode-segmentation",
@@ -1217,7 +1182,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1289,6 +1254,19 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustix"
+version = "0.38.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "rustversion"
@@ -1449,19 +1427,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
+name = "terminal_size"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "winapi-util",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -1534,7 +1507,7 @@ name = "tokio-console"
 version = "0.1.10"
 dependencies = [
  "atty",
- "clap 3.2.25",
+ "clap",
  "clap_complete",
  "color-eyre",
  "console-api",
@@ -1840,12 +1813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,15 +1860,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2065,7 +2023,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 name = "xtask"
 version = "0.1.0"
 dependencies = [
- "clap 4.4.6",
+ "clap",
  "color-eyre",
  "tonic-build",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,9 +826,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "lock_api"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,8 +246,8 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
@@ -208,12 +256,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.4.2",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.5.1",
+ "strsim",
+]
+
+[[package]]
 name = "clap_complete"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
 dependencies = [
- "clap",
+ "clap 3.2.25",
 ]
 
 [[package]]
@@ -230,6 +300,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +319,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "color-eyre"
@@ -265,6 +353,12 @@ dependencies = [
  "tracing-core",
  "tracing-error",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console-api"
@@ -1440,7 +1534,7 @@ name = "tokio-console"
 version = "0.1.10"
 dependencies = [
  "atty",
- "clap",
+ "clap 3.2.25",
  "clap_complete",
  "color-eyre",
  "console-api",
@@ -1734,6 +1828,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +1936,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +1976,12 @@ name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1860,6 +1996,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +2012,12 @@ name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1884,6 +2032,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,10 +2056,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
- "clap",
+ "clap 4.4.6",
  "color-eyre",
  "tonic-build",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,54 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,7 +71,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -246,41 +198,44 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "4.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "906f7fe1da4185b7a282b2bc90172a496f9def1aca4545fe7526810741591e14"
 dependencies = [
  "clap_builder",
  "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "351f9ad9688141ed83dfd8f5fb998a06225ef444b48ff4dc43de6d409b7fd10b"
 dependencies = [
- "anstream",
- "anstyle",
+ "bitflags 1.3.2",
  "clap_lex",
+ "is-terminal",
+ "once_cell",
  "strsim",
+ "termcolor",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.4.3"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ae8ba90b9d8b007efe66e55e48fb936272f5ca00349b5b0e89877520d35ea7"
+checksum = "40d3120a421cd111c43f1a6c7d0dd83bb6aaa0659c164468a1654014632a5ec6"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "81d7dc0031c3a59a04fc2ba395c8e2dd463cba1859275f065d225f6122221b45"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -290,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "color-eyre"
@@ -321,12 +276,6 @@ dependencies = [
  "tracing-core",
  "tracing-error",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console-api"
@@ -681,6 +630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +748,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "rustix 0.38.15",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +795,12 @@ name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -943,7 +926,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1257,6 +1240,20 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
+version = "0.37.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4279d76516df406a8bd37e7dff53fd37d1a093f997a3c34a5c21658c126db06d"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
@@ -1264,7 +1261,7 @@ dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.8",
  "windows-sys 0.48.0",
 ]
 
@@ -1427,12 +1424,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.3.0"
+name = "termcolor"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
- "rustix",
+ "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.24",
  "windows-sys 0.48.0",
 ]
 
@@ -1801,12 +1807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,6 +1860,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -30,8 +30,8 @@ keywords = [
 atty = "0.2"
 console-api = { version = "0.6.0", path = "../console-api", features = ["transport"] }
 # Use 1.64.0 compatible version of `clap@4.1.14`.
-clap = { version = "=4.1.14", features = ["wrap_help", "cargo", "derive", "env"] }
-clap_complete = "=4.1.6"
+clap = { version = "~4.1.14", features = ["wrap_help", "cargo", "derive", "env"] }
+clap_complete = "~4.1.6"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.10", features = ["transport"] }
 futures = "0.3"

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -29,7 +29,8 @@ keywords = [
 [dependencies]
 atty = "0.2"
 console-api = { version = "0.6.0", path = "../console-api", features = ["transport"] }
-clap = { version = "4.1.14", features = [
+# Use 1.64.0 compatible version of `clap@4.1.14`.
+clap = { version = "=4.1.14", features = [
     # these are all enabled by default
     "std", "color", "help", "usage", "error-context", "suggestions",
     # auto-wrap help text to fit the terminal width
@@ -41,7 +42,7 @@ clap = { version = "4.1.14", features = [
     # parse values from env vars
     "env"
 ] }
-clap_complete = "4.1.6"
+clap_complete = "=4.1.6"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.10", features = ["transport"] }
 futures = "0.3"

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -29,7 +29,7 @@ keywords = [
 [dependencies]
 atty = "0.2"
 console-api = { version = "0.6.0", path = "../console-api", features = ["transport"] }
-clap = { version = "4", features = [
+clap = { version = "4.1.14", features = [
     # these are all enabled by default
     "std", "color", "help", "usage", "error-context", "suggestions",
     # auto-wrap help text to fit the terminal width
@@ -41,7 +41,7 @@ clap = { version = "4", features = [
     # parse values from env vars
     "env"
 ] }
-clap_complete = "4"
+clap_complete = "4.1.6"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.10", features = ["transport"] }
 futures = "0.3"

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -30,6 +30,7 @@ keywords = [
 atty = "0.2"
 console-api = { version = "0.6.0", path = "../console-api", features = ["transport"] }
 clap = { version = "3", features = ["cargo", "derive", "env"] }
+clap_complete = "3"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.10", features = ["transport"] }
 futures = "0.3"
@@ -49,4 +50,3 @@ humantime = "2.1.0"
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 dirs = "4"
-clap_complete = "3"

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -30,18 +30,7 @@ keywords = [
 atty = "0.2"
 console-api = { version = "0.6.0", path = "../console-api", features = ["transport"] }
 # Use 1.64.0 compatible version of `clap@4.1.14`.
-clap = { version = "=4.1.14", features = [
-    # these are all enabled by default
-    "std", "color", "help", "usage", "error-context", "suggestions",
-    # auto-wrap help text to fit the terminal width
-    "wrap_help",
-    # use Cargo env vars when determining help text
-    "cargo",
-    # enable derive attributes
-    "derive",
-    # parse values from env vars
-    "env"
-] }
+clap = { version = "=4.1.14", features = ["wrap_help", "cargo", "derive", "env"] }
 clap_complete = "=4.1.6"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.10", features = ["transport"] }
@@ -49,7 +38,7 @@ futures = "0.3"
 ratatui = { version = "0.20.1", default-features = false, features = ["crossterm"] }
 tower = "0.4.12"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3.0" }
+tracing-subscriber = { version = "0.3" }
 tracing-journald = { version = "0.2", optional = true }
 prost-types = "0.12"
 crossterm = { version = "0.26.1", features = ["event-stream"] }

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -29,15 +29,26 @@ keywords = [
 [dependencies]
 atty = "0.2"
 console-api = { version = "0.6.0", path = "../console-api", features = ["transport"] }
-clap = { version = "3", features = ["cargo", "derive", "env"] }
-clap_complete = "3"
+clap = { version = "4", features = [
+    # these are all enabled by default
+    "std", "color", "help", "usage", "error-context", "suggestions",
+    # auto-wrap help text to fit the terminal width
+    "wrap_help",
+    # use Cargo env vars when determining help text
+    "cargo",
+    # enable derive attributes
+    "derive",
+    # parse values from env vars
+    "env"
+] }
+clap_complete = "4"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.10", features = ["transport"] }
 futures = "0.3"
 ratatui = { version = "0.20.1", default-features = false, features = ["crossterm"] }
 tower = "0.4.12"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.0" }
 tracing-journald = { version = "0.2", optional = true }
 prost-types = "0.12"
 crossterm = { version = "0.26.1", features = ["event-stream"] }

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -40,9 +40,6 @@ Options:
           
           [default: /tmp/tokio-console/logs]
 
-      --no-colors
-          Disable ANSI colors entirely
-
       --lang <LANG>
           Overrides the terminal's default language
           
@@ -52,6 +49,9 @@ Options:
           Explicitly use only ASCII characters
           
           [possible values: true, false]
+
+      --no-colors
+          Disable ANSI colors entirely
 
       --colorterm <truecolor>
           Overrides the value of the `COLORTERM` environment variable.

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -1,107 +1,106 @@
-USAGE:
-    tokio-console [OPTIONS] [TARGET_ADDR] [SUBCOMMAND]
+Commands:
+  gen-config      Generate a `console.toml` config file with the default configuration values, overridden by any
+                      provided command-line arguments
+  gen-completion  Generate shell completions
+  help            Print this message or the help of the given subcommand(s)
 
-ARGS:
-    <TARGET_ADDR>
-            The address of a console-enabled process to connect to.
-            
-            This may be an IP address and port, or a DNS name.
-            
-            On Unix platforms, this may also be a URI with the `file` scheme that specifies the path
-            to a Unix domain socket, as in `file://localhost/path/to/socket`.
-            
-            [default: http://127.0.0.1:6669]
+Arguments:
+  [TARGET_ADDR]
+          The address of a console-enabled process to connect to.
+          
+          This may be an IP address and port, or a DNS name.
+          
+          On Unix platforms, this may also be a URI with the `file` scheme that specifies the path to a Unix domain
+          socket, as in `file://localhost/path/to/socket`.
+          
+          [default: http://127.0.0.1:6669]
 
-OPTIONS:
-        --ascii-only <ASCII_ONLY>
-            Explicitly use only ASCII characters
+Options:
+      --log <LOG_FILTER>
+          Log level filter for the console's internal diagnostics.
+          
+          Logs are written to a new file at the path given by the `--log-dir` argument (or its default value), or to the
+          system journal if `systemd-journald` support is enabled.
+          
+          If this is set to 'off' or is not set, no logs will be written.
+          
+          [default: off]
+          
+          [env: RUST_LOG=]
 
-        --colorterm <truecolor>
-            Overrides the value of the `COLORTERM` environment variable.
-            
-            If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
-            
-            [env: COLORTERM=truecolor]
-            [possible values: 24bit, truecolor]
+      --log-dir <LOG_DIRECTORY>
+          Path to a directory to write the console's internal logs to.
+          
+          [default: /tmp/tokio-console/logs]
 
-    -h, --help
-            Print help information
+      --no-colors
+          Disable ANSI colors entirely
 
-        --lang <LANG>
-            Overrides the terminal's default language
-            
-            [env: LANG=en_US.UTF-8]
+      --lang <LANG>
+          Overrides the terminal's default language
+          
+          [env: LANG=en_US.UTF-8]
 
-        --log <ENV_FILTER>
-            Log level filter for the console's internal diagnostics.
-            
-            Logs are written to a new file at the path given by the `--log-dir` argument (or its
-            default value), or to the system journal if `systemd-journald` support is enabled.
-            
-            If this is set to 'off' or is not set, no logs will be written.
-            
-            [default: off]
-            
-            [env: RUST_LOG=]
+      --ascii-only <ASCII_ONLY>
+          Explicitly use only ASCII characters
+          
+          [possible values: true, false]
 
-        --log-dir <LOG_DIRECTORY>
-            Path to a directory to write the console's internal logs to.
-            
-            [default: /tmp/tokio-console/logs]
+      --colorterm <truecolor>
+          Overrides the value of the `COLORTERM` environment variable.
+          
+          If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
+          
+          [env: COLORTERM=truecolor]
+          [possible values: 24bit, truecolor]
 
-        --no-colors
-            Disable ANSI colors entirely
+      --palette <PALETTE>
+          Explicitly set which color palette to use
+          
+          [possible values: 8, 16, 256, all, off]
 
-        --no-duration-colors <COLOR_DURATIONS>
-            Disable color-coding for duration units
+      --no-duration-colors <COLOR_DURATIONS>
+          Disable color-coding for duration units
+          
+          [possible values: true, false]
 
-        --no-terminated-colors <COLOR_TERMINATED>
-            Disable color-coding for terminated tasks
+      --no-terminated-colors <COLOR_TERMINATED>
+          Disable color-coding for terminated tasks
+          
+          [possible values: true, false]
 
-        --palette <PALETTE>
-            Explicitly set which color palette to use
-            
-            [possible values: 8, 16, 256, all, off]
+      --retain-for <RETAIN_FOR>
+          How long to continue displaying completed tasks and dropped resources after they have been closed.
+          
+          This accepts either a duration, parsed as a combination of time spans (such as `5days 2min 2s`), or `none` to
+          disable removing completed tasks and dropped resources.
+          
+          Each time span is an integer number followed by a suffix. Supported suffixes are:
+          
+          * `nsec`, `ns` -- nanoseconds
+          
+          * `usec`, `us` -- microseconds
+          
+          * `msec`, `ms` -- milliseconds
+          
+          * `seconds`, `second`, `sec`, `s`
+          
+          * `minutes`, `minute`, `min`, `m`
+          
+          * `hours`, `hour`, `hr`, `h`
+          
+          * `days`, `day`, `d`
+          
+          * `weeks`, `week`, `w`
+          
+          * `months`, `month`, `M` -- defined as 30.44 days
+          
+          * `years`, `year`, `y` -- defined as 365.25 days
+          
+          [default: 6s]
 
-        --retain-for <RETAIN_FOR>
-            How long to continue displaying completed tasks and dropped resources after they have
-            been closed.
-            
-            This accepts either a duration, parsed as a combination of time spans (such as `5days
-            2min 2s`), or `none` to disable removing completed tasks and dropped resources.
-            
-            Each time span is an integer number followed by a suffix. Supported suffixes are:
-            
-            * `nsec`, `ns` -- nanoseconds
-            
-            * `usec`, `us` -- microseconds
-            
-            * `msec`, `ms` -- milliseconds
-            
-            * `seconds`, `second`, `sec`, `s`
-            
-            * `minutes`, `minute`, `min`, `m`
-            
-            * `hours`, `hour`, `hr`, `h`
-            
-            * `days`, `day`, `d`
-            
-            * `weeks`, `week`, `w`
-            
-            * `months`, `month`, `M` -- defined as 30.44 days
-            
-            * `years`, `year`, `y` -- defined as 365.25 days
-            
-            [default: 6s]
+  -h, --help
+          Print help (see a summary with '-h')
 
-    -V, --version
-            Print version information
-
-SUBCOMMANDS:
-    gen-completion
-            Generate shell completions
-    gen-config
-            Generate a `console.toml` config file with the default configuration values, overridden
-            by any provided command-line arguments
-    help
-            Print this message or the help of the given subcommand(s)
+  -V, --version
+          Print version

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -1,8 +1,10 @@
 Commands:
-  gen-config      Generate a `console.toml` config file with the default configuration values, overridden by any
+  gen-config      Generate a `console.toml` config file with the
+                      default configuration values, overridden by any
                       provided command-line arguments
   gen-completion  Generate shell completions
-  help            Print this message or the help of the given subcommand(s)
+  help            Print this message or the help of the given
+                      subcommand(s)
 
 Arguments:
   [TARGET_ADDR]
@@ -10,8 +12,9 @@ Arguments:
           
           This may be an IP address and port, or a DNS name.
           
-          On Unix platforms, this may also be a URI with the `file` scheme that specifies the path to a Unix domain
-          socket, as in `file://localhost/path/to/socket`.
+          On Unix platforms, this may also be a URI with the `file`
+          scheme that specifies the path to a Unix domain socket, as in
+          `file://localhost/path/to/socket`.
           
           [default: http://127.0.0.1:6669]
 
@@ -19,10 +22,12 @@ Options:
       --log <LOG_FILTER>
           Log level filter for the console's internal diagnostics.
           
-          Logs are written to a new file at the path given by the `--log-dir` argument (or its default value), or to the
-          system journal if `systemd-journald` support is enabled.
+          Logs are written to a new file at the path given by the
+          `--log-dir` argument (or its default value), or to the system
+          journal if `systemd-journald` support is enabled.
           
-          If this is set to 'off' or is not set, no logs will be written.
+          If this is set to 'off' or is not set, no logs will be
+          written.
           
           [default: off]
           
@@ -49,7 +54,8 @@ Options:
       --colorterm <truecolor>
           Overrides the value of the `COLORTERM` environment variable.
           
-          If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
+          If this is set to `24bit` or `truecolor`, 24-bit RGB color
+          support will be enabled.
           
           [env: COLORTERM=truecolor]
           [possible values: 24bit, truecolor]
@@ -70,12 +76,15 @@ Options:
           [possible values: true, false]
 
       --retain-for <RETAIN_FOR>
-          How long to continue displaying completed tasks and dropped resources after they have been closed.
+          How long to continue displaying completed tasks and dropped
+          resources after they have been closed.
           
-          This accepts either a duration, parsed as a combination of time spans (such as `5days 2min 2s`), or `none` to
-          disable removing completed tasks and dropped resources.
+          This accepts either a duration, parsed as a combination of
+          time spans (such as `5days 2min 2s`), or `none` to disable
+          removing completed tasks and dropped resources.
           
-          Each time span is an integer number followed by a suffix. Supported suffixes are:
+          Each time span is an integer number followed by a suffix.
+          Supported suffixes are:
           
           * `nsec`, `ns` -- nanoseconds
           

--- a/tokio-console/args.example
+++ b/tokio-console/args.example
@@ -1,10 +1,12 @@
 Commands:
-  gen-config      Generate a `console.toml` config file with the
-                      default configuration values, overridden by any
-                      provided command-line arguments
-  gen-completion  Generate shell completions
-  help            Print this message or the help of the given
-                      subcommand(s)
+  gen-config
+          Generate a `console.toml` config file with the default
+          configuration values, overridden by any provided command-line
+          arguments
+  gen-completion
+          Generate shell completions
+  help
+          Print this message or the help of the given subcommand(s)
 
 Arguments:
   [TARGET_ADDR]

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -154,10 +154,6 @@ impl Serialize for RetainFor {
 #[derive(Clap, Debug, Clone)]
 #[clap(group = ArgGroup::new("colors").conflicts_with("no-colors"))]
 pub struct ViewOptions {
-    /// Disable ANSI colors entirely.
-    #[clap(name = "no-colors", long = "no-colors",action = ArgAction::SetTrue)]
-    no_colors: bool,
-
     /// Overrides the terminal's default language.
     #[clap(long = "lang", env = "LANG")]
     lang: Option<String>,
@@ -165,6 +161,10 @@ pub struct ViewOptions {
     /// Explicitly use only ASCII characters.
     #[clap(long = "ascii-only")]
     ascii_only: Option<bool>,
+
+    /// Disable ANSI colors entirely.
+    #[clap(name = "no-colors", long = "no-colors",action = ArgAction::SetTrue)]
+    no_colors: bool,
 
     /// Overrides the value of the `COLORTERM` environment variable.
     ///

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -719,6 +719,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn verify_cli() {
+        use clap::CommandFactory;
+        Config::command().debug_assert()
+    }
+
+    #[test]
     fn args_example_changed() {
         use clap::CommandFactory;
 

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -776,7 +776,13 @@ mod tests {
 
         let path = PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join("args.example");
 
-        let mut cmd = Config::command();
+        let mut cmd = Config::command()
+            // always use the same terminal width when generating the help text,
+            // so that the text wrapping doesn't change based on the terminal
+            // size that the test was run in.
+            // (72 chars seems to fit reasonably in the default width of
+            // RustDoc's code formatting)
+            .term_width(72);
         let mut helptext = Vec::new();
         // Format the help text to a string.
         cmd.write_long_help(&mut Cursor::new(&mut helptext))

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -1,5 +1,6 @@
 use crate::view::Palette;
-use clap::{ArgGroup, IntoApp, Parser as Clap, Subcommand, ValueHint};
+use clap::builder::{PossibleValuesParser, TypedValueParser};
+use clap::{ArgAction, ArgGroup, CommandFactory, Parser as Clap, Subcommand, ValueHint};
 use clap_complete::Shell;
 use color_eyre::eyre::WrapErr;
 use serde::{Deserialize, Serialize};
@@ -11,6 +12,7 @@ use std::process::Command;
 use std::str::FromStr;
 use std::time::Duration;
 use tonic::transport::Uri;
+use tracing_subscriber::filter;
 
 #[derive(Clap, Debug)]
 #[clap(
@@ -44,7 +46,7 @@ pub struct Config {
     ///
     /// [default: off]
     #[clap(long = "log", env = "RUST_LOG")]
-    pub(crate) env_filter: Option<tracing_subscriber::EnvFilter>,
+    log_filter: Option<LogFilter>,
 
     /// Path to a directory to write the console's internal logs to.
     ///
@@ -117,7 +119,7 @@ pub enum OptionalCmd {
     GenCompletion {
         #[clap(name = "install", long = "install")]
         install: bool,
-        #[clap(arg_enum)]
+        #[clap(value_enum)]
         shell: Shell,
     },
 }
@@ -153,7 +155,7 @@ impl Serialize for RetainFor {
 #[clap(group = ArgGroup::new("colors").conflicts_with("no-colors"))]
 pub struct ViewOptions {
     /// Disable ANSI colors entirely.
-    #[clap(name = "no-colors", long = "no-colors", takes_value = false)]
+    #[clap(name = "no-colors", long = "no-colors",action = ArgAction::SetTrue)]
     no_colors: bool,
 
     /// Overrides the terminal's default language.
@@ -171,15 +173,14 @@ pub struct ViewOptions {
         long = "colorterm",
         name = "truecolor",
         env = "COLORTERM",
-        parse(from_str = parse_true_color),
-        possible_values = &["24bit", "truecolor"],
+        value_parser = true_color_parser(),
     )]
     truecolor: Option<bool>,
 
     /// Explicitly set which color palette to use.
     #[clap(
         long,
-        possible_values = &["8", "16", "256", "all", "off"],
+        value_parser = palette_parser(),
         group = "colors",
         conflicts_with_all = &["no-colors", "truecolor"]
     )]
@@ -202,6 +203,35 @@ pub struct ColorToggles {
     #[clap(long = "no-terminated-colors", group = "colors")]
     #[serde(rename = "terminated")]
     color_terminated: Option<bool>,
+}
+
+#[derive(Clone, Debug)]
+struct LogFilter(filter::Targets);
+
+// === impl LogFilter ===
+impl fmt::Display for LogFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut comma = false;
+        if let Some(default) = self.0.default_level() {
+            write!(f, "{}", default)?;
+            comma = true;
+        }
+
+        for (target, level) in &self.0 {
+            write!(f, "{}{}={}", if comma { "," } else { "" }, target, level)?;
+            comma = true;
+        }
+
+        Ok(())
+    }
+}
+
+impl FromStr for LogFilter {
+    type Err = filter::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        filter::Targets::from_str(s).map(Self)
+    }
 }
 
 /// A struct used to parse the toml config file
@@ -259,13 +289,13 @@ impl Config {
         toml::to_string_pretty(&config).map_err(Into::into)
     }
 
-    pub fn trace_init(&mut self) -> color_eyre::Result<()> {
+    pub fn trace_init(&self) -> color_eyre::Result<()> {
         use tracing_subscriber::prelude::*;
-        let filter = match self.env_filter.take() {
+        let filter = match self.log_filter.clone() {
             // if logging is totally disabled, don't bother even constructing
             // the subscriber
             None => return Ok(()),
-            Some(filter) => filter,
+            Some(LogFilter(filter)) => filter,
         };
 
         // If we're on a Linux distro with journald, try logging to the system
@@ -284,7 +314,7 @@ impl Config {
         let fmt = if should_fmt {
             let dir = self
                 .log_directory
-                .take()
+                .clone()
                 .unwrap_or_else(default_log_directory);
 
             // first ensure that the log directory exists
@@ -361,7 +391,7 @@ impl Config {
             self, builder =>
                 subcmd,
                 target_addr,
-                env_filter,
+                log_filter,
                 log_directory,
                 retain_for,
                 view_options.no_colors,
@@ -386,7 +416,7 @@ impl Config {
         Self {
             log_directory: other.log_directory.or(self.log_directory),
             target_addr: other.target_addr.or(self.target_addr),
-            env_filter: other.env_filter.or(self.env_filter),
+            log_filter: other.log_filter.or(self.log_filter),
             retain_for: other.retain_for.or(self.retain_for),
             view_options: self.view_options.merge_with(other.view_options),
             subcmd: other.subcmd.or(self.subcmd),
@@ -398,7 +428,9 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             target_addr: Some(default_target_addr()),
-            env_filter: Some(tracing_subscriber::EnvFilter::new("off")),
+            log_filter: Some(LogFilter(
+                filter::Targets::new().with_default(filter::LevelFilter::OFF),
+            )),
             log_directory: Some(default_log_directory()),
             retain_for: Some(RetainFor::default()),
             view_options: ViewOptions::default(),
@@ -514,8 +546,19 @@ impl Default for ViewOptions {
     }
 }
 
-fn parse_true_color(s: &str) -> bool {
-    let s = s.trim();
+fn true_color_parser() -> impl TypedValueParser<Value = bool> {
+    PossibleValuesParser::new(&["24bit", "truecolor"]).map(parse_true_color)
+}
+
+fn palette_parser() -> impl TypedValueParser<Value = Palette> {
+    PossibleValuesParser::new(&["8", "16", "256", "all", "off"]).map(|s| {
+        s.parse::<Palette>()
+            .expect("possible values must have validated that this is a valid `Palette`")
+    })
+}
+
+fn parse_true_color(s: impl AsRef<str>) -> bool {
+    let s = s.as_ref().trim();
     s.eq_ignore_ascii_case("truecolor") || s.eq_ignore_ascii_case("24bit")
 }
 
@@ -579,7 +622,7 @@ impl ConfigFile {
         Ok(uri)
     }
 
-    fn env_filter(&self) -> color_eyre::Result<Option<tracing_subscriber::EnvFilter>> {
+    fn log_filter(&self) -> color_eyre::Result<Option<LogFilter>> {
         let filter_str = self.log.as_deref();
 
         // If logging is totally disabled, may as well bail completely.
@@ -587,11 +630,11 @@ impl ConfigFile {
             return Ok(None);
         }
 
-        let env_filter = filter_str
-            .map(|directive| directive.parse::<tracing_subscriber::EnvFilter>())
+        let log_filter = filter_str
+            .map(|directive| directive.parse::<filter::Targets>().map(LogFilter))
             .transpose()
             .wrap_err_with(|| format!("failed to parse log filter {:?}", self.log))?;
-        Ok(env_filter)
+        Ok(log_filter)
     }
 
     fn retain_for(&self) -> Option<RetainFor> {
@@ -621,7 +664,7 @@ impl From<Config> for ConfigFile {
     fn from(config: Config) -> Self {
         Self {
             default_target_addr: config.target_addr.map(|addr| addr.to_string()),
-            log: config.env_filter.map(|filter| filter.to_string()),
+            log: config.log_filter.map(|filter| filter.to_string()),
             log_directory: config.log_directory,
             retention: config.retain_for,
             charset: Some(CharsetConfig {
@@ -644,7 +687,7 @@ impl TryFrom<ConfigFile> for Config {
     fn try_from(mut value: ConfigFile) -> Result<Self, Self::Error> {
         Ok(Config {
             target_addr: value.target_addr()?,
-            env_filter: value.env_filter()?,
+            log_filter: value.log_filter()?,
             log_directory: value.log_directory.take(),
             retain_for: value.retain_for(),
             view_options: ViewOptions {

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -547,11 +547,11 @@ impl Default for ViewOptions {
 }
 
 fn true_color_parser() -> impl TypedValueParser<Value = bool> {
-    PossibleValuesParser::new(&["24bit", "truecolor"]).map(parse_true_color)
+    PossibleValuesParser::new(["24bit", "truecolor"]).map(parse_true_color)
 }
 
 fn palette_parser() -> impl TypedValueParser<Value = Palette> {
-    PossibleValuesParser::new(&["8", "16", "256", "all", "off"]).map(|s| {
+    PossibleValuesParser::new(["8", "16", "256", "all", "off"]).map(|s| {
         s.parse::<Palette>()
             .expect("possible values must have validated that this is a valid `Palette`")
     })

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -25,7 +25,7 @@ mod warnings;
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
-    let mut args = config::Config::parse()?;
+    let args = config::Config::parse()?;
     // initialize error handling first, in case panics occur while setting up
     // other stuff.
     let styles = view::Styles::from_config(args.view_options.clone());

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 tonic-build = { version = "0.10", default-features = false, features = [
     "prost", "transport"
 ] }
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 tonic-build = { version = "0.10", default-features = false, features = [
     "prost", "transport"
 ] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "~4.1.14", features = ["derive"] }
 color-eyre = "0.6"


### PR DESCRIPTION
Based on https://github.com/tokio-rs/console/pull/384

close https://github.com/tokio-rs/console/pull/384

---

Commit message as updated by @hds:

Tokio console was previously using Clap v3, which is in maintenance and                             
doesn't always receive necessary updates. For example, the fix for a new                            
lint in Clippy was submitted by us (and updated in #414).                                           
                                                                                                    
This change updates to Clap 4.1, as the 4.x versions are generally                                  
better supported. This is the latest version of Clap which is compatible                            
with our current MSRV of 1.64. From the 4.2 versions there are some                                 
depdendencies which require Rust 1.70.                                                              
                                                                                                    
Additionally, we switched from using a `tracing_subscriber::EnvFilter`                              
to a `tracing_subscriber::filter::Targets` for filtering the console's                              
internal log messages. This is because `clap` requires that all arg                                 
values be `Clone` in v4, and we weren't using `EnvFilter` span filtering                            
anyway, so we felt like this was the simplest option.                                               
                                                                                                    
This change shouldn't result in any change in behavior besides                                      
differences in CLI help text formatting.

This change is based on the work originally done in #384.