### PR TITLE
test(subscriber): prefer `sleep` over `yield_now` in tests

### DIFF
--- a/console-subscriber/tests/framework.rs
+++ b/console-subscriber/tests/framework.rs
@@ -100,7 +100,7 @@ fn test_spawned_task() {
     let future = async {
         task::Builder::new()
             .name("another-name")
-            .spawn(async { task::yield_now().await })
+            .spawn(async { sleep(Duration::ZERO).await })
     };
 
     assert_task(expected_task, future);
@@ -113,7 +113,7 @@ fn test_spawned_task() {
 fn fail_wrong_task_name() {
     let expected_task = ExpectedTask::default().match_name("wrong-name".into());
 
-    let future = async { task::yield_now().await };
+    let future = async { sleep(Duration::ZERO).await };
 
     assert_task(expected_task, future);
 }
@@ -132,11 +132,11 @@ fn multiple_tasks() {
     let future = async {
         let task1 = task::Builder::new()
             .name("task-1")
-            .spawn(async { task::yield_now().await })
+            .spawn(async { sleep(Duration::ZERO).await })
             .unwrap();
         let task2 = task::Builder::new()
             .name("task-2")
-            .spawn(async { task::yield_now().await })
+            .spawn(async { sleep(Duration::ZERO).await })
             .unwrap();
 
         tokio::try_join! {
@@ -166,11 +166,11 @@ fn fail_1_of_2_expected_tasks() {
     let future = async {
         let task1 = task::Builder::new()
             .name("task-1")
-            .spawn(async { task::yield_now().await })
+            .spawn(async { sleep(Duration::ZERO).await })
             .unwrap();
         let task2 = task::Builder::new()
             .name("task-2")
-            .spawn(async { task::yield_now().await })
+            .spawn(async { sleep(Duration::ZERO).await })
             .unwrap();
 
         tokio::try_join! {


### PR DESCRIPTION
A flakiness problem has been discovered with the `console-subscriber`
integration tests introduced in #452. Issue #473 is tracking the issue.

It has been observed that we only "miss" the wake operation event when
it comes from `yield_now()`, but not when it comes from a task that
yielded due to `sleep`, even when the duration is zero. it is likely
that this is due to nature of the underlying race condition.

This change removes all the calls to `yield_now()` from the `framework`
tests, except those where we wish to actually test self wakes.