### PR TITLE
fix(console): fix the issue of continuous reconnection caused by decode failure

### DIFF
--- a/tokio-console/src/conn.rs
+++ b/tokio-console/src/conn.rs
@@ -65,6 +65,7 @@ macro_rules! with_client {
 
 impl Connection {
     const BACKOFF: Duration = Duration::from_millis(500);
+    const MAX_DECODING_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
     pub fn new(target: Uri) -> Self {
         Self {
             target,
@@ -108,6 +109,7 @@ impl Connection {
                     }
                 };
                 let mut client = InstrumentClient::new(channel);
+                client = client.max_decoding_message_size(Self::MAX_DECODING_MESSAGE_SIZE);
                 let request = tonic::Request::new(InstrumentRequest {});
                 let stream = Box::new(client.watch_updates(request).await?.into_inner());
                 Ok::<State, Box<dyn Error + Send + Sync>>(State::Connected { client, stream })


### PR DESCRIPTION
> 2023-12-12T08:46:56.332653Z  WARN tokio_console::conn: error from stream status=status: OutOfRange, message: "Error, message length too large: found 5913832 bytes, the limit is: 4194304 bytes", details: [], metadata: MetadataMap { headers: {} }


By default, both of the `tonic`'s `max_decoding_message_size` is `4M`, when there are too many async tasks, the decoding will over `4M`, causing `tokio-console` decoding to fail. 

When it fails, the `tokio-console` interface will continuously display `Connected/Reconnect`, as it may be a bit strange to make the `decoding maximum value` a command line parameter, so make it `16M` as a `const value`.