### PR TITLE
fix: handle Windows path correctly

### DIFF
--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -511,10 +511,8 @@ fn truncate_registry_path(s: String) -> String {
 
     static REGEX: OnceCell<Regex> = OnceCell::new();
     let regex = REGEX.get_or_init(|| {
-        Regex::new(
-            r".*(/|\\)\.cargo(/|\\)(registry(/|\\)src(/|\\)[^/\\]*(/|\\)|git(/|\\)checkouts(/|\\))",
-        )
-        .expect("failed to compile regex")
+        Regex::new(r".*[/\\]\.cargo[/\\](registry[/\\]src[/\\][^/\\]*[/\\]|git[/\\]checkouts[/\\])")
+            .expect("failed to compile regex")
     });
 
     let s = match regex.replace(&s, "<cargo>/") {

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -504,9 +504,18 @@ impl Attribute {
     }
 }
 
+// A naive way to determine if a path is a Windows path.
+// If the path has a drive letter and more backslashes than forward slashes, it's a Windows path.
 fn is_windows_path(path: &str) -> bool {
-    let re = regex::Regex::new(r"^[a-zA-Z]:\\").unwrap();
-    re.is_match(path)
+    use once_cell::sync::OnceCell;
+    use regex::Regex;
+
+    static REGEX: OnceCell<Regex> = OnceCell::new();
+    let regex = REGEX.get_or_init(|| Regex::new(r"^[a-zA-Z]:\\").expect("failed to compile regex"));
+    let has_drive_letter = regex.is_match(path);
+    let slash_count = path.find('/').iter().count();
+    let backslash_count = path.find('\\').iter().count();
+    has_drive_letter && backslash_count > slash_count
 }
 
 fn truncate_registry_path(s: String) -> String {

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -513,8 +513,8 @@ fn is_windows_path(path: &str) -> bool {
     static REGEX: OnceCell<Regex> = OnceCell::new();
     let regex = REGEX.get_or_init(|| Regex::new(r"^[a-zA-Z]:\\").expect("failed to compile regex"));
     let has_drive_letter = regex.is_match(path);
-    let slash_count = path.find('/').iter().count();
-    let backslash_count = path.find('\\').iter().count();
+    let slash_count = path.chars().filter(|&c| c == '/').count();
+    let backslash_count = path.chars().filter(|&c| c == '\\').count();
     has_drive_letter && backslash_count > slash_count
 }
 


### PR DESCRIPTION
fix https://github.com/tokio-rs/console/issues/550

We need to make truncate_registry_path can handle Windows path as well. Because tokio-console can connect to any server from different platforms, so we use the same path separator to have the same experience.

Some test snapshots:
local package: 
<img width="1919" alt="image" src="https://github.com/tokio-rs/console/assets/29879298/58d18099-bad4-4851-ad37-bb08e4cfa8e2">

crates.io package: 
<img width="1915" alt="image" src="https://github.com/tokio-rs/console/assets/29879298/999f5db8-abdb-4a4e-9e90-7dcc6bf7388e">
