### PR TITLE
fix(console): add pretty format for 'last woken' time 

### DIFF
--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -204,8 +204,9 @@ impl TaskView {
         if let Some(since) = task.since_wake(now) {
             wakeups.reserve(3);
             wakeups.push(Span::raw(", "));
-            wakeups.push(bold("last woken:"));
-            wakeups.push(Span::from(format!(" {:?} ago", since)));
+            wakeups.push(bold("last woken: "));
+            wakeups.push(styles.time_units(since, view::DUR_LIST_PRECISION, None));
+            wakeups.push(Span::raw(" ago"));
         }
 
         waker_stats.push(Spans::from(wakeups));


### PR DESCRIPTION
Closes #524

How it looks after the change:
![Screenshot 2024-02-23 at 9 08 50 PM](https://github.com/tokio-rs/console/assets/5137691/64fd8d1e-ca3d-431c-9db0-9a34c56535d8)
