### PR TITLE
chore: check minimal versions on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ env:
   RUSTUP_MAX_RETRIES: 10
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
+  # Pin a nightly version for minimal versions
+  rust_nightly: nightly-2024-05-05
 
 jobs:
   check:
@@ -41,6 +43,27 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run cargo check
         run: cargo check
+
+  minimal-versions:
+    name: minimal-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_nightly }}
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - uses: Swatinem/rust-cache@v2
+      - name: "check -Z direct-minimal-versions"
+        run: |
+          # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
+          # from determining minimal versions based on dev-dependencies.
+          cargo hack --remove-dev-deps --workspace
+          # Update Cargo.lock to minimal version dependencies.
+          cargo +${{ env.rust_nightly }} update -Z direct-minimal-versions
+          cargo check
 
   test_os:
     name: Tests on ${{ matrix.os }} with Rust ${{ matrix.rust }}

--- a/console-api/Cargo.toml
+++ b/console-api/Cargo.toml
@@ -34,13 +34,13 @@ tonic = { version = "0.12.3", default-features = false, features = [
     "codegen",
     "transport",
 ] }
-prost = "0.13.1"
-prost-types = "0.13.1"
-tracing-core = "0.1.17"
-futures-core = "0.3"
+prost = "0.13.3"
+prost-types = "0.13.3"
+tracing-core = "0.1.30"
+futures-core = "0.3.31"
 
 [dev-dependencies]
-tonic-build = { version = "0.12", default-features = false, features = [
+tonic-build = { version = "0.12.3", default-features = false, features = [
     "prost", "transport"
 ] }
 # explicit dep so we can get the version with fixed whitespace.

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -32,24 +32,24 @@ grpc-web = ["dep:tonic-web"]
 
 [dependencies]
 crossbeam-utils = "0.8.7"
-tokio = { version = "^1.21", features = ["sync", "time", "macros", "tracing"] }
-tokio-stream = { version = "0.1", features = ["net"] }
-thread_local = "1.1.3"
-console-api = { version = "0.8.1", path = "../console-api", features = ["transport"] }
-tonic = { version = "0.12", features = ["transport"] }
-tracing-core = "0.1.24"
-tracing = "0.1.26"
+tokio = { version = "1.34", features = ["sync", "time", "macros", "tracing"] }
+tokio-stream = { version = "0.1.16", features = ["net"] }
+thread_local = "1.1.4"
+console-api = { version = "0.8.0", path = "../console-api", features = ["transport"] }
+tonic = { version = "0.12.3", features = ["transport"] }
+tracing-core = "0.1.30"
+tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["fmt", "registry"] }
-futures-task = { version = "0.3", default-features = false }
-hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
-parking_lot = { version = "0.12", optional = true }
+futures-task = { version = "0.3.31", default-features = false }
+hdrhistogram = { version = "7.4.0", default-features = false, features = ["serialization"] }
+parking_lot = { version = "0.12.1", optional = true }
 humantime = "2.1.0"
-prost = "0.13.1"
-prost-types = "0.13.1"
+prost = "0.13.3"
+prost-types = "0.13.3"
 hyper-util = { version = "0.1.6", features = ["tokio"] }
 
 # Required for recording:
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1"
 crossbeam-channel = "0.5"
 
@@ -57,8 +57,8 @@ crossbeam-channel = "0.5"
 tonic-web = { version = "0.12", optional = true }
 
 [dev-dependencies]
-tokio = { version = "^1.21", features = ["full", "rt-multi-thread"] }
-tower = { version = "0.4", default-features = false }
+tokio = { version = "1.34", features = ["full", "rt-multi-thread"] }
+tower = { version = "0.4.12", default-features = false }
 futures = "0.3"
 http = "1.1"
 tower-http = { version = "0.5", features = ["cors"] }

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -36,26 +36,26 @@ eula = false
 console-api = { version = "0.8.1", path = "../console-api", features = ["transport"] }
 clap = { version = "~4.5.4", features = ["wrap_help", "cargo", "derive", "env"] }
 clap_complete = "~4.5.2"
-tokio = { version = "1", features = ["full", "rt-multi-thread"] }
-tonic = { version = "0.12", features = ["transport"] }
+tokio = { version = "1.34", features = ["full", "rt-multi-thread"] }
+tonic = { version = "0.12.3", features = ["transport"] }
 futures = "0.3"
 ratatui = { version = "0.26.2", default-features = false, features = ["crossterm"] }
 tower = "0.4.12"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3" }
+tracing = "0.1.35"
+tracing-subscriber = { version = "0.3.17" }
 tracing-journald = { version = "0.2", optional = true }
-prost-types = "0.13.1"
+prost-types = "0.13.3"
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 color-eyre = { version = "0.6", features = ["issue-url"] }
-hdrhistogram = { version = "7.3.0", default-features = false, features = ["serialization"] }
+hdrhistogram = { version = "7.4.0", default-features = false, features = ["serialization"] }
 # Keep this in sync with the version from `tonic`.
 # Because we inspect the error from tonic, we need to make sure that the
 # version of h2 we use is compatible with the version of tonic we use.
-h2 = "0.4"
-regex = "1.5"
-once_cell = "1.8"
+h2 = "0.4.6"
+regex = "1.11"
+once_cell = "1.17.1"
 humantime = "2.1.0"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
 toml = "0.5"
 dirs = "5"
 hyper-util = { version = "0.1.6", features = ["tokio"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,9 +7,9 @@ rust-version = "1.74.0"
 publish = false
 
 [dependencies]
-tonic-build = { version = "0.12", default-features = false, features = [
+tonic-build = { version = "0.12.3", default-features = false, features = [
     "prost", "transport"
 ] }
 clap = { version = "~4.5.4", features = ["derive"] }
 color-eyre = "0.6"
-regex = "1.11.0"
+regex = "1.11"


### PR DESCRIPTION
As reported in issue #592, in our release of `console-api` 0.8.1, we
specified that we required a tonic version of 0.12 in teh Cargo.toml
file. However, since we had generated Rust code with `tonic-build`
0.12.3, we had some code that was only present in `tonic` from 0.12.3
as well.

This error was fixed in #593.

However, this showed a gap in our CI testing, we don't test against
minimum versions of our dependencies to catch this kind of error.

This change adds a CI job to check the minimal versions of our direct
dependencies. We perform a cargo update with the `-Z
direct-minimal-versions` flag and then perform cargo check. This would
have caught the previous error and will catch any new ones of a similar
type.

One downside to this approach is that we must explicitly give a minimum
version for our direct dependencies that is equal to or greater than the
minimum version that any of of transitive dependencies specify for that
same crate. However this check is probably worth the annoyance.