### PR TITLE
feat: add `--allow` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,15 +234,16 @@ Options:
           
           This is a comma-separated list of warnings to allow.
           
-          Each warning is specified by its name, which is one of: *
-          `self-wakes` -- Warns when a task wakes itself more than a
+          Each warning is specified by its name, which is one of:
+          
+          * `self-wakes` -- Warns when a task wakes itself more than a
           certain percentage of its total wakeups. Default percentage is
-          50%. * `lost-waker` -- Warns when a task is dropped without
-          being woken.
+          50%.
+          
+          * `lost-waker` -- Warns when a task is dropped without being
+          woken.
           
           * `never-yielded` -- Warns when a task has never yielded.
-          
-          [possible values: self-wakes, lost-waker, never-yielded]
 
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.

--- a/README.md
+++ b/README.md
@@ -236,8 +236,6 @@ Options:
           
           Each warning is specified by its name, which is one of:
           
-          * `all` -- Allow all warnings.
-          
           * `self-wakes` -- Warns when a task wakes itself more than a
           certain percentage of its total wakeups. Default percentage is
           50%.
@@ -246,6 +244,8 @@ Options:
           woken.
           
           * `never-yielded` -- Warns when a task has never yielded.
+          
+          If this is set to `all`, all warnings are allowed.
           
           [possible values: all, self-wakes, lost-waker, never-yielded]
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,21 @@ Options:
           [default: self-wakes lost-waker never-yielded]
           [possible values: self-wakes, lost-waker, never-yielded]
 
+  -A, --allow <ALLOW_WARNINGS>...
+          Allow lint warnings.
+          
+          This is a comma-separated list of warnings to allow.
+          
+          Each warning is specified by its name, which is one of: *
+          `self-wakes` -- Warns when a task wakes itself more than a
+          certain percentage of its total wakeups. Default percentage is
+          50%. * `lost-waker` -- Warns when a task is dropped without
+          being woken.
+          
+          * `never-yielded` -- Warns when a task has never yielded.
+          
+          [possible values: self-wakes, lost-waker, never-yielded]
+
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.
           

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Options:
           
           Each warning is specified by its name, which is one of:
           
+          * `all` -- Allow all warnings.
+          
           * `self-wakes` -- Warns when a task wakes itself more than a
           certain percentage of its total wakeups. Default percentage is
           50%.
@@ -244,6 +246,8 @@ Options:
           woken.
           
           * `never-yielded` -- Warns when a task has never yielded.
+          
+          [possible values: all, self-wakes, lost-waker, never-yielded]
 
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -5,6 +5,7 @@ warnings = [
     'lost-waker',
     'never-yielded',
 ]
+allow_warnings = []
 log_directory = '/tmp/tokio-console/logs'
 retention = '6s'
 

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -5,7 +5,6 @@ warnings = [
     'lost-waker',
     'never-yielded',
 ]
