### PR TITLE
docs(api): fix typo in proto

### DIFF
--- a/console-api/proto/async_ops.proto
+++ b/console-api/proto/async_ops.proto
@@ -7,7 +7,7 @@ import "google/protobuf/duration.proto";
 import "common.proto";
 
 
-// An `AsyncOp` state update. 
+// An `AsyncOp` state update.
 //
 // This includes a list of any new async ops, and updates to the associated statistics
 // for any async ops that have changed since the last update.
@@ -35,7 +35,7 @@ message AsyncOpUpdate {
 // An async operation.
 //
 // An async operation is an operation that is associated with a resource
-// This could, for example, be a a read or write on a TCP stream, or a receive operation on
+// This could, for example, be a read or write on a TCP stream, or a receive operation on
 // a channel.
 message AsyncOp {
     // The async op's ID.

--- a/console-api/src/generated/rs.tokio.console.async_ops.rs
+++ b/console-api/src/generated/rs.tokio.console.async_ops.rs
@@ -30,7 +30,7 @@ pub struct AsyncOpUpdate {
 /// An async operation.
 ///
 /// An async operation is an operation that is associated with a resource
-/// This could, for example, be a a read or write on a TCP stream, or a receive operation on
+/// This could, for example, be a read or write on a TCP stream, or a receive operation on
 /// a channel.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
`a a` -> `a`