### PR TITLE
fix(console): removes duplicate controls from async ops view

### DIFF
--- a/tokio-console/src/view/async_ops.rs
+++ b/tokio-console/src/view/async_ops.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     view::{
         self, bold,
-        controls::Controls,
         table::{TableList, TableListState},
         DUR_LEN, DUR_TABLE_PRECISION,
     },
@@ -195,24 +194,6 @@ impl TableList<9> for AsyncOpsTable {
             table_list_state.len()
         ))]);
 
-        let layout = layout::Layout::default()
-            .direction(layout::Direction::Vertical)
-            .margin(0);
-
-        let controls = Controls::new(view_controls(), &area, styles);
-        let chunks = layout
-            .constraints(
-                [
-                    layout::Constraint::Length(controls.height()),
-                    layout::Constraint::Max(area.height),
-                ]
-                .as_ref(),
-            )
-            .split(area);
-
-        let controls_area = chunks[0];
-        let async_ops_area = chunks[1];
-
         let attributes_width = layout::Constraint::Percentage(100);
         let widths = &[
             id_width.constraint(),
@@ -233,8 +214,7 @@ impl TableList<9> for AsyncOpsTable {
             .highlight_symbol(view::TABLE_HIGHLIGHT_SYMBOL)
             .highlight_style(Style::default().add_modifier(style::Modifier::BOLD));
 
-        frame.render_stateful_widget(table, async_ops_area, &mut table_list_state.table_state);
-        frame.render_widget(controls.into_widget(), controls_area);
+        frame.render_stateful_widget(table, area, &mut table_list_state.table_state);
 
         table_list_state
             .sorted_items


### PR DESCRIPTION
- Removes duplicate controls from the Async Ops view 

Original:
<img width="1501" alt="Screenshot 2024-02-12 at 7 49 43 PM" src="https://github.com/tokio-rs/console/assets/22461703/cb0bd330-a85e-4123-ab8c-7228a007063a">

Change:
<img width="1505" alt="Screenshot 2024-02-12 at 7 45 24 PM" src="https://github.com/tokio-rs/console/assets/22461703/8b72cf07-8390-449e-8714-b4b50f78c81b">

