### PR TITLE
refactor(console): remove useless `Pin::new()` on streaming

### DIFF
--- a/tokio-console/src/conn.rs
+++ b/tokio-console/src/conn.rs
@@ -4,7 +4,7 @@ use console_api::instrument::{
 };
 use console_api::tasks::TaskDetails;
 use futures::stream::StreamExt;
-use std::{error::Error, pin::Pin, time::Duration};
+use std::{error::Error, time::Duration};
 #[cfg(unix)]
 use tokio::net::UnixStream;
 use tonic::{
@@ -129,7 +129,7 @@ impl Connection {
     pub async fn next_update(&mut self) -> Update {
         loop {
             match self.state {
-                State::Connected { ref mut stream, .. } => match Pin::new(stream).next().await {
+                State::Connected { ref mut stream, .. } => match stream.next().await {
                     Some(Ok(update)) => return update,
                     Some(Err(status)) => {
                         tracing::warn!(%status, "error from stream");


### PR DESCRIPTION
It seems we don't need to Pin it here.

For the next API:
```rust
    /// Creates a future that resolves to the next item in the stream.
    ///
    /// Note that because `next` doesn't take ownership over the stream,
    /// the [`Stream`] type must be [`Unpin`]. If you want to use `next` with a
    /// [`!Unpin`](Unpin) stream, you'll first have to pin the stream. This can
    /// be done by boxing the stream using [`Box::pin`] or
    /// pinning it to the stack using the `pin_mut!` macro from the `pin_utils`
    /// crate.
```

But here it is a Unpin stream, so we don't need to pin it.