### PR TITLE
test(subscriber): test with custom `self_wake()` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,24 +1722,22 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1784,13 +1782,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.90",
+ "syn 2.0.33",
 ]
 
 [[package]]

--- a/console-subscriber/tests/framework.rs
+++ b/console-subscriber/tests/framework.rs
@@ -63,7 +63,7 @@ fn self_wakes() {
         .match_default_name()
         .expect_self_wakes(1);
 
-    let future = async { task::yield_now().await };
+    let future = async { support::self_wake().await };
 
     assert_task(expected_task, future);
 }

--- a/console-subscriber/tests/wake.rs
+++ b/console-subscriber/tests/wake.rs
@@ -2,7 +2,7 @@ mod support;
 use std::time::Duration;
 
 use support::{assert_task, ExpectedTask};
-use tokio::{task, time::sleep};
+use tokio::time::sleep;
 
 #[test]
 fn sleep_wakes() {
@@ -41,7 +41,7 @@ fn self_wake() {
         .expect_self_wakes(1);
 
     let future = async {
-        task::yield_now().await;
+        support::self_wake().await;
     };
 
     assert_task(expected_task, future);


### PR DESCRIPTION
Part of the testing performed in the `console-subscriber` integration
tests is detecting self wakes. This relied upon the `yield_now()` from
Tokio.

However, the behavior of this function was changed in
tokio-rs/tokio#5223 and since Tokio 1.23 the wake doesn't occur in the
task that `yield_now()` is called from. This breaks the test when using
a newer version of Tokio.

This change replaces the use of `yield_now()` with a custom
`self_wake()` function that returns a future which does perform a self
wake (wakes the task from within itself before returning
`Poll::Pending`).

The same custom `self_wake()` is also included in the `app` example so
that it shows self wakes correctly.

Tokio has been updated to 1.28.2 in the lock file (the last with
compatible MSRV) so that this fix is tested.

Ref #512