### PR TITLE
feat: add the WatchState API

### DIFF
--- a/console-api/proto/instrument.proto
+++ b/console-api/proto/instrument.proto
@@ -14,6 +14,8 @@ service Instrument {
     rpc WatchUpdates(InstrumentRequest) returns (stream Update) {}
     // Produces a stream of updates describing the activity of a specific task.
     rpc WatchTaskDetails(TaskDetailsRequest) returns (stream tasks.TaskDetails) {}
+    // Produces a stream of state of the aggregator.
+    rpc WatchState(StateRequest) returns (stream State) {}
     // Registers that the console observer wants to pause the stream.
     rpc Pause(PauseRequest) returns (PauseResponse) {}
     // Registers that the console observer wants to resume the stream.
@@ -70,6 +72,23 @@ message Update {
 
     // Any new span metadata that was registered since the last update.
     common.RegisterMetadata new_metadata = 5;
+}
+
+// StateRequest requests the current state of the aggregator.
+message StateRequest {
+}
+
+// State carries the current state of the aggregator.
+message State {
+    Temporality temporality = 1;
+}
+
+// The time "state" of the aggregator.
+enum Temporality {
+    // The aggregator is currently live.
+    LIVE = 0;
+    // The aggregator is currently paused.
+    PAUSED = 1;
 }
 
 // `PauseResponse` is the value returned after a pause request.

--- a/console-api/src/generated/rs.tokio.console.instrument.rs
+++ b/console-api/src/generated/rs.tokio.console.instrument.rs
@@ -51,11 +51,9 @@ pub struct Update {
     pub new_metadata: ::core::option::Option<super::common::RegisterMetadata>,
 }
 /// StateRequest requests the current state of the aggregator.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct StateRequest {}
 /// State carries the current state of the aggregator.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct State {
     #[prost(enumeration = "Temporality", tag = "1")]
@@ -83,8 +81,8 @@ impl Temporality {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            Temporality::Live => "LIVE",
-            Temporality::Paused => "PAUSED",
+            Self::Live => "LIVE",
+            Self::Paused => "PAUSED",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -260,8 +258,7 @@ pub mod instrument_client {
                 .ready()
                 .await
                 .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
+                    tonic::Status::unknown(
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
@@ -377,7 +374,7 @@ pub mod instrument_server {
         type WatchStateStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::State, tonic::Status>,
             >
-            + Send
+            + std::marker::Send
             + 'static;
         /// Produces a stream of state of the aggregator.
         async fn watch_state(

--- a/console-subscriber/examples/grpc_web/app/src/gen/instrument_connect.ts
+++ b/console-subscriber/examples/grpc_web/app/src/gen/instrument_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { InstrumentRequest, PauseRequest, PauseResponse, ResumeRequest, ResumeResponse, TaskDetailsRequest, Update } from "./instrument_pb.js";
+import { InstrumentRequest, PauseRequest, PauseResponse, ResumeRequest, ResumeResponse, State, StateRequest, TaskDetailsRequest, Update } from "./instrument_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 import { TaskDetails } from "./tasks_pb.js";
 
@@ -35,6 +35,17 @@ export const Instrument = {
       name: "WatchTaskDetails",
       I: TaskDetailsRequest,
       O: TaskDetails,
+      kind: MethodKind.ServerStreaming,
+    },
+    /**
+     * Produces a stream of state of the aggregator.
+     *
+     * @generated from rpc rs.tokio.console.instrument.Instrument.WatchState
+     */
+    watchState: {
+      name: "WatchState",
+      I: StateRequest,
+      O: State,
       kind: MethodKind.ServerStreaming,
     },
     /**

--- a/console-subscriber/examples/grpc_web/app/src/gen/instrument_pb.ts
+++ b/console-subscriber/examples/grpc_web/app/src/gen/instrument_pb.ts
@@ -11,6 +11,32 @@ import { ResourceUpdate } from "./resources_pb.js";
 import { AsyncOpUpdate } from "./async_ops_pb.js";
 
 /**
+ * The time "state" of the aggregator.
+ *
+ * @generated from enum rs.tokio.console.instrument.Temporality
+ */
+export enum Temporality {
+  /**
+   * The aggregator is currently live.
+   *
+   * @generated from enum value: LIVE = 0;
+   */
+  LIVE = 0,
+
+  /**
+   * The aggregator is currently paused.
+   *
+   * @generated from enum value: PAUSED = 1;
+   */
+  PAUSED = 1,
+}
+// Retrieve enum metadata with: proto3.getEnumType(Temporality)
+proto3.util.setEnumType(Temporality, "rs.tokio.console.instrument.Temporality", [
+  { no: 0, name: "LIVE" },
+  { no: 1, name: "PAUSED" },
+]);
+
+/**
  * InstrumentRequest requests the stream of updates
  * to observe the async runtime state over time.
  *
@@ -236,6 +262,78 @@ export class Update extends Message<Update> {
 
   static equals(a: Update | PlainMessage<Update> | undefined, b: Update | PlainMessage<Update> | undefined): boolean {
     return proto3.util.equals(Update, a, b);
+  }
+}
+
+/**
+ * StateRequest requests the current state of the aggregator.
+ *
+ * @generated from message rs.tokio.console.instrument.StateRequest
+ */
+export class StateRequest extends Message<StateRequest> {
+  constructor(data?: PartialMessage<StateRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "rs.tokio.console.instrument.StateRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): StateRequest {
+    return new StateRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): StateRequest {
+    return new StateRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): StateRequest {
+    return new StateRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: StateRequest | PlainMessage<StateRequest> | undefined, b: StateRequest | PlainMessage<StateRequest> | undefined): boolean {
+    return proto3.util.equals(StateRequest, a, b);
+  }
+}
+
+/**
+ * State carries the current state of the aggregator.
+ *
+ * @generated from message rs.tokio.console.instrument.State
+ */
+export class State extends Message<State> {
+  /**
+   * @generated from field: rs.tokio.console.instrument.Temporality temporality = 1;
+   */
+  temporality = Temporality.LIVE;
+
+  constructor(data?: PartialMessage<State>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "rs.tokio.console.instrument.State";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "temporality", kind: "enum", T: proto3.getEnumType(Temporality) },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): State {
+    return new State().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): State {
+    return new State().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): State {
+    return new State().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: State | PlainMessage<State> | undefined, b: State | PlainMessage<State> | undefined): boolean {
+    return proto3.util.equals(State, a, b);
   }
 }
 

--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -89,7 +89,7 @@ pub struct Aggregator {
     poll_ops: Vec<proto::resources::PollOp>,
 
     /// The time "state" of the aggregator, such as paused or live.
-    temporality:  proto::instrument::Temporality,
+    temporality: proto::instrument::Temporality,
 
     /// Used to anchor monotonic timestamps to a base `SystemTime`, to produce a
     /// timestamp that can be sent over the wire.

--- a/console-subscriber/src/lib.rs
+++ b/console-subscriber/src/lib.rs
@@ -1252,10 +1252,13 @@ impl proto::instrument::instrument_server::Instrument for Server {
         &self,
         _req: tonic::Request<proto::instrument::StateRequest>,
     ) -> Result<tonic::Response<Self::WatchStateStream>, tonic::Status> {
-       let (stream_sender, stream_recv) = mpsc::channel(self.client_buffer);
-       self.subscribe.send(Command::WatchState(Watch(stream_sender))).await.map_err(|_| {
-            tonic::Status::internal("cannot get state, aggregation task is not running")
-        })?;
+        let (stream_sender, stream_recv) = mpsc::channel(self.client_buffer);
+        self.subscribe
+            .send(Command::WatchState(Watch(stream_sender)))
+            .await
+            .map_err(|_| {
+                tonic::Status::internal("cannot get state, aggregation task is not running")
+            })?;
         let stream = tokio_stream::wrappers::ReceiverStream::new(stream_recv);
         Ok(tonic::Response::new(stream))
     }

--- a/tokio-console/src/conn.rs
+++ b/tokio-console/src/conn.rs
@@ -37,6 +37,7 @@ enum State {
     Disconnected(Duration),
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Message {
     Update(Update),
     State(console_api::instrument::State),

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -134,7 +134,6 @@ async fn main() -> color_eyre::Result<()> {
                     }
                 }
             }
-
             details_update = details_rx.recv() => {
                 if let Some(details_update) = details_update {
                     state.update_task_details(details_update);

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -95,10 +95,8 @@ async fn main() -> color_eyre::Result<()> {
                 if input::is_space(&input) {
                     if state.is_paused() {
                         conn.resume().await;
-                        state.resume();
                     } else {
                         conn.pause().await;
-                        state.pause();
                     }
                 }
 

--- a/tokio-console/src/main.rs
+++ b/tokio-console/src/main.rs
@@ -124,9 +124,17 @@ async fn main() -> color_eyre::Result<()> {
                     _ => {}
                 }
             },
-            instrument_update = conn.next_update() => {
-                state.update(&view.styles, view.current_view(), instrument_update);
+            instrument_message = conn.next_message() => {
+                match instrument_message {
+                    conn::Message::Update(update) => {
+                        state.update(&view.styles, view.current_view(), update);
+                    },
+                    conn::Message::State(state_update) => {
+                        state.update_state(state_update);
+                    }
+                }
             }
+
             details_update = details_rx.recv() => {
                 if let Some(details_update) = details_update {
                     state.update_task_details(details_update);

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -34,7 +34,7 @@ pub(crate) type DetailsRef = Rc<RefCell<Option<Details>>>;
 pub(crate) struct State {
     metas: HashMap<u64, Metadata>,
     last_updated_at: Option<SystemTime>,
-    temporality: Temporality,
+    temporality: proto::instrument::Temporality,
     tasks_state: TasksState,
     resources_state: ResourcesState,
     async_ops_state: AsyncOpsState,
@@ -69,12 +69,6 @@ pub(crate) enum FieldValue {
     U64(u64),
     I64(i64),
     Debug(String),
-}
-
-#[derive(Debug)]
-enum Temporality {
-    Live,
-    Paused,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -169,6 +163,10 @@ impl State {
         }
     }
 
+    pub(crate) fn update_state(&mut self, state: proto::instrument::State) {
+        self.temporality = proto::instrument::Temporality::try_from(state.temporality).unwrap();
+    }
+
     pub(crate) fn retain_active(&mut self) {
         if self.is_paused() {
             return;
@@ -238,21 +236,15 @@ impl State {
     // temporality methods
 
     pub(crate) fn pause(&mut self) {
-        self.temporality = Temporality::Paused;
+        self.temporality = proto::instrument::Temporality::Paused;
     }
 
     pub(crate) fn resume(&mut self) {
-        self.temporality = Temporality::Live;
+        self.temporality = proto::instrument::Temporality::Live;
     }
 
     pub(crate) fn is_paused(&self) -> bool {
-        matches!(self.temporality, Temporality::Paused)
-    }
-}
-
-impl Default for Temporality {
-    fn default() -> Self {
-        Self::Live
+        matches!(self.temporality, proto::instrument::Temporality::Paused)
     }
 }
 

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -233,16 +233,6 @@ impl State {
         *self.current_task_details.borrow_mut() = None;
     }
 
-    // temporality methods
-
-    pub(crate) fn pause(&mut self) {
-        self.temporality = proto::instrument::Temporality::Paused;
-    }
-
-    pub(crate) fn resume(&mut self) {
-        self.temporality = proto::instrument::Temporality::Live;
-    }
-
     pub(crate) fn is_paused(&self) -> bool {
         matches!(self.temporality, proto::instrument::Temporality::Paused)
     }

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -163,10 +163,6 @@ impl State {
         }
     }
 
-    pub(crate) fn update_state(&mut self, state: proto::instrument::State) {
-        self.temporality = proto::instrument::Temporality::try_from(state.temporality).unwrap();
-    }
-
     pub(crate) fn retain_active(&mut self) {
         if self.is_paused() {
             return;
@@ -231,6 +227,12 @@ impl State {
 
     pub(crate) fn unset_task_details(&mut self) {
         *self.current_task_details.borrow_mut() = None;
+    }
+
+    // temporality methods
+
+    pub(crate) fn update_state(&mut self, state: proto::instrument::State) {
+        self.temporality = proto::instrument::Temporality::try_from(state.temporality).unwrap();
     }
 
     pub(crate) fn is_paused(&self) -> bool {


### PR DESCRIPTION
close https://github.com/tokio-rs/console/issues/551
close https://github.com/tokio-rs/console/pull/567

This pull request introduces a new stream API named "WatchState." Currently, it only provides the current temporality, which will enable clients to check if the server has been paused.

See more: https://github.com/tokio-rs/console/pull/567#discussion_r1694635301


https://github.com/user-attachments/assets/51bfb1cc-3f72-4acd-94bc-6cbefa729963


