### PR TITLE
feat(console): add large future lints

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ Options:
           
           * `never-yielded` -- Warns when a task has never yielded.
           
+          * `auto-boxed-future` -- Warnings when the future driving a
+          task was automatically boxed by the runtime because it was
+          large.
+          
           * `large-future` -- Warnings when the future driving a task
           occupies a large amount of stack space.
           
@@ -248,13 +252,17 @@ Options:
           
           * `never-yielded` -- Warns when a task has never yielded.
           
+          * `auto-boxed-future` -- Warnings when the future driving a
+          task was automatically boxed by the runtime because it was
+          large.
+          
           * `large-future` -- Warnings when the future driving a task
           occupies a large amount of stack space.
           
           If this is set to `all`, all warnings are allowed.
           
           [possible values: all, self-wakes, lost-waker, never-yielded,
-          large-future]
+          large-future, auto-boxed-future]
 
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.

--- a/README.md
+++ b/README.md
@@ -224,8 +224,13 @@ Options:
           
           * `never-yielded` -- Warns when a task has never yielded.
           
-          [default: self-wakes lost-waker never-yielded]
-          [possible values: self-wakes, lost-waker, never-yielded]
+          * `large-future` -- Warnings when the future driving a task
+          occupies a large amount of stack space.
+          
+          [default: self-wakes lost-waker never-yielded
+          auto-boxed-future large-future]
+          [possible values: self-wakes, lost-waker, never-yielded,
+          auto-boxed-future, large-future]
 
   -A, --allow <ALLOW_WARNINGS>...
           Allow lint warnings.
@@ -243,9 +248,13 @@ Options:
           
           * `never-yielded` -- Warns when a task has never yielded.
           
+          * `large-future` -- Warnings when the future driving a task
+          occupies a large amount of stack space.
+          
           If this is set to `all`, all warnings are allowed.
           
-          [possible values: all, self-wakes, lost-waker, never-yielded]
+          [possible values: all, self-wakes, lost-waker, never-yielded,
+          large-future]
 
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.

--- a/console-subscriber/README.md
+++ b/console-subscriber/README.md
@@ -130,6 +130,9 @@ Other instrumentation is added in later Tokio releases:
 
 * [Tokio v1.21.0] or later is required to use newest `task::Builder::spawn*` APIs.
 
