### PR TITLE
test(console): use try_cmd to generate the help text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,54 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,10 +278,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.0"
+name = "combine"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concolor"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015267563b1df20adccdd00cb05257b1dfbea70a04928e9cf88ffb850c1a40af"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "concolor-query",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
 
 [[package]]
 name = "console-api"
@@ -488,12 +461,6 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -705,7 +672,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.8.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -717,12 +684,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "hdrhistogram"
@@ -868,17 +829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
-dependencies = [
- "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1161,7 +1112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
- "indexmap 1.8.1",
+ "indexmap",
 ]
 
 [[package]]
@@ -1521,15 +1472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,16 +1536,14 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "snapbox"
-version = "0.4.14"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b377c0b6e4715c116473d8e40d51e3fa5b0a2297ca9b2a931ba800667b259ed"
+checksum = "767a1d5da232b6959cd1bd5c9e8db8a7cce09c3038e89deedb49a549a2aefd93"
 dependencies = [
- "anstream",
- "anstyle",
+ "concolor",
  "content_inspector",
  "dunce",
  "filetime",
- "libc",
  "normalize-line-endings",
  "os_pipe",
  "similar",
@@ -1611,17 +1551,14 @@ dependencies = [
  "tempfile",
  "wait-timeout",
  "walkdir",
- "windows-sys 0.48.0",
+ "yansi",
 ]
 
 [[package]]
 name = "snapbox-macros"
-version = "0.3.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1559baff8a696add3322b9be3e940d433e7bb4e38d79017205fd37ff28b28e"
-dependencies = [
- "anstream",
-]
+checksum = "c01dea7e04cbb27ef4c86e9922184608185f7cd95c1763bc30d727cda4a5e930"
 
 [[package]]
 name = "socket2"
@@ -1852,25 +1789,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
- "indexmap 2.0.2",
+ "combine",
+ "indexmap",
+ "itertools",
  "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -1921,7 +1848,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.8.1",
+ "indexmap",
  "pin-project",
  "pin-project-lite",
  "rand",
@@ -2038,9 +1965,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trycmd"
-version = "0.14.19"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed009372a42fb103e6f8767b9222925485e03cca032b700d203e2c5b67bee4fb"
+checksum = "ffb4185126cc904642173a54c185083f410c86d1202ada6761aacf7c40829f13"
 dependencies = [
  "glob",
  "humantime",
@@ -2102,12 +2029,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "valuable"
@@ -2351,15 +2272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "winnow"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
@@ -2367,3 +2279,9 @@ dependencies = [
  "color-eyre",
  "tonic-build",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "console-api"
 version = "0.6.0"
 dependencies = [
@@ -316,6 +370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +395,30 @@ checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
@@ -391,10 +478,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -434,6 +533,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -577,6 +688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,7 +705,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.8.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -600,6 +717,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "hdrhistogram"
@@ -676,6 +799,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,7 +868,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -852,6 +995,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +1054,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +1104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "os_pipe"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,7 +1143,7 @@ checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.13",
  "smallvec",
  "windows-sys 0.34.0",
 ]
@@ -993,7 +1161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.8.1",
 ]
 
 [[package]]
@@ -1160,10 +1328,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1175,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.13",
  "thiserror",
 ]
 
@@ -1278,6 +1475,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,22 +1491,22 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.90",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1315,6 +1521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1537,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signal-hook"
@@ -1354,6 +1575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1591,37 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "snapbox"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b377c0b6e4715c116473d8e40d51e3fa5b0a2297ca9b2a931ba800667b259ed"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "content_inspector",
+ "dunce",
+ "filetime",
+ "libc",
+ "normalize-line-endings",
+ "os_pipe",
+ "similar",
+ "snapbox-macros",
+ "tempfile",
+ "wait-timeout",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1559baff8a696add3322b9be3e940d433e7bb4e38d79017205fd37ff28b28e"
+dependencies = [
+ "anstream",
+]
 
 [[package]]
 name = "socket2"
@@ -1418,7 +1676,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.13",
  "remove_dir_all",
  "winapi",
 ]
@@ -1535,6 +1793,7 @@ dependencies = [
  "tracing",
  "tracing-journald",
  "tracing-subscriber",
+ "trycmd",
 ]
 
 [[package]]
@@ -1593,6 +1852,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap 2.0.2",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,7 +1921,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.8.1",
  "pin-project",
  "pin-project-lite",
  "rand",
