### PR TITLE
refactor: apply `clippy::needless-lifetimes` suggestions

### DIFF
--- a/tokio-console/src/view/durations.rs
+++ b/tokio-console/src/view/durations.rs
@@ -40,7 +40,7 @@ pub(crate) struct Durations<'a> {
     percentiles_width: u16,
 }
 
-impl<'a> Widget for Durations<'a> {
+impl Widget for Durations<'_> {
     fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         // Only split the durations area in half if we're also drawing a
         // sparkline. We require UTF-8 to draw the sparkline and also enough width.

--- a/tokio-console/src/view/mini_histogram.rs
+++ b/tokio-console/src/view/mini_histogram.rs
@@ -44,7 +44,7 @@ pub(crate) struct HistogramMetadata {
     pub(crate) highest_outlier: Option<Duration>,
 }
 
-impl<'a> Default for MiniHistogram<'a> {
+impl Default for MiniHistogram<'_> {
     fn default() -> Self {
         MiniHistogram {
             block: None,
@@ -57,7 +57,7 @@ impl<'a> Default for MiniHistogram<'a> {
     }
 }
 
-impl<'a> Widget for MiniHistogram<'a> {
+impl Widget for MiniHistogram<'_> {
     fn render(mut self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         let inner_area = match self.block.take() {
             Some(b) => {

--- a/tokio-console/src/view/percentiles.rs
+++ b/tokio-console/src/view/percentiles.rs
@@ -21,7 +21,7 @@ pub(crate) struct Percentiles<'a> {
     title: &'a str,
 }
 
-impl<'a> Widget for Percentiles<'a> {
+impl Widget for Percentiles<'_> {
     fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         let inner = Paragraph::new(self.make_percentiles_inner())
             .block(self.styles.border_block().title(self.title));


### PR DESCRIPTION
See: https://github.com/tokio-rs/console/actions/runs/12277528296/job/34257115867?pr=602

I used `cargo clippy --workspace --all-targets --no-deps --fx` to fix it.