+* [Tokio v1.41.0] (as yet unreleased) or later is required for task future sizes and the related
+  tokio-console lints `auto-boxed-future` and `large-future`.
+
 [Tokio v1.0.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.0.0
 [Tokio v1.7.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.7.0
 [Tokio v1.12.0]:https://github.com/tokio-rs/tokio/releases/tag/tokio-1.12.0
@@ -147,6 +150,7 @@ Other instrumentation is added in later Tokio releases:
 [init]: https://docs.rs/console-subscriber/latest/console_subscriber/fn.init.html
 [compile_time_filters]: https://docs.rs/tracing/latest/tracing/level_filters/index.html#compile-time-filters
 [Tokio v1.21.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.21.0
+[Tokio v1.41.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.41.0
 
 ### Adding the Console Subscriber
 

--- a/console-subscriber/examples/app.rs
+++ b/console-subscriber/examples/app.rs
@@ -51,6 +51,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     .spawn(spawn_blocking(5))
                     .unwrap();
             }
+            "large" => {
+                tokio::task::Builder::new()
+                    .name("pretty-big")
+                    // Below debug mode auto-boxing limit
+                    .spawn(large_future::<1024>())
+                    .unwrap();
+                tokio::task::Builder::new()
+                    .name("huge")
+                    // Larger than the release mode auto-boxing limit
+                    .spawn(large_future::<20_000>())
+                    .unwrap();
+                tokio::task::Builder::new()
+                    .name("huge-blocking-wait")
+                    // Larger than the release mode auto-boxing limit
+                    .spawn(large_blocking::<20_000>())
+                    .unwrap();
+            }
             "help" | "-h" => {
                 eprintln!("{}", HELP);
                 return Ok(());
@@ -150,6 +167,41 @@ async fn spawn_blocking(seconds: u64) {
         })
         .await;
     }
+}
+
+#[tracing::instrument]
+async fn large_future<const N: usize>() {
+    let mut numbers = [0_u8; N];
+
+    loop {
+        for idx in 0..N {
+            numbers[idx] = (idx % 256) as u8;
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            (0..=idx).for_each(|jdx| {
+                assert_eq!(numbers[jdx], (jdx % 256) as u8);
+            });
+        }
+    }
+}
+
+async fn large_blocking<const N: usize>() {
+    let numbers = [0_usize; N];
+
+    tokio::task::Builder::new()
+        .name("huge-blocking")
+        .spawn_blocking(move || {
+            let mut numbers = numbers;
+            loop {
+                for idx in 0..N {
+                    numbers[idx] = idx;
+                    std::thread::sleep(Duration::from_millis(100));
+                    (0..=idx).for_each(|jdx| {
+                        assert_eq!(numbers[jdx], jdx);
+                    });
+                }
+            }
+        })
+        .unwrap();
 }
 
 fn self_wake() -> impl Future<Output = ()> {

--- a/console-subscriber/examples/app.rs
+++ b/console-subscriber/examples/app.rs
@@ -12,6 +12,8 @@ OPTIONS:
     burn        Includes a (misbehaving) task that spins CPU with self-wakes
     coma        Includes a (misbehaving) task that forgets to register a waker
     noyield     Includes a (misbehaving) task that spawns tasks that never yield
+    blocking    Includes a blocking task that  (not misbehaving)
+    large       Includes tasks that are driven by futures that are larger than recommended
 "#;
 
 #[tokio::main]
@@ -62,11 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     // Larger than the release mode auto-boxing limit
                     .spawn(large_future::<20_000>())
                     .unwrap();
-                tokio::task::Builder::new()
-                    .name("huge-blocking-wait")
-                    // Larger than the release mode auto-boxing limit
-                    .spawn(large_blocking::<20_000>())
-                    .unwrap();
+                large_blocking::<20_000>();
             }
             "help" | "-h" => {
                 eprintln!("{}", HELP);
@@ -184,19 +182,20 @@ async fn large_future<const N: usize>() {
     }
 }
 
-async fn large_blocking<const N: usize>() {
-    let numbers = [0_usize; N];
+fn large_blocking<const N: usize>() {
+    let numbers = [0_u8; N];
 
     tokio::task::Builder::new()
         .name("huge-blocking")
         .spawn_blocking(move || {
             let mut numbers = numbers;
+
             loop {
                 for idx in 0..N {
-                    numbers[idx] = idx;
+                    numbers[idx] = (idx % 256) as u8;
                     std::thread::sleep(Duration::from_millis(100));
                     (0..=idx).for_each(|jdx| {
-                        assert_eq!(numbers[jdx], jdx);
+                        assert_eq!(numbers[jdx], (jdx % 256) as u8);
                     });
                 }
             }

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -62,3 +62,4 @@ hyper-util = { version = "0.1.6", features = ["tokio"] }
 
 [dev-dependencies]
 trycmd = "0.15.4"
+

--- a/tokio-console/console.example.toml
+++ b/tokio-console/console.example.toml
@@ -4,6 +4,8 @@ warnings = [
     'self-wakes',
     'lost-waker',
     'never-yielded',
+    'auto-boxed-future',
+    'large-future',
 ]
 log_directory = '/tmp/tokio-console/logs'
 retention = '6s'

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -63,6 +63,9 @@ pub struct Config {
     /// * `lost-waker` -- Warns when a task is dropped without being woken.
     ///
     /// * `never-yielded` -- Warns when a task has never yielded.
+    ///
+    /// * `large-future` -- Warnings when the future driving a task occupies a large amount of
+    ///                     stack space.
     #[clap(long = "warn", short = 'W', value_delimiter = ',', num_args = 1..)]
     #[clap(default_values_t = KnownWarnings::default_enabled_warnings())]
     pub(crate) warnings: Vec<KnownWarnings>,
@@ -80,9 +83,12 @@ pub struct Config {
     ///
     /// * `never-yielded` -- Warns when a task has never yielded.
     ///
+    /// * `large-future` -- Warnings when the future driving a task occupies a large amount of
+    ///                     stack space.
+    ///
     /// If this is set to `all`, all warnings are allowed.
     ///
-    /// [possible values: all, self-wakes, lost-waker, never-yielded]
+    /// [possible values: all, self-wakes, lost-waker, never-yielded, large-future]
     #[clap(long = "allow", short = 'A', num_args = 1..)]
     pub(crate) allow_warnings: Option<AllowedWarnings>,
 
@@ -143,6 +149,8 @@ pub(crate) enum KnownWarnings {
     SelfWakes,
     LostWaker,
     NeverYielded,
+    AutoBoxedFuture,
+    LargeFuture,
 }
 
 impl FromStr for KnownWarnings {
@@ -153,6 +161,8 @@ impl FromStr for KnownWarnings {
             "self-wakes" => Ok(KnownWarnings::SelfWakes),
             "lost-waker" => Ok(KnownWarnings::LostWaker),
             "never-yielded" => Ok(KnownWarnings::NeverYielded),
+            "auto-boxed-future" => Ok(KnownWarnings::AutoBoxedFuture),
+            "large-future" => Ok(KnownWarnings::LargeFuture),
             _ => Err(format!("unknown warning: {}", s)),
         }
     }
@@ -164,6 +174,8 @@ impl From<&KnownWarnings> for warnings::Linter<Task> {
             KnownWarnings::SelfWakes => warnings::Linter::new(warnings::SelfWakePercent::default()),
             KnownWarnings::LostWaker => warnings::Linter::new(warnings::LostWaker),
             KnownWarnings::NeverYielded => warnings::Linter::new(warnings::NeverYielded::default()),
+            KnownWarnings::AutoBoxedFuture => warnings::Linter::new(warnings::AutoBoxedFuture),
+            KnownWarnings::LargeFuture => warnings::Linter::new(warnings::LargeFuture::default()),
         }
     }
 }
@@ -174,6 +186,8 @@ impl fmt::Display for KnownWarnings {
             KnownWarnings::SelfWakes => write!(f, "self-wakes"),
             KnownWarnings::LostWaker => write!(f, "lost-waker"),
             KnownWarnings::NeverYielded => write!(f, "never-yielded"),
+            KnownWarnings::AutoBoxedFuture => write!(f, "auto-boxed-future"),
+            KnownWarnings::LargeFuture => write!(f, "large-future"),
         }
     }
 }
@@ -184,6 +198,8 @@ impl KnownWarnings {
             KnownWarnings::SelfWakes,
             KnownWarnings::LostWaker,
             KnownWarnings::NeverYielded,
+            KnownWarnings::AutoBoxedFuture,
+            KnownWarnings::LargeFuture,
         ]
     }
 }

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -64,6 +64,9 @@ pub struct Config {
     ///
     /// * `never-yielded` -- Warns when a task has never yielded.
     ///
+    /// * `auto-boxed-future` -- Warnings when the future driving a task was automatically boxed by
+    ///                          the runtime because it was large.
+    ///
     /// * `large-future` -- Warnings when the future driving a task occupies a large amount of
     ///                     stack space.
     #[clap(long = "warn", short = 'W', value_delimiter = ',', num_args = 1..)]
@@ -82,6 +85,9 @@ pub struct Config {
     /// * `lost-waker` -- Warns when a task is dropped without being woken.
     ///
     /// * `never-yielded` -- Warns when a task has never yielded.
+    ///
+    /// * `auto-boxed-future` -- Warnings when the future driving a task was automatically boxed by
+    ///                          the runtime because it was large.
     ///
     /// * `large-future` -- Warnings when the future driving a task occupies a large amount of
     ///                     stack space.

--- a/tokio-console/src/config.rs
+++ b/tokio-console/src/config.rs
@@ -88,7 +88,7 @@ pub struct Config {
     ///
     /// If this is set to `all`, all warnings are allowed.
     ///
-    /// [possible values: all, self-wakes, lost-waker, never-yielded, large-future]
+    /// [possible values: all, self-wakes, lost-waker, never-yielded, large-future, auto-boxed-future]
     #[clap(long = "allow", short = 'A', num_args = 1..)]
     pub(crate) allow_warnings: Option<AllowedWarnings>,
 

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -277,6 +277,8 @@ impl Field {
     const KIND: &'static str = "kind";
     const NAME: &'static str = "task.name";
     const TASK_ID: &'static str = "task.id";
+    const SIZE_BYTES: &'static str = "size.bytes";
+    const ORIGINAL_SIZE_BYTES: &'static str = "original_size.bytes";
 
     /// Creates a new Field with a pre-interned `name` and a `FieldValue`.
     fn new(name: InternedStr, value: FieldValue) -> Self {

--- a/tokio-console/src/warnings.rs
+++ b/tokio-console/src/warnings.rs
@@ -290,7 +290,7 @@ impl Warn<Task> for AutoBoxedFuture {
             .size_bytes()
             .expect("warning should not trigger if size is None");
         format!(
-            "This task was auto-boxed by the runtime due to its size (originally \
+            "This task's future was auto-boxed by the runtime when spawning, due to its size (originally \
             {original_size} bytes, boxed size {boxed_size} bytes)",
         )
     }
@@ -307,7 +307,7 @@ impl LargeFuture {
     pub(crate) fn new(min_size: usize) -> Self {
         Self {
             min_size,
-            description: format!("tasks are large (threshold {} bytes)", min_size),
+            description: format!("tasks are {} bytes or larger", min_size),
         }
     }
 }

--- a/tokio-console/tests/cli-ui.stdout
+++ b/tokio-console/tests/cli-ui.stdout
@@ -53,8 +53,13 @@ Options:
           
           * `never-yielded` -- Warns when a task has never yielded.
           
-          [default: self-wakes lost-waker never-yielded]
-          [possible values: self-wakes, lost-waker, never-yielded]
+          * `large-future` -- Warnings when the future driving a task
+          occupies a large amount of stack space.
+          
+          [default: self-wakes lost-waker never-yielded
+          auto-boxed-future large-future]
+          [possible values: self-wakes, lost-waker, never-yielded,
+          auto-boxed-future, large-future]
 
   -A, --allow <ALLOW_WARNINGS>...
           Allow lint warnings.
@@ -72,9 +77,13 @@ Options:
           
           * `never-yielded` -- Warns when a task has never yielded.
           
+          * `large-future` -- Warnings when the future driving a task
+          occupies a large amount of stack space.
+          
           If this is set to `all`, all warnings are allowed.
           
-          [possible values: all, self-wakes, lost-waker, never-yielded]
+          [possible values: all, self-wakes, lost-waker, never-yielded,
+          large-future]
 
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.

--- a/tokio-console/tests/cli-ui.stdout
+++ b/tokio-console/tests/cli-ui.stdout
@@ -53,6 +53,10 @@ Options:
           
           * `never-yielded` -- Warns when a task has never yielded.
           
+          * `auto-boxed-future` -- Warnings when the future driving a
+          task was automatically boxed by the runtime because it was
+          large.
+          
           * `large-future` -- Warnings when the future driving a task
           occupies a large amount of stack space.
           
@@ -77,13 +81,17 @@ Options:
           
           * `never-yielded` -- Warns when a task has never yielded.
           
+          * `auto-boxed-future` -- Warnings when the future driving a
+          task was automatically boxed by the runtime because it was
+          large.
+          
           * `large-future` -- Warnings when the future driving a task
           occupies a large amount of stack space.
           
           If this is set to `all`, all warnings are allowed.
           
           [possible values: all, self-wakes, lost-waker, never-yielded,
-          large-future]
+          large-future, auto-boxed-future]
 
       --log-dir <LOG_DIRECTORY>
           Path to a directory to write the console's internal logs to.


### PR DESCRIPTION
In Tokio, the futures for tasks are stored on the stack unless they are
explicitly boxed. Having very large futures can be problematic as it can
cause a stack overflow.

This change makes use of new instrumentation in Tokio
(tokio-rs/tokio#6881) which includes the size of the future which drives
a task. The size isn't given its own column (we're running out of
horizontal space) and appears in the additional fields column. In the
case that a future was auto-boxed by Tokio, the original size of the
task will also be provided.

Two new lints have been added for large futures. The first will detect
auto-boxed futures and warn about them. The second will detect futures
which are large (over 1024 bytes by default), but have not been
auto-boxed by the runtime.

Since the new lints depend on the new instrumentation in Tokio, they
will only trigger if the instrumented application is running using
`tokio` 1.41.0 or later. The version is as yet, unreleased.

Both lints have been added to the default list.

## PR Notes

Here's a screenshot with the new lints triggered on tasks from the `app` example.

<img width="1161" alt="large_future_lints" src="https://github.com/user-attachments/assets/d678d5a2-70d7-4eed-92cc-00e3c4ccfb17">