### PR TITLE
Take care of `TOKIO_CONSOLE_BUFFER_CAPACITY` and set it on `Builder::with_default_env`

### DIFF
--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -333,6 +333,10 @@ impl Builder {
             self.recording_path = Some(path.into());
         }
 
+        if let Some(capacity) = usize_from_env("TOKIO_CONSOLE_BUFFER_CAPACITY") {
+            self.event_buffer_capacity = capacity;
+        }
+
         self
     }
 
@@ -761,6 +765,17 @@ fn duration_from_env(var_name: &str) -> Option<Duration> {
         Ok(dur) => Some(dur.into()),
         Err(e) => panic!(
             "failed to parse a duration from `{}={:?}`: {}",
+            var_name, var, e
+        ),
+    }
+}
+
+fn usize_from_env(var_name: &str) -> Option<usize> {
+    let var = std::env::var(var_name).ok()?;
+    match var.parse::<usize>() {
+        Ok(num) => Some(num),
+        Err(e) => panic!(
+            "failed to parse a usize from `{}={:?}`: {}",
             var_name, var, e
         ),
     }


### PR DESCRIPTION
When the recorded process spawns a lot of tasks and execute a lot of operations, a red message can be seen on the top of the console saying `dropped: 14319181 async_ops, 1601630 tasks, 634586 resources`. That means that the buffer is not sufficiently big to record these and someone in the tokio Discord advised to use the `TOKIO_CONSOLE_BUFFER_CAPACITY` variable to tune that buffer. Turns out it was not a thing, so this pr adds it.