### PR TITLE
test(subscriber): add test for tasks being kept open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,7 +1710,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "tokio"
 version = "1.34.0"
-source = "git+https://github.com/tokio-rs/tokio.git?branch=hds/task-span-explicit-root#571d01cb73c22e6b7bc645b4e59f0b06d85f7d0f"
+source = "git+https://github.com/tokio-rs/tokio.git?branch=master#7a30504fd423aa782239ead92f3afa3474f8037c"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1769,7 +1769,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "2.2.0"
-source = "git+https://github.com/tokio-rs/tokio.git?branch=hds/task-span-explicit-root#571d01cb73c22e6b7bc645b4e59f0b06d85f7d0f"
+source = "git+https://github.com/tokio-rs/tokio.git?branch=master#7a30504fd423aa782239ead92f3afa3474f8037c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.9.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi",
 ]
@@ -787,7 +787,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -896,9 +896,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -988,14 +988,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1587,6 +1587,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,24 +1709,21 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+version = "1.34.0"
+source = "git+https://github.com/tokio-rs/tokio.git?branch=hds/task-span-explicit-root#571d01cb73c22e6b7bc645b4e59f0b06d85f7d0f"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.5",
  "tokio-macros",
  "tracing",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1761,13 +1768,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+version = "2.2.0"
+source = "git+https://github.com/tokio-rs/tokio.git?branch=hds/task-span-explicit-root#571d01cb73c22e6b7bc645b4e59f0b06d85f7d0f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.90",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2122,9 +2128,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi",
 ]
@@ -2146,19 +2152,6 @@ dependencies = [
  "windows_i686_msvc 0.34.0",
  "windows_x86_64_gnu 0.34.0",
  "windows_x86_64_msvc 0.34.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
 ]
 
 [[package]]
@@ -2199,12 +2192,6 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -2214,12 +2201,6 @@ name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2235,12 +2216,6 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -2250,12 +2225,6 @@ name = "windows_x86_64_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2274,12 +2243,6 @@ name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "xtask"
 ]
 resolver = "2"
+
+[patch.crates-io]
+tokio = { git = "https://github.com/tokio-rs/tokio.git", branch = "hds/task-span-explicit-root" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-tokio = { git = "https://github.com/tokio-rs/tokio.git", branch = "hds/task-span-explicit-root" }
+tokio = { git = "https://github.com/tokio-rs/tokio.git", branch = "master" }

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -32,7 +32,7 @@ env-filter = ["tracing-subscriber/env-filter"]
 [dependencies]
 
 crossbeam-utils = "0.8.7"
-tokio = { version = "^1.21", features = ["sync", "time", "macros", "tracing"] }
+tokio = { version = "1.34", features = ["sync", "time", "macros", "tracing"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 thread_local = "1.1.3"
 console-api = { version = "0.6.0", path = "../console-api", features = ["transport"] }
@@ -54,7 +54,7 @@ serde_json = "1"
 crossbeam-channel = "0.5"
 
 [dev-dependencies]
-tokio = { version = "^1.21", features = ["full", "rt-multi-thread"] }
+tokio = { version = "1.34", features = ["full", "rt-multi-thread"] }
 tower = { version = "0.4", default-features = false }
 futures = "0.3"
 

--- a/console-subscriber/tests/spawn.rs
+++ b/console-subscriber/tests/spawn.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 mod support;
-use support::{assert_tasks, spawn_named, ExpectedTask};
+use support::{assert_tasks, spawn_named, ExpectedTask, TaskState};
 
 /// This test asserts the behavior that was fixed in #440. Before that fix,
 /// the polls of a child were also counted towards the parent (the task which
@@ -30,6 +30,31 @@ fn child_polls_dont_count_towards_parent_polls() {
         .expect("joining parent failed");
 
         child_join_handle.await.expect("joining child failed");
+    };
+
+    assert_tasks(expected_tasks, future);
+}
+
+/// This test asserts that the lifetime of a task is not affected by the
+/// lifetimes of tasks that it spawns. The test will pass when #345 is
+/// fixed.
+#[test]
+fn spawner_task_with_running_children_completes() {
+    let expected_tasks = vec![
+        ExpectedTask::default()
+            .match_name("parent".into())
+            .expect_state(TaskState::Completed),
+        ExpectedTask::default()
+            .match_name("child".into())
+            .expect_state(TaskState::Idle),
+    ];
+
+    let future = async {
+        spawn_named("parent", async {
+            spawn_named("child", futures::future::pending::<()>());
+        })
+        .await
+        .expect("joining parent failed");
     };
 
     assert_tasks(expected_tasks, future);

--- a/console-subscriber/tests/support/mod.rs
+++ b/console-subscriber/tests/support/mod.rs
@@ -8,6 +8,8 @@ use subscriber::run_test;
 
 pub(crate) use subscriber::MAIN_TASK_NAME;
 pub(crate) use task::ExpectedTask;
+#[allow(unused_imports)]
+pub(crate) use task::TaskState;
 use tokio::task::JoinHandle;
 
 /// Assert that an `expected_task` is recorded by a console-subscriber


### PR DESCRIPTION
In the Tokio instrumentation, a tracing span is created for each task
which is spawned. Since the new span is created within the context of
where `tokio::spawn()` (or similar) is called from, it gets a contextual
parent attached.

In tracing, when a span has a child span (either because the child was
created in the context of the parent, or because the parent was set
explicitly) then that span will not be closed until the child has
closed.

The result in the console subscriber is that a task which spawns another
task won't have a `dropped_at` time set until the spawned task exits,
even if the parent task exits much earlier. This causes Tokio Console to
show an incorrect lost waker warning (#345). It also affects other spans
that are entered when a task is spawned (#412).

The solution is to modify the instrumentation in Tokio so that task
spans are explicit roots (`parent: None`). This will be done as part of
enriching the Tokio instrumentation (tokio-rs/tokio#5792).

This change adds functionality to the test framework within
`console-subscriber` so that the state of a task can be set as an
expectation. The state is calculated based on 4 values:
* `console_api::tasks::Stats::dropped_at`
* `console_api::tasks::Stats::last_wake`
* `console_api::PollStats::last_poll_started`
* `console_api::PollStats::last_poll_ended`

It can then be tested that a task that spawns another task and then ends
actually goes to the `Completed` state, even if the spawned task is
still running. As of Tokio 1.33.0, this test fails, but the PR **FIXME:TBD**
fixes this and the test should pass from Tokio 1.34 onwards.