### PR TITLE
fix(subscriber): ignore metadata that is not a span or event

### DIFF
--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -530,7 +530,7 @@ where
 {
     fn register_callsite(&self, meta: &'static Metadata<'static>) -> subscriber::Interest {
         if !meta.is_span() && !meta.is_event() {
-            return subscriber::Interest::never()
+            return subscriber::Interest::never();
         }
 
         let dropped = match (meta.name(), meta.target()) {

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -529,6 +529,10 @@ where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
     fn register_callsite(&self, meta: &'static Metadata<'static>) -> subscriber::Interest {
+        if !meta.is_span() && !meta.is_event() {
+            return subscriber::Interest::never()
+        }
+
         let dropped = match (meta.name(), meta.target()) {
             ("runtime.spawn", _) | ("task", "tokio::task") => {
                 self.spawn_callsites.insert(meta);


### PR DESCRIPTION
As described in #553, there are parts of code that expects tracing `Metadata` to be of type `EVENT` or `SPAN`.

This PR ensure that any tracing metadata with a different type will be ignored instead of panicking when running in debug mode like [here](https://github.com/tokio-rs/console/blob/60bcf87537d414b21efbd84159207f9ecda5e914/console-api/src/common.rs#L48).