### PR TITLE
chore: include tonic updates in release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,6 +290,8 @@ Must be one of the following:
 * **feat**: A new feature
 * **fix**: A bug fix
 * **docs**: Documentation only changes
+* **update**: A dependency update (when a core dependency, especially
+  `tonic`, gets a breaking update)
 * **style**: Changes that do not affect the meaning of the code
   (white-space, formatting, missing semi-colons, etc)
 * **refactor**: A code change that neither fixes a bug or adds a feature

--- a/cliff.toml
+++ b/cliff.toml
@@ -67,6 +67,7 @@ split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
   { pattern = '^(feat|fix|doc|perf)\((api|subscriber|console)\) ', replace = '${1}(${2}): '}, # fix missing colon after commit type
+  { pattern = '^chore: bump tonic', replace = 'update: bump tonic' }, # Upgrading tonic is a breaking change and hence, not a chore
   { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/tokio-rs/console/issues/${2}))"}, # replace issue numbers
 ]
 # regex for parsing and grouping commits
@@ -75,6 +76,7 @@ commit_parsers = [
   { message = "^fix", group = "Fixed" },
   { message = "^doc", group = "Documented" },
   { message = "^perf", group = "Performance" },
+  { message = "^update", group = "Updated" },
   { message = "^refactor", skip = true },
   { message = "^refac", skip = true },
   { message = "^style", skip = true },


### PR DESCRIPTION
In the past we have marked commits which update tonic as `chore`, which
excludes them from the release notes. However, when we update tonic to a
new (pre-1.0) major version, such as from 0.10 to 0.11, this is a
breaking change for both the `console-api` and the `console-subscriber`
crates. As such, it shouldn't be skipped.

This change adds a new commit type `update`, to use for updating
dependencies. It will have it's own section in the release notes. A
commit preprocessing rule has been added to the Git-Cliff config file to
change commit subjects from `chore: bump tonic` to `update: bump tonic`
so that they're caught in the new category (this will fix it for the
next release which includes upgrading tonic from 0.10 to 0.11).

The contributor guide has also been updated to mention this new commit
type.