### PR TITLE
fix(console): lints trigger with non-async tasks

### DIFF
--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -354,6 +354,10 @@ impl Task {
         self.stats.last_wake > self.stats.last_poll_started
     }
 
+    pub(crate) fn is_blocking(&self) -> bool {
+        matches!(self.kind.as_ref(), "block_on" | "blocking")
+    }
+
     pub(crate) fn is_completed(&self) -> bool {
         self.stats.total.is_some()
     }

--- a/tokio-console/src/warnings.rs
+++ b/tokio-console/src/warnings.rs
@@ -148,6 +148,10 @@ impl Warn<Task> for SelfWakePercent {
     }
 
     fn check(&self, task: &Task) -> Warning {
+        // Don't fire warning for tasks that are not async
+        if task.is_blocking() {
+            return Warning::Ok;
+        }
         let self_wakes = task.self_wake_percent();
         if self_wakes > self.min_percent {
             Warning::Warn
@@ -174,6 +178,10 @@ impl Warn<Task> for LostWaker {
     }
 
     fn check(&self, task: &Task) -> Warning {
+        // Don't fire warning for tasks that are not async
+        if task.is_blocking() {
+            return Warning::Ok;
+        }
         if !task.is_completed()
             && task.waker_count() == 0
             && !task.is_running()
@@ -222,6 +230,10 @@ impl Warn<Task> for NeverYielded {
     }
 
     fn check(&self, task: &Task) -> Warning {
+        // Don't fire warning for tasks that are not async
+        if task.is_blocking() {
+            return Warning::Ok;
+        }
         // Don't fire warning for tasks that are waiting to run
         if task.state() != TaskState::Running {
             return Warning::Ok;


### PR DESCRIPTION
change existing lints to only trigger with tasks that are async; those are all except those with kind 'blocking' and 'block_on'

this commit fixes issue #516