### PR TITLE
fix(console): avoid crash when accessing selected item

### DIFF
--- a/tokio-console/src/view/mod.rs
+++ b/tokio-console/src/view/mod.rs
@@ -132,14 +132,12 @@ impl View {
                 // mutate the currently selected view.
                 match event {
                     key!(Enter) => {
-                        if let Some(task_weak) = self.tasks_list.selected_item() {
-                            if let Some(task) = task_weak.upgrade() {
-                                update_kind = UpdateKind::SelectTask(task.borrow().span_id());
-                                self.state = TaskInstance(self::task::TaskView::new(
-                                    task,
-                                    state.task_details_ref(),
-                                ));
-                            }
+                        if let Some(task) = self.tasks_list.selected_item() {
+                            update_kind = UpdateKind::SelectTask(task.borrow().span_id());
+                            self.state = TaskInstance(self::task::TaskView::new(
+                                task,
+                                state.task_details_ref(),
+                            ));
                         }
                     }
                     _ => {
@@ -151,12 +149,9 @@ impl View {
             ResourcesList => {
                 match event {
                     key!(Enter) => {
-                        if let Some(res_weak) = self.resources_list.selected_item() {
-                            if let Some(res) = res_weak.upgrade() {
-                                update_kind = UpdateKind::SelectResource(res.borrow().span_id());
-                                self.state =
-                                    ResourceInstance(self::resource::ResourceView::new(res));
-                            }
+                        if let Some(res) = self.resources_list.selected_item() {
+                            update_kind = UpdateKind::SelectResource(res.borrow().span_id());
+                            self.state = ResourceInstance(self::resource::ResourceView::new(res));
                         }
                     }
                     _ => {
@@ -174,24 +169,21 @@ impl View {
                         update_kind = UpdateKind::Other;
                     }
                     key!(Enter) => {
-                        if let Some(op_weak) = view.async_ops_table.selected_item() {
-                            if let Some(op) = op_weak.upgrade() {
-                                if let Some(task_id) = op.borrow().task_id() {
-                                    let task = self
-                                        .tasks_list
-                                        .sorted_items
-                                        .iter()
-                                        .filter_map(|i| i.upgrade())
-                                        .find(|t| task_id == t.borrow().id());
+                        if let Some(op) = view.async_ops_table.selected_item() {
+                            if let Some(task_id) = op.borrow().task_id() {
+                                let task = self
+                                    .tasks_list
+                                    .sorted_items
+                                    .iter()
+                                    .filter_map(|i| i.upgrade())
+                                    .find(|t| task_id == t.borrow().id());
 
-                                    if let Some(task) = task {
-                                        update_kind =
-                                            UpdateKind::SelectTask(task.borrow().span_id());
-                                        self.state = TaskInstance(self::task::TaskView::new(
-                                            task,
-                                            state.task_details_ref(),
-                                        ));
-                                    }
+                                if let Some(task) = task {
+                                    update_kind = UpdateKind::SelectTask(task.borrow().span_id());
+                                    self.state = TaskInstance(self::task::TaskView::new(
+                                        task,
+                                        state.task_details_ref(),
+                                    ));
                                 }
                             }
                         }

--- a/tokio-console/src/view/mod.rs
+++ b/tokio-console/src/view/mod.rs
@@ -132,12 +132,14 @@ impl View {
                 // mutate the currently selected view.
                 match event {
                     key!(Enter) => {
-                        if let Some(task) = self.tasks_list.selected_item().upgrade() {
-                            update_kind = UpdateKind::SelectTask(task.borrow().span_id());
-                            self.state = TaskInstance(self::task::TaskView::new(
-                                task,
-                                state.task_details_ref(),
-                            ));
+                        if let Some(task_weak) = self.tasks_list.selected_item() {
+                            if let Some(task) = task_weak.upgrade() {
+                                update_kind = UpdateKind::SelectTask(task.borrow().span_id());
+                                self.state = TaskInstance(self::task::TaskView::new(
+                                    task,
+                                    state.task_details_ref(),
+                                ));
+                            }
                         }
                     }
                     _ => {
@@ -149,9 +151,12 @@ impl View {
             ResourcesList => {
                 match event {
                     key!(Enter) => {
-                        if let Some(res) = self.resources_list.selected_item().upgrade() {
-                            update_kind = UpdateKind::SelectResource(res.borrow().span_id());
-                            self.state = ResourceInstance(self::resource::ResourceView::new(res));
+                        if let Some(res_weak) = self.resources_list.selected_item() {
+                            if let Some(res) = res_weak.upgrade() {
+                                update_kind = UpdateKind::SelectResource(res.borrow().span_id());
+                                self.state =
+                                    ResourceInstance(self::resource::ResourceView::new(res));
+                            }
                         }
                     }
                     _ => {
@@ -169,21 +174,24 @@ impl View {
                         update_kind = UpdateKind::Other;
                     }
                     key!(Enter) => {
-                        if let Some(op) = view.async_ops_table.selected_item().upgrade() {
-                            if let Some(task_id) = op.borrow().task_id() {
-                                let task = self
-                                    .tasks_list
-                                    .sorted_items
-                                    .iter()
-                                    .filter_map(|i| i.upgrade())
-                                    .find(|t| task_id == t.borrow().id());
+                        if let Some(op_weak) = view.async_ops_table.selected_item() {
+                            if let Some(op) = op_weak.upgrade() {
+                                if let Some(task_id) = op.borrow().task_id() {
+                                    let task = self
+                                        .tasks_list
+                                        .sorted_items
+                                        .iter()
+                                        .filter_map(|i| i.upgrade())
+                                        .find(|t| task_id == t.borrow().id());
 
-                                if let Some(task) = task {
-                                    update_kind = UpdateKind::SelectTask(task.borrow().span_id());
-                                    self.state = TaskInstance(self::task::TaskView::new(
-                                        task,
-                                        state.task_details_ref(),
-                                    ));
+                                    if let Some(task) = task {
+                                        update_kind =
+                                            UpdateKind::SelectTask(task.borrow().span_id());
+                                        self.state = TaskInstance(self::task::TaskView::new(
+                                            task,
+                                            state.task_details_ref(),
+                                        ));
+                                    }
                                 }
                             }
                         }

--- a/tokio-console/src/view/table.rs
+++ b/tokio-console/src/view/table.rs
@@ -154,18 +154,19 @@ impl<T: TableList<N>, const N: usize> TableListState<T, N> {
         self.scroll_with(|_, _| 0)
     }
 
-    pub(in crate::view) fn selected_item(&self) -> Weak<RefCell<T::Row>> {
-        self.table_state
-            .selected()
-            .map(|i| {
-                let selected = if self.sort_descending {
-                    i
+    pub(in crate::view) fn selected_item(&self) -> Option<Weak<RefCell<T::Row>>> {
+        self.table_state.selected().and_then(|i| {
+            if self.sort_descending {
+                if i < self.sorted_items.len() {
+                    Some(self.sorted_items[i].clone())
                 } else {
-                    self.sorted_items.len() - i - 1
-                };
-                self.sorted_items[selected].clone()
-            })
-            .unwrap_or_default()
+                    None
+                }
+            } else {
+                let adjusted_index = self.sorted_items.len().checked_sub(i + 1)?;
+                self.sorted_items.get(adjusted_index).cloned()
+            }
+        })
     }
 
     pub(in crate::view) fn render(

--- a/tokio-console/src/view/table.rs
+++ b/tokio-console/src/view/table.rs
@@ -13,7 +13,7 @@ use ratatui::{
 use std::convert::TryFrom;
 
 use std::cell::RefCell;
-use std::rc::Weak;
+use std::rc::{Rc, Weak};
 
 pub(crate) trait TableList<const N: usize> {
     type Row;
@@ -154,19 +154,22 @@ impl<T: TableList<N>, const N: usize> TableListState<T, N> {
         self.scroll_with(|_, _| 0)
     }
 
-    pub(in crate::view) fn selected_item(&self) -> Option<Weak<RefCell<T::Row>>> {
-        self.table_state.selected().and_then(|i| {
-            if self.sort_descending {
-                if i < self.sorted_items.len() {
-                    Some(self.sorted_items[i].clone())
+    pub(in crate::view) fn selected_item(&self) -> Option<Rc<RefCell<T::Row>>> {
+        self.table_state
+            .selected()
+            .and_then(|i| {
+                if self.sort_descending {
+                    if i < self.sorted_items.len() {
+                        Some(self.sorted_items[i].clone())
+                    } else {
+                        None
+                    }
                 } else {
-                    None
+                    let adjusted_index = self.sorted_items.len().checked_sub(i + 1)?;
+                    self.sorted_items.get(adjusted_index).cloned()
                 }
-            } else {
-                let adjusted_index = self.sorted_items.len().checked_sub(i + 1)?;
-                self.sorted_items.get(adjusted_index).cloned()
-            }
-        })
+            })
+            .and_then(|weak| weak.upgrade())
     }
 
     pub(in crate::view) fn render(


### PR DESCRIPTION
We should check the length before using the index to access it.

close https://github.com/tokio-rs/console/issues/565

Test locally:

https://github.com/tokio-rs/console/assets/29879298/5c4fd5da-e1c7-490b-bd67-1257972076d3

But it is difficult to view it, you can try it by following the steps from the issue.