### PR TITLE
chore: run clippy against all targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
 
 name: CI
@@ -48,8 +48,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        rust: [ stable ]
         include:
           # Make 1.64 MSRV, as it's Tonic 0.10's MSRV.
           - rust: 1.64.0
@@ -100,7 +100,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
   grpc_web:
     name: gRPC-web Example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
 
 name: CI
@@ -48,8 +48,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        rust: [ stable ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [stable]
         include:
           # Make 1.64 MSRV, as it's Tonic 0.10's MSRV.
           - rust: 1.64.0

--- a/console-subscriber/examples/app.rs
+++ b/console-subscriber/examples/app.rs
@@ -145,7 +145,6 @@ async fn no_yield(seconds: u64) {
 #[tracing::instrument]
 async fn spawn_blocking(seconds: u64) {
     loop {
-        let seconds = seconds;
         _ = tokio::task::spawn_blocking(move || {
             std::thread::sleep(Duration::from_secs(seconds));
         })

--- a/console-subscriber/examples/app.rs
+++ b/console-subscriber/examples/app.rs
@@ -165,7 +165,7 @@ fn self_wake() -> impl Future<Output = ()> {
             mut self: std::pin::Pin<&mut Self>,
             cx: &mut std::task::Context<'_>,
         ) -> Poll<Self::Output> {
-            if self.yielded == true {
+            if self.yielded {
                 return Poll::Ready(());
             }
 

--- a/console-subscriber/tests/spawn.rs
+++ b/console-subscriber/tests/spawn.rs
@@ -10,6 +10,8 @@ use support::{assert_tasks, spawn_named, ExpectedTask};
 /// spawned the child task). In this scenario, that would result in the parent
 /// having 3 polls counted, when it should really be 1.
 #[test]
+// The child task is polled explicitly to control its execution.
+// As a result, the clippy warning is ignored.
 #[allow(clippy::async_yields_async)]
 fn child_polls_dont_count_towards_parent_polls() {
     let expected_tasks = vec![

--- a/console-subscriber/tests/spawn.rs
+++ b/console-subscriber/tests/spawn.rs
@@ -10,6 +10,7 @@ use support::{assert_tasks, spawn_named, ExpectedTask};
 /// spawned the child task). In this scenario, that would result in the parent
 /// having 3 polls counted, when it should really be 1.
 #[test]
+#[allow(clippy::async_yields_async)]
 fn child_polls_dont_count_towards_parent_polls() {
     let expected_tasks = vec![
         ExpectedTask::default()

--- a/console-subscriber/tests/support/mod.rs
+++ b/console-subscriber/tests/support/mod.rs
@@ -60,7 +60,7 @@ where
     tokio::task::Builder::new()
         .name(name)
         .spawn(f)
-        .expect(&format!("spawning task '{name}' failed"))
+        .unwrap_or_else(|_| panic!("spawning task '{name}' failed"))
 }
 
 /// Wakes itself from within this task.

--- a/console-subscriber/tests/support/mod.rs
+++ b/console-subscriber/tests/support/mod.rs
@@ -91,7 +91,7 @@ pub(crate) fn self_wake() -> impl Future<Output = ()> {
             mut self: std::pin::Pin<&mut Self>,
             cx: &mut std::task::Context<'_>,
         ) -> Poll<Self::Output> {
-            if self.yielded == true {
+            if self.yielded {
                 return Poll::Ready(());
             }
 

--- a/console-subscriber/tests/support/subscriber.rs
+++ b/console-subscriber/tests/support/subscriber.rs
@@ -318,7 +318,7 @@ fn validate_expected_tasks(
     if failures.is_empty() {
         Ok(())
     } else {
-        Err(TestFailure { failures: failures })
+        Err(TestFailure { failures })
     }
 }
 

--- a/console-subscriber/tests/support/subscriber.rs
+++ b/console-subscriber/tests/support/subscriber.rs
@@ -322,6 +322,7 @@ fn validate_expected_tasks(
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn validate_expected_task(
     expected: &ExpectedTask,
     actual_tasks: &Vec<ActualTask>,

--- a/console-subscriber/tests/support/subscriber.rs
+++ b/console-subscriber/tests/support/subscriber.rs
@@ -23,9 +23,9 @@ struct TestFailure {
 
 impl fmt::Display for TestFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Task validation failed:\n")?;
+        writeln!(f, "Task validation failed:")?;
         for failure in &self.failures {
-            write!(f, " - {failure}\n")?;
+            writeln!(f, " - {failure}")?;
         }
         Ok(())
     }

--- a/console-subscriber/tests/support/task.rs
+++ b/console-subscriber/tests/support/task.rs
@@ -93,6 +93,7 @@ pub(crate) struct ExpectedTask {
     expect_polls: Option<u64>,
 }
 
+#[allow(clippy::result_large_err)]
 impl ExpectedTask {
     /// Returns whether or not an actual task matches this expected task.
     ///
@@ -110,7 +111,6 @@ impl ExpectedTask {
 
     /// Returns an error specifying that no match was found for this expected
     /// task.
-    #[allow(clippy::result_large_err)]
     pub(super) fn no_match_error(&self) -> Result<(), TaskValidationFailure> {
         Err(TaskValidationFailure {
             expected: self.clone(),
@@ -127,7 +127,6 @@ impl ExpectedTask {
     /// If all expectations are met, this method returns `Ok(())`. If any
     /// expectations are not met, then the first incorrect expectation will
     /// be returned as an `Err`.
-    #[allow(clippy::result_large_err)]
     pub(super) fn validate_actual_task(
         &self,
         actual_task: &ActualTask,

--- a/console-subscriber/tests/support/task.rs
+++ b/console-subscriber/tests/support/task.rs
@@ -84,25 +84,13 @@ impl fmt::Debug for TaskValidationFailure {
 /// This struct contains the fields that an expected task will attempt to match
 /// actual tasks on, as well as the expectations that will be used to validate
 /// which the actual task is as expected.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct ExpectedTask {
     match_name: Option<String>,
     expect_present: Option<bool>,
     expect_wakes: Option<u64>,
     expect_self_wakes: Option<u64>,
     expect_polls: Option<u64>,
-}
-
-impl Default for ExpectedTask {
-    fn default() -> Self {
-        Self {
-            match_name: None,
-            expect_present: None,
-            expect_wakes: None,
-            expect_self_wakes: None,
-            expect_polls: None,
-        }
-    }
 }
 
 impl ExpectedTask {

--- a/console-subscriber/tests/support/task.rs
+++ b/console-subscriber/tests/support/task.rs
@@ -122,6 +122,7 @@ impl ExpectedTask {
 
     /// Returns an error specifying that no match was found for this expected
     /// task.
+    #[allow(clippy::result_large_err)]
     pub(super) fn no_match_error(&self) -> Result<(), TaskValidationFailure> {
         Err(TaskValidationFailure {
             expected: self.clone(),
@@ -138,6 +139,7 @@ impl ExpectedTask {
     /// If all expectations are met, this method returns `Ok(())`. If any
     /// expectations are not met, then the first incorrect expectation will
     /// be returned as an `Err`.
+    #[allow(clippy::result_large_err)]
     pub(super) fn validate_actual_task(
         &self,
         actual_task: &ActualTask,

--- a/console-subscriber/tests/wake.rs
+++ b/console-subscriber/tests/wake.rs
@@ -1,8 +1,6 @@
 mod support;
-use std::time::Duration;
 
 use support::{assert_task, ExpectedTask};
-use tokio::time::sleep;
 
 #[test]
 fn self_wake() {


### PR DESCRIPTION
This would help us to check if there is any clippy warning in the tests.

I found it after https://github.com/tokio-rs/console/pull/544. There are some unused imports in our test code.

Use `cargo clippy --workspace --all-targets --no-deps -- -D warnings` to test all targes which include the test targets.