### PR TITLE
fix: tidy Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-console"
-version = "0.2.0"
+version = "0.1.11"
 dependencies = [
  "clap",
  "clap_complete",


### PR DESCRIPTION
tokio-console would be 0.1.11.


Do we have any bugs in our release process?