### PR TITLE
fix(api): bump minimum version of tonic

### DIFF
--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -29,7 +29,7 @@ keywords = [
 transport = ["tonic/transport"]
 
 [dependencies]
-tonic = { version = "0.12", default-features = false, features = [
+tonic = { version = "0.12.3", default-features = false, features = [
     "prost",
     "codegen",
     "transport",


### PR DESCRIPTION
Change the minimum version of tonic from 0.12 to 0.12.3. This fixes compilation in downstream projects with old lock files, since the generated code now uses a constant only present in tonic 0.12.3.

Closes #592