-allow_warnings = []
 log_directory = '/tmp/tokio-console/logs'
 retention = '6s'
 

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -73,14 +73,14 @@ pub struct Config {
     ///
     /// Each warning is specified by its name, which is one of:
     ///
-    /// * `all` -- Allow all warnings.
-    ///
     /// * `self-wakes` -- Warns when a task wakes itself more than a certain percentage of its total wakeups.
     ///                  Default percentage is 50%.
     ///
     /// * `lost-waker` -- Warns when a task is dropped without being woken.
     ///
     /// * `never-yielded` -- Warns when a task has never yielded.
+    ///
+    /// If this is set to `all`, all warnings are allowed.
     #[clap(long = "allow", short = 'A', value_delimiter = ',', num_args = 1.., value_parser = PossibleValuesParser::new(AllowedWarnings::possible_values()))]
     pub(crate) allow_warnings: Option<AllowedWarnings>,
 

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -81,7 +81,9 @@ pub struct Config {
     /// * `never-yielded` -- Warns when a task has never yielded.
     ///
     /// If this is set to `all`, all warnings are allowed.
-    #[clap(long = "allow", short = 'A', value_delimiter = ',', num_args = 1.., value_parser = PossibleValuesParser::new(AllowedWarnings::possible_values()))]
+    ///
+    /// [possible values: all, self-wakes, lost-waker, never-yielded]
+    #[clap(long = "allow", short = 'A', value_delimiter = ',', num_args = 1..)]
     pub(crate) allow_warnings: Option<AllowedWarnings>,
 
     /// Path to a directory to write the console's internal logs to.
@@ -211,11 +213,6 @@ impl FromStr for AllowedWarnings {
 }
 
 impl AllowedWarnings {
-    fn possible_values() -> &'static [&'static str] {
-        // NOTE: Please keep this list in sync with the `KnownWarnings` enum.
-        &["all", "self-wakes", "lost-waker", "never-yielded"]
-    }
-
     fn merge(&self, allowed: &Self) -> Self {
         match (self, allowed) {
             (AllowedWarnings::All, _) => AllowedWarnings::All,

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -63,7 +63,6 @@ pub struct Config {
     /// * `lost-waker` -- Warns when a task is dropped without being woken.
     ///
     /// * `never-yielded` -- Warns when a task has never yielded.
-    ///
     #[clap(long = "warn", short = 'W', value_delimiter = ',', num_args = 1..)]
     #[clap(default_values_t = KnownWarnings::default_enabled_warnings())]
     pub(crate) warnings: Vec<KnownWarnings>,
@@ -73,12 +72,14 @@ pub struct Config {
     /// This is a comma-separated list of warnings to allow.
     ///
     /// Each warning is specified by its name, which is one of:
+    ///
     /// * `self-wakes` -- Warns when a task wakes itself more than a certain percentage of its total wakeups.
     ///                  Default percentage is 50%.
+    ///
     /// * `lost-waker` -- Warns when a task is dropped without being woken.
     ///
     /// * `never-yielded` -- Warns when a task has never yielded.
-    #[clap(long = "allow", short = 'A')]
+    #[clap(long = "allow", short = 'A', value_delimiter = ',', num_args = 1..)]
     pub(crate) allow_warnings: Option<AllowedWarnings>,
 
     /// Path to a directory to write the console's internal logs to.

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -187,11 +187,14 @@ impl KnownWarnings {
         ]
     }
 }
-
+/// An enum representing the types of warnings that are allowed.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub(crate) enum AllowedWarnings {
+    /// Represents the case where all warnings are allowed.
     All,
-    Some(BTreeSet<KnownWarnings>),
+    /// Represents the case where only some specific warnings are allowed.
+    /// The allowed warnings are stored in a `BTreeSet` of `KnownWarnings`.
+    Explicit(BTreeSet<KnownWarnings>),
 }
 
 impl FromStr for AllowedWarnings {
@@ -206,7 +209,7 @@ impl FromStr for AllowedWarnings {
                     .map(|s| s.parse::<KnownWarnings>())
                     .collect::<Result<BTreeSet<_>, _>>()
                     .map_err(|err| format!("failed to parse warning: {}", err))?;
-                Ok(AllowedWarnings::Some(warnings))
+                Ok(AllowedWarnings::Explicit(warnings))
             }
         }
     }
@@ -217,10 +220,10 @@ impl AllowedWarnings {
         match (self, allowed) {
             (AllowedWarnings::All, _) => AllowedWarnings::All,
             (_, AllowedWarnings::All) => AllowedWarnings::All,
-            (AllowedWarnings::Some(a), AllowedWarnings::Some(b)) => {
+            (AllowedWarnings::Explicit(a), AllowedWarnings::Explicit(b)) => {
                 let mut warnings = a.clone();
                 warnings.extend(b.clone());
-                AllowedWarnings::Some(warnings)
+                AllowedWarnings::Explicit(warnings)
             }
         }
     }

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -73,13 +73,15 @@ pub struct Config {
     ///
     /// Each warning is specified by its name, which is one of:
     ///
+    /// * `all` -- Allow all warnings.
+    ///
     /// * `self-wakes` -- Warns when a task wakes itself more than a certain percentage of its total wakeups.
     ///                  Default percentage is 50%.
     ///
     /// * `lost-waker` -- Warns when a task is dropped without being woken.
     ///
     /// * `never-yielded` -- Warns when a task has never yielded.
-    #[clap(long = "allow", short = 'A', value_delimiter = ',', num_args = 1..)]
+    #[clap(long = "allow", short = 'A', value_delimiter = ',', num_args = 1.., value_parser = PossibleValuesParser::new(AllowedWarnings::possible_values()))]
     pub(crate) allow_warnings: Option<AllowedWarnings>,
 
     /// Path to a directory to write the console's internal logs to.
@@ -209,6 +211,11 @@ impl FromStr for AllowedWarnings {
 }
 
 impl AllowedWarnings {
+    fn possible_values() -> &'static [&'static str] {
+        // NOTE: Please keep this list in sync with the `KnownWarnings` enum.
+        &["all", "self-wakes", "lost-waker", "never-yielded"]
+    }
+
     fn merge(&self, allowed: &Self) -> Self {
         match (self, allowed) {
             (AllowedWarnings::All, _) => AllowedWarnings::All,

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -83,7 +83,7 @@ pub struct Config {
     /// If this is set to `all`, all warnings are allowed.
     ///
     /// [possible values: all, self-wakes, lost-waker, never-yielded]
-    #[clap(long = "allow", short = 'A', value_delimiter = ',', num_args = 1..)]
+    #[clap(long = "allow", short = 'A', num_args = 1..)]
     pub(crate) allow_warnings: Option<AllowedWarnings>,
 
     /// Path to a directory to write the console's internal logs to.

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -188,6 +188,8 @@ impl KnownWarnings {
     }
 }
 /// An enum representing the types of warnings that are allowed.
+// Note: ValueEnum only supports unit variants, so we have to use a custom
+// parser for this.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub(crate) enum AllowedWarnings {
     /// Represents the case where all warnings are allowed.

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -66,14 +66,12 @@ async fn main() -> color_eyre::Result<()> {
     // A channel to send the task details update stream (no need to keep outdated details in the memory)
     let (details_tx, mut details_rx) = mpsc::channel::<TaskDetails>(2);
     let warnings = match args.allow_warnings {
-        Some(allow_warnings) => match allow_warnings {
-            AllowedWarnings::All => vec![],
-            AllowedWarnings::Some(allow_warnings) => args
-                .warnings
-                .iter()
-                .filter(|lint| !allow_warnings.contains(lint))
-                .collect::<Vec<_>>(),
-        },
+        Some(AllowedWarnings::All) => vec![],
+        Some(AllowedWarnings::Explicit(allow_warnings)) => args
+            .warnings
+            .iter()
+            .filter(|lint| !allow_warnings.contains(lint))
+            .collect::<Vec<_>>(),
         None => args.warnings.iter().collect::<Vec<_>>(),
     };
 

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -67,16 +67,19 @@ async fn main() -> color_eyre::Result<()> {
     let (details_tx, mut details_rx) = mpsc::channel::<TaskDetails>(2);
 
     let warnings = match args.allow_warnings {
-        AllowedWarnings::All => {
-            vec![]
-        }
-        AllowedWarnings::Some(allow_warnings) => {
-            let warnings = args
-                .warnings
-                .iter()
-                .filter(|lint| !allow_warnings.contains(lint));
-            warnings.collect()
-        }
+        Some(allow_warnings) => match allow_warnings {
+            AllowedWarnings::All => {
+                vec![]
+            }
+            AllowedWarnings::Some(allow_warnings) => {
+                let warnings = args
+                    .warnings
+                    .iter()
+                    .filter(|lint| !allow_warnings.contains(lint));
+                warnings.collect::<Vec<_>>()
+            }
+        },
+        None => args.warnings.iter().collect::<Vec<_>>(),
     };
 
     let mut state = State::default()

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -65,19 +65,14 @@ async fn main() -> color_eyre::Result<()> {
     let (update_tx, update_rx) = watch::channel(UpdateKind::Other);
     // A channel to send the task details update stream (no need to keep outdated details in the memory)
     let (details_tx, mut details_rx) = mpsc::channel::<TaskDetails>(2);
-
     let warnings = match args.allow_warnings {
         Some(allow_warnings) => match allow_warnings {
-            AllowedWarnings::All => {
-                vec![]
-            }
-            AllowedWarnings::Some(allow_warnings) => {
-                let warnings = args
-                    .warnings
-                    .iter()
-                    .filter(|lint| !allow_warnings.contains(lint));
-                warnings.collect::<Vec<_>>()
-            }
+            AllowedWarnings::All => vec![],
+            AllowedWarnings::Some(allow_warnings) => args
+                .warnings
+                .iter()
+                .filter(|lint| !allow_warnings.contains(lint))
+                .collect::<Vec<_>>(),
         },
         None => args.warnings.iter().collect::<Vec<_>>(),
     };

--- a/tokio-console/tests/cli-ui.stdout
+++ b/tokio-console/tests/cli-ui.stdout
@@ -65,6 +65,8 @@ Options:
           
           Each warning is specified by its name, which is one of:
           
+          * `all` -- Allow all warnings.
+          
           * `self-wakes` -- Warns when a task wakes itself more than a
           certain percentage of its total wakeups. Default percentage is
           50%.
@@ -73,6 +75,8 @@ Options:
           woken.
           
           * `never-yielded` -- Warns when a task has never yielded.
+          
+          [possible values: all, self-wakes, lost-waker, never-yielded]
 
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.

--- a/tokio-console/tests/cli-ui.stdout
+++ b/tokio-console/tests/cli-ui.stdout
@@ -58,6 +58,21 @@ Options:
           [default: self-wakes lost-waker never-yielded]
           [possible values: self-wakes, lost-waker, never-yielded]
 
+  -A, --allow <ALLOW_WARNINGS>...
+          Allow lint warnings.
+          
+          This is a comma-separated list of warnings to allow.
+          
+          Each warning is specified by its name, which is one of: *
+          `self-wakes` -- Warns when a task wakes itself more than a
+          certain percentage of its total wakeups. Default percentage is
+          50%. * `lost-waker` -- Warns when a task is dropped without
+          being woken.
+          
+          * `never-yielded` -- Warns when a task has never yielded.
+          
+          [possible values: self-wakes, lost-waker, never-yielded]
+
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.
           

--- a/tokio-console/tests/cli-ui.stdout
+++ b/tokio-console/tests/cli-ui.stdout
@@ -63,15 +63,16 @@ Options:
           
           This is a comma-separated list of warnings to allow.
           
-          Each warning is specified by its name, which is one of: *
-          `self-wakes` -- Warns when a task wakes itself more than a
+          Each warning is specified by its name, which is one of:
+          
+          * `self-wakes` -- Warns when a task wakes itself more than a
           certain percentage of its total wakeups. Default percentage is
-          50%. * `lost-waker` -- Warns when a task is dropped without
-          being woken.
+          50%.
+          
+          * `lost-waker` -- Warns when a task is dropped without being
+          woken.
           
           * `never-yielded` -- Warns when a task has never yielded.
-          
-          [possible values: self-wakes, lost-waker, never-yielded]
 
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.

--- a/tokio-console/tests/cli-ui.stdout
+++ b/tokio-console/tests/cli-ui.stdout
@@ -65,8 +65,6 @@ Options:
           
           Each warning is specified by its name, which is one of:
           
-          * `all` -- Allow all warnings.
-          
           * `self-wakes` -- Warns when a task wakes itself more than a
           certain percentage of its total wakeups. Default percentage is
           50%.
@@ -75,6 +73,8 @@ Options:
           woken.
           
           * `never-yielded` -- Warns when a task has never yielded.
+          
+          If this is set to `all`, all warnings are allowed.
           
           [possible values: all, self-wakes, lost-waker, never-yielded]
 


### PR DESCRIPTION
ref https://github.com/tokio-rs/console/pull/493#discussion_r1410610481

## Description
This pull request adds a new flag to `tokio-console` that allows warning lints to be selectively disabled. Additionally, you can use the value `all` to disable all warnings.
For example, you can use it like this: following manner: `cargo run -- --warn "self-wakes,lost-waker,never-yielded" --allow "self-wakes,never-yielded"`

## Explanation of Changes
Added an `AllowedWarnings` enum to the command line interface to represent the allowed warnings. `All` for disable all warnings. `Explicit` explicitly indicates which warning can be ignored.
