### PR TITLE
chore(console): fix clippy::unnecessary_fallible_conversions warning

### DIFF
--- a/tokio-console/src/conn.rs
+++ b/tokio-console/src/conn.rs
@@ -103,7 +103,7 @@ impl Connection {
                         return Err("unix domain sockets are not supported on this platform".into());
                     }
                     _ => {
-                        let endpoint = Endpoint::try_from(self.target.clone())?;
+                        let endpoint = Endpoint::from(self.target.clone());
                         endpoint.connect().await?
                     }
                 };


### PR DESCRIPTION
This fixes a new clippy lint added in 1.75. This warning is currently causing CI failure https://github.com/tokio-rs/console/actions/runs/7437067584/job/20234273745?pr=506.

```
error: use of a fallible conversion when an infallible one could be used
   --> tokio-console/src/conn.rs:106:40
    |
106 |                         let endpoint = Endpoint::try_from(self.target.clone())?;
    |                                        ^^^^^^^^^^^^^^^^^^ help: use: `From::from`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_fallible_conversions
    = note: `-D clippy::unnecessary-fallible-conversions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_fallible_conversions)]`
```