### PR TITLE
docs(subscriber): fix typo in doc comment

### DIFF
--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -985,7 +985,7 @@ impl Server {
     /// #
     /// use console_subscriber::{ConsoleLayer, ServerParts};
     /// use tonic_web::GrpcWebLayer;
-    /// use tower_web::cors::{CorsLayer, AllowOrigin};
+    /// use tower_http::cors::{CorsLayer, AllowOrigin};
     /// use http::header::HeaderName;
     /// # use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
     /// # const DEFAULT_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);


### PR DESCRIPTION
```
error[E0433]: failed to resolve: use of undeclared crate or module `tower_web`
 --> console-subscriber/src/lib.rs:989:5
  |
9 | use tower_web::cors::{CorsLayer, AllowOrigin};
  |     ^^^^^^^^^ use of undeclared crate or module `tower_web`
  |
help: there is a crate or module with a similar name
  |
9 | use tonic_web::cors::{CorsLayer, AllowOrigin};
```
The actual struct is https://docs.rs/tower-http/latest/tower_http/cors/struct.CorsLayer.html