### PR TITLE
test(subscriber): remove very flaky tests

### DIFF
--- a/console-subscriber/tests/wake.rs
+++ b/console-subscriber/tests/wake.rs
@@ -5,35 +5,6 @@ use support::{assert_task, ExpectedTask};
 use tokio::time::sleep;
 
 #[test]
-fn sleep_wakes() {
-    let expected_task = ExpectedTask::default()
-        .match_default_name()
-        .expect_wakes(1)
-        .expect_self_wakes(0);
-
-    let future = async {
-        sleep(Duration::ZERO).await;
-    };
-
-    assert_task(expected_task, future);
-}
-
-#[test]
-fn double_sleep_wakes() {
-    let expected_task = ExpectedTask::default()
-        .match_default_name()
-        .expect_wakes(2)
-        .expect_self_wakes(0);
-
-    let future = async {
-        sleep(Duration::ZERO).await;
-        sleep(Duration::ZERO).await;
-    };
-
-    assert_task(expected_task, future);
-}
-
-#[test]
 fn self_wake() {
     let expected_task = ExpectedTask::default()
         .match_default_name()


### PR DESCRIPTION
We have identified that some of the `console-subscriber` integration
tests are flaky (#473). This appears to be a result of the following
issue in `tracing` tokio-rs/tracing#2743.

Flaky tests are really worse than no tests. So these tests will be
removed until the flakiness can be fixed.