### PR TITLE
chore(deps): bump ahash from 0.8.6 to 0.8.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1191,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "option-ext"


### PR DESCRIPTION
close https://github.com/tokio-rs/console/issues/569

Just `cargo update -p ahash --precise 0.8.11`.

```sh
console on  main [$⇡] via 🦀 v1.81.0-nightly 
❯ cargo update -p ahash --precise 0.8.11
    Updating crates.io index
    Updating ahash v0.8.6 -> v0.8.11
    Updating once_cell v1.17.1 -> v1.19.0
note: pass `--verbose` to see 184 unchanged dependencies behind latest
```