### PR TITLE
refactor: use dep syntax to avoid crate rename

### DIFF
--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -26,9 +26,9 @@ keywords = [
 
 [features]
 default = ["env-filter"]
-parking_lot = ["parking_lot_crate", "tracing-subscriber/parking_lot"]
+parking_lot = ["dep:parking_lot", "tracing-subscriber/parking_lot"]
 env-filter = ["tracing-subscriber/env-filter"]
-grpc-web = ["tonic-web"]
+grpc-web = ["dep:tonic-web"]
 
 [dependencies]
 crossbeam-utils = "0.8.7"
@@ -42,9 +42,7 @@ tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["fmt", "registry"] }
 futures-task = { version = "0.3", default-features = false }
 hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
-# The parking_lot dependency is renamed, because we want our `parking_lot`
-# feature to also enable `tracing-subscriber`'s parking_lot feature flag.
-parking_lot_crate = { package = "parking_lot", version = "0.12", optional = true }
+parking_lot = { version = "0.12", optional = true }
 humantime = "2.1.0"
 prost = "0.12"
 prost-types = "0.12.0"

--- a/console-subscriber/src/sync.rs
+++ b/console-subscriber/src/sync.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code, unused_imports)]
 
 #[cfg(feature = "parking_lot")]
-pub(crate) use parking_lot_crate::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub(crate) use parking_lot::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[cfg(not(feature = "parking_lot"))]
 pub(crate) use self::std_impl::*;


### PR DESCRIPTION
Use the `dep:` syntax to explicitly define `parking_lot` as dependency in the feature definition, added in Rust 1.60. This allows to avoid the rename of `parking_lot` to `parking_lot_crate` internally.