@@ -1756,6 +2037,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "trycmd"
+version = "0.14.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed009372a42fb103e6f8767b9222925485e03cca032b700d203e2c5b67bee4fb"
+dependencies = [
+ "glob",
+ "humantime",
+ "humantime-serde",
+ "rayon",
+ "serde",
+ "shlex",
+ "snapbox",
+ "toml_edit",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,10 +2104,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2027,6 +2349,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xtask"

--- a/README.md
+++ b/README.md
@@ -167,12 +167,16 @@ The console command-line tool supports a number of additional flags to configure
 its behavior. The `help` command will print a list of supported command-line
 flags and arguments:
 
-```text
+```console
+$ tokio-console --help
+The Tokio console: a debugger for async Rust.
+
+Usage: tokio-console [OPTIONS] [TARGET_ADDR] [COMMAND]
+
 Commands:
   gen-config
-          Generate a `console.toml` config file with the default
-          configuration values, overridden by any provided command-line
-          arguments
+          Generate a `console.toml` config file with the default configuration values, overridden by
+          any provided command-line arguments
   gen-completion
           Generate shell completions
   help
@@ -181,43 +185,40 @@ Commands:
 Arguments:
   [TARGET_ADDR]
           The address of a console-enabled process to connect to.
-
+          
           This may be an IP address and port, or a DNS name.
-
-          On Unix platforms, this may also be a URI with the `file`
-          scheme that specifies the path to a Unix domain socket, as in
-          `file://localhost/path/to/socket`.
-
+          
+          On Unix platforms, this may also be a URI with the `file` scheme that specifies the path
+          to a Unix domain socket, as in `file://localhost/path/to/socket`.
+          
           [default: http://127.0.0.1:6669]
 
 Options:
       --log <LOG_FILTER>
           Log level filter for the console's internal diagnostics.
-
-          Logs are written to a new file at the path given by the
-          `--log-dir` argument (or its default value), or to the system
-          journal if `systemd-journald` support is enabled.
-
-          If this is set to 'off' or is not set, no logs will be
-          written.
-
+          
+          Logs are written to a new file at the path given by the `--log-dir` argument (or its
+          default value), or to the system journal if `systemd-journald` support is enabled.
+          
+          If this is set to 'off' or is not set, no logs will be written.
+          
           [default: off]
-
+          
           [env: RUST_LOG=]
 
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.
-
+          
           [default: /tmp/tokio-console/logs]
 
       --lang <LANG>
           Overrides the terminal's default language
-
+          
           [env: LANG=en_US.UTF-8]
 
       --ascii-only <ASCII_ONLY>
           Explicitly use only ASCII characters
-
+          
           [possible values: true, false]
 
       --no-colors
@@ -225,59 +226,56 @@ Options:
 
       --colorterm <truecolor>
           Overrides the value of the `COLORTERM` environment variable.
-
-          If this is set to `24bit` or `truecolor`, 24-bit RGB color
-          support will be enabled.
-
+          
+          If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
+          
           [env: COLORTERM=truecolor]
           [possible values: 24bit, truecolor]
 
       --palette <PALETTE>
           Explicitly set which color palette to use
-
+          
           [possible values: 8, 16, 256, all, off]
 
       --no-duration-colors <COLOR_DURATIONS>
           Disable color-coding for duration units
-
+          
           [possible values: true, false]
 
       --no-terminated-colors <COLOR_TERMINATED>
           Disable color-coding for terminated tasks
-
+          
           [possible values: true, false]
 
       --retain-for <RETAIN_FOR>
-          How long to continue displaying completed tasks and dropped
-          resources after they have been closed.
-
-          This accepts either a duration, parsed as a combination of
-          time spans (such as `5days 2min 2s`), or `none` to disable
-          removing completed tasks and dropped resources.
-
-          Each time span is an integer number followed by a suffix.
-          Supported suffixes are:
-
+          How long to continue displaying completed tasks and dropped resources after they have been
+          closed.
+          
+          This accepts either a duration, parsed as a combination of time spans (such as `5days 2min
+          2s`), or `none` to disable removing completed tasks and dropped resources.
+          
+          Each time span is an integer number followed by a suffix. Supported suffixes are:
+          
           * `nsec`, `ns` -- nanoseconds
-
+          
           * `usec`, `us` -- microseconds
-
+          
           * `msec`, `ms` -- milliseconds
-
+          
           * `seconds`, `second`, `sec`, `s`
-
+          
           * `minutes`, `minute`, `min`, `m`
-
+          
           * `hours`, `hour`, `hr`, `h`
-
+          
           * `days`, `day`, `d`
-
+          
           * `weeks`, `week`, `w`
-
+          
           * `months`, `month`, `M` -- defined as 30.44 days
-
+          
           * `years`, `year`, `y` -- defined as 365.25 days
-
+          
           [default: 6s]
 
   -h, --help
@@ -285,6 +283,7 @@ Options:
 
   -V, --version
           Print version
+
 ```
 
 ## for development

--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ Usage: tokio-console [OPTIONS] [TARGET_ADDR] [COMMAND]
 
 Commands:
   gen-config
-          Generate a `console.toml` config file with the default configuration values, overridden by
-          any provided command-line arguments
+          Generate a `console.toml` config file with the default
+          configuration values, overridden by any provided command-line
+          arguments
   gen-completion
           Generate shell completions
   help
@@ -188,8 +189,9 @@ Arguments:
           
           This may be an IP address and port, or a DNS name.
           
-          On Unix platforms, this may also be a URI with the `file` scheme that specifies the path
-          to a Unix domain socket, as in `file://localhost/path/to/socket`.
+          On Unix platforms, this may also be a URI with the `file`
+          scheme that specifies the path to a Unix domain socket, as in
+          `file://localhost/path/to/socket`.
           
           [default: http://127.0.0.1:6669]
 
@@ -197,10 +199,12 @@ Options:
       --log <LOG_FILTER>
           Log level filter for the console's internal diagnostics.
           
-          Logs are written to a new file at the path given by the `--log-dir` argument (or its
-          default value), or to the system journal if `systemd-journald` support is enabled.
+          Logs are written to a new file at the path given by the
+          `--log-dir` argument (or its default value), or to the system
+          journal if `systemd-journald` support is enabled.
           
-          If this is set to 'off' or is not set, no logs will be written.
+          If this is set to 'off' or is not set, no logs will be
+          written.
           
           [default: off]
           
@@ -227,7 +231,8 @@ Options:
       --colorterm <truecolor>
           Overrides the value of the `COLORTERM` environment variable.
           
-          If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
+          If this is set to `24bit` or `truecolor`, 24-bit RGB color
+          support will be enabled.
           
           [env: COLORTERM=truecolor]
           [possible values: 24bit, truecolor]
@@ -248,13 +253,15 @@ Options:
           [possible values: true, false]
 
       --retain-for <RETAIN_FOR>
-          How long to continue displaying completed tasks and dropped resources after they have been
-          closed.
+          How long to continue displaying completed tasks and dropped
+          resources after they have been closed.
           
-          This accepts either a duration, parsed as a combination of time spans (such as `5days 2min
-          2s`), or `none` to disable removing completed tasks and dropped resources.
+          This accepts either a duration, parsed as a combination of
+          time spans (such as `5days 2min 2s`), or `none` to disable
+          removing completed tasks and dropped resources.
           
-          Each time span is an integer number followed by a suffix. Supported suffixes are:
+          Each time span is an integer number followed by a suffix.
+          Supported suffixes are:
           
           * `nsec`, `ns` -- nanoseconds
           

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -51,3 +51,6 @@ humantime = "2.1.0"
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 dirs = "4"
+
+[dev-dependencies]
+trycmd = "0.14.19"

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.64.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>", "Tokio Contributors <team@tokio.rs>",]
 readme = "README.md"
 default-run = "tokio-console"
-homepage = "https://github.com/tokio-rs/console/tree/main/tokio-console" 
+homepage = "https://github.com/tokio-rs/console/tree/main/tokio-console"
 description = """
 The Tokio console: a debugger for async Rust.
 """
@@ -53,4 +53,5 @@ toml = "0.5"
 dirs = "4"
 
 [dev-dependencies]
-trycmd = "0.14.19"
+# Use 1.64.0 compatible version of `trycmd@0.13.4`.
+trycmd = "=0.13.4"

--- a/tokio-console/cli-ui.stdout
+++ b/tokio-console/cli-ui.stdout
@@ -4,8 +4,9 @@ Usage: tokio-console [OPTIONS] [TARGET_ADDR] [COMMAND]
 
 Commands:
   gen-config
-          Generate a `console.toml` config file with the default configuration values, overridden by
-          any provided command-line arguments
+          Generate a `console.toml` config file with the default
+          configuration values, overridden by any provided command-line
+          arguments
   gen-completion
           Generate shell completions
   help
@@ -17,8 +18,9 @@ Arguments:
           
           This may be an IP address and port, or a DNS name.
           
-          On Unix platforms, this may also be a URI with the `file` scheme that specifies the path
-          to a Unix domain socket, as in `file://localhost/path/to/socket`.
+          On Unix platforms, this may also be a URI with the `file`
+          scheme that specifies the path to a Unix domain socket, as in
+          `file://localhost/path/to/socket`.
           
           [default: http://127.0.0.1:6669]
 
@@ -26,10 +28,12 @@ Options:
       --log <LOG_FILTER>
           Log level filter for the console's internal diagnostics.
           
-          Logs are written to a new file at the path given by the `--log-dir` argument (or its
-          default value), or to the system journal if `systemd-journald` support is enabled.
+          Logs are written to a new file at the path given by the
+          `--log-dir` argument (or its default value), or to the system
+          journal if `systemd-journald` support is enabled.
           
-          If this is set to 'off' or is not set, no logs will be written.
+          If this is set to 'off' or is not set, no logs will be
+          written.
           
           [default: off]
           
@@ -56,7 +60,8 @@ Options:
       --colorterm <truecolor>
           Overrides the value of the `COLORTERM` environment variable.
           
-          If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
+          If this is set to `24bit` or `truecolor`, 24-bit RGB color
+          support will be enabled.
           
           [env: COLORTERM=truecolor]
           [possible values: 24bit, truecolor]
@@ -77,13 +82,15 @@ Options:
           [possible values: true, false]
 
       --retain-for <RETAIN_FOR>
-          How long to continue displaying completed tasks and dropped resources after they have been
-          closed.
+          How long to continue displaying completed tasks and dropped
+          resources after they have been closed.
           
-          This accepts either a duration, parsed as a combination of time spans (such as `5days 2min
-          2s`), or `none` to disable removing completed tasks and dropped resources.
+          This accepts either a duration, parsed as a combination of
+          time spans (such as `5days 2min 2s`), or `none` to disable
+          removing completed tasks and dropped resources.
           
-          Each time span is an integer number followed by a suffix. Supported suffixes are:
+          Each time span is an integer number followed by a suffix.
+          Supported suffixes are:
           
           * `nsec`, `ns` -- nanoseconds
           

--- a/tokio-console/cli-ui.stdout
+++ b/tokio-console/cli-ui.stdout
@@ -1,8 +1,11 @@
+The Tokio console: a debugger for async Rust.
+
+Usage: tokio-console [OPTIONS] [TARGET_ADDR] [COMMAND]
+
 Commands:
   gen-config
-          Generate a `console.toml` config file with the default
-          configuration values, overridden by any provided command-line
-          arguments
+          Generate a `console.toml` config file with the default configuration values, overridden by
+          any provided command-line arguments
   gen-completion
           Generate shell completions
   help
@@ -14,9 +17,8 @@ Arguments:
           
           This may be an IP address and port, or a DNS name.
           
-          On Unix platforms, this may also be a URI with the `file`
-          scheme that specifies the path to a Unix domain socket, as in
-          `file://localhost/path/to/socket`.
+          On Unix platforms, this may also be a URI with the `file` scheme that specifies the path
+          to a Unix domain socket, as in `file://localhost/path/to/socket`.
           
           [default: http://127.0.0.1:6669]
 
@@ -24,12 +26,10 @@ Options:
       --log <LOG_FILTER>
           Log level filter for the console's internal diagnostics.
           
-          Logs are written to a new file at the path given by the
-          `--log-dir` argument (or its default value), or to the system
-          journal if `systemd-journald` support is enabled.
+          Logs are written to a new file at the path given by the `--log-dir` argument (or its
+          default value), or to the system journal if `systemd-journald` support is enabled.
           
-          If this is set to 'off' or is not set, no logs will be
-          written.
+          If this is set to 'off' or is not set, no logs will be written.
           
           [default: off]
           
@@ -56,8 +56,7 @@ Options:
       --colorterm <truecolor>
           Overrides the value of the `COLORTERM` environment variable.
           
-          If this is set to `24bit` or `truecolor`, 24-bit RGB color
-          support will be enabled.
+          If this is set to `24bit` or `truecolor`, 24-bit RGB color support will be enabled.
           
           [env: COLORTERM=truecolor]
           [possible values: 24bit, truecolor]
@@ -78,15 +77,13 @@ Options:
           [possible values: true, false]
 
       --retain-for <RETAIN_FOR>
-          How long to continue displaying completed tasks and dropped
-          resources after they have been closed.
+          How long to continue displaying completed tasks and dropped resources after they have been
+          closed.
           
-          This accepts either a duration, parsed as a combination of
-          time spans (such as `5days 2min 2s`), or `none` to disable
-          removing completed tasks and dropped resources.
+          This accepts either a duration, parsed as a combination of time spans (such as `5days 2min
+          2s`), or `none` to disable removing completed tasks and dropped resources.
           
-          Each time span is an integer number followed by a suffix.
-          Supported suffixes are:
+          Each time span is an integer number followed by a suffix. Supported suffixes are:
           
           * `nsec`, `ns` -- nanoseconds
           

--- a/tokio-console/cli-ui.toml
+++ b/tokio-console/cli-ui.toml
@@ -1,0 +1,3 @@
+bin.name = "tokio-console"
+args = ["--help"]
+stdin= ""

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -768,7 +768,12 @@ mod tests {
     }
 
     #[test]
+    // You can use `TRYCMD=overwrite` to overwrite the expected output.
     fn cli_tests() {
+        // 72 chars seems to fit reasonably in the default width of
+        // RustDoc's code formatting
+        // Set the env var COLUMNS to override this.
+        env::set_var("COLUMNS", "72");
         trycmd::TestCases::new()
             .case("cli-ui.toml")
             .case("../README.md");

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -754,7 +754,7 @@ mod tests {
     use std::{
         env,
         fs::File,
-        io::{BufWriter, Cursor, Write},
+        io::Write,
         path::{Path, PathBuf},
         process,
     };
@@ -768,50 +768,10 @@ mod tests {
     }
 
     #[test]
-    fn args_example_changed() {
-        use clap::CommandFactory;
-
-        // Override env vars that may effect the defaults.
-        clobber_env_vars();
-
-        let path = PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join("args.example");
-
-        let mut cmd = Config::command()
-            // always use the same terminal width when generating the help text,
-            // so that the text wrapping doesn't change based on the terminal
-            // size that the test was run in.
-            // (72 chars seems to fit reasonably in the default width of
-            // RustDoc's code formatting)
-            .term_width(72);
-        let mut helptext = Vec::new();
-        // Format the help text to a string.
-        cmd.write_long_help(&mut Cursor::new(&mut helptext))
-            .expect("generating help should succeed");
-        let helptext = String::from_utf8(helptext).expect("help text is UTF-8");
-
-        let mut file = {
-            let file = File::create(&path).expect("failed to open file");
-            BufWriter::new(file)
-        };
-        // Drop the first four lines of the help text, as they include the
-        // version number, and it seems like a pain to have to re-generate the
-        // file every time the version changes...
-        for line in helptext.lines().skip(4) {
-            writeln!(file, "{}", line).expect("writing to file succeeds");
-        }
-
-        file.flush().expect("flushing should succeed");
-        drop(file);
-
-        if let Err(diff) = git_diff(&path) {
-            panic!(
-                "\n/!\\ command line arguments have changed!\n\
-                you should commit the new version of `{}`\n\n\
-                git diff output:\n\n{}\n",
-                path.display(),
-                diff
-            );
-        }
+    fn cli_tests() {
+        trycmd::TestCases::new()
+            .case("cli-ui.toml")
+            .case("../README.md");
     }
 
     #[test]

--- a/tokio-console/src/lib.rs
+++ b/tokio-console/src/lib.rs
@@ -12,7 +12,7 @@
 /// `tokio-console`:
 ///
 /// ```text
-#[doc = include_str!("../args.example")]
+#[doc = include_str!("../cli-ui.stdout")]
 /// ```
 ///
 /// This text can also be displayed by running `tokio-console help`.


### PR DESCRIPTION
I tried to use `try_cmd` to avoid [this kind of problem](https://github.com/tokio-rs/console/pull/470). 

1. It is easier to use `TRYCMD=overwrite` to update all outputs.
2. We also test the output from the README file.