### PR TITLE
fix(console): add dynamic constraints layout in task details screen

### DIFF
--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -127,7 +127,7 @@ impl TaskView {
             )
         };
 
-        let stats_area = Layout::default()
+        let stats_area_check = Layout::default()
             .direction(layout::Direction::Horizontal)
             .constraints(
                 [
@@ -137,6 +137,51 @@ impl TaskView {
                 .as_ref(),
             )
             .split(stats_area);
+
+        let mut location_lines_vector: Vec<String> = vec![];
+        let title = "Location: ";
+        let location_max_width = stats_area_check[0].width as usize - 2 - title.len(); // NOTE: -2 for the border
+        let stats_area = if task.location().len() > location_max_width {
+            let max_width_stats_area = area.width - 45;
+            if max_width_stats_area < task.location().len() as u16 {
+                location_lines_vector = task
+                    .location()
+                    .to_string()
+                    .chars()
+                    .collect::<Vec<char>>()
+                    .chunks(max_width_stats_area as usize)
+                    .map(|chunk| chunk.iter().collect())
+                    .collect();
+
+                let area_needed_to_render_location = task.location().len() as u16;
+                Layout::default()
+                    .direction(layout::Direction::Horizontal)
+                    .constraints(
+                        [
+                            layout::Constraint::Min(area_needed_to_render_location + 15), //Note: 15 is the length of "| Location:     |"
+                            layout::Constraint::Min(32),
+                        ]
+                        .as_ref(),
+                    )
+                    .split(stats_area)
+            } else {
+                let area_needed_to_render_location = task.location().len() as u16;
+                location_lines_vector.push(task.location().to_string());
+                Layout::default()
+                    .direction(layout::Direction::Horizontal)
+                    .constraints(
+                        [
+                            layout::Constraint::Min(area_needed_to_render_location + 15), //Note: 15 is the length of "| Location:     |"
+                            layout::Constraint::Min(32),
+                        ]
+                        .as_ref(),
+                    )
+                    .split(stats_area)
+            }
+        } else {
+            location_lines_vector.push(task.location().to_string());
+            stats_area_check
+        };
 
         // Just preallocate capacity for ID, name, target, total, busy, and idle.
         let mut overview = Vec::with_capacity(8);
@@ -152,17 +197,13 @@ impl TaskView {
 
         overview.push(Line::from(vec![bold("Target: "), Span::raw(task.target())]));
 
-        let title = "Location: ";
-        let location_max_width = stats_area[0].width as usize - 2 - title.len(); // NOTE: -2 for the border
-        let location = if task.location().len() > location_max_width {
-            let ellipsis = styles.if_utf8("\u{2026}", "...");
-            let start = task.location().len() - location_max_width + ellipsis.chars().count();
-            format!("{}{}", ellipsis, &task.location()[start..])
-        } else {
-            task.location().to_string()
-        };
-
-        overview.push(Line::from(vec![bold(title), Span::raw(location)]));
+        let first_line = location_lines_vector[0].clone();
+        location_lines_vector.remove(0);
+        let location_vector = vec![bold(title), Span::raw(first_line)];
+        overview.push(Line::from(location_vector));
+        for line in location_lines_vector {
+            overview.push(Line::from(Span::raw(format!("    {}", line))));
+        }
 
         let total = task.total(now);
 
@@ -185,28 +226,37 @@ impl TaskView {
 
         let mut waker_stats = vec![Line::from(vec![
             bold("Current wakers: "),
-            Span::from(format!("{} (", task.waker_count())),
-            bold("clones: "),
-            Span::from(format!("{}, ", task.waker_clones())),
-            bold("drops: "),
-            Span::from(format!("{})", task.waker_drops())),
+            Span::from(format!("{} ", task.waker_count())),
         ])];
+        let waker_stats_clones = vec![
+            bold("  Clones: "),
+            Span::from(format!("{}, ", task.waker_clones())),
+        ];
 
-        let mut wakeups = vec![
+        let waker_stats_drops = vec![
+            bold("  Drops: "),
+            Span::from(format!("{}", task.waker_drops())),
+        ];
+
+        let wakeups = vec![
             bold("Woken: "),
             Span::from(format!("{} times", task.wakes())),
         ];
 
+        let mut last_woken_line = vec![];
+
         // If the task has been woken, add the time since wake to its stats as well.
         if let Some(since) = task.since_wake(now) {
-            wakeups.reserve(3);
-            wakeups.push(Span::raw(", "));
-            wakeups.push(bold("last woken: "));
-            wakeups.push(styles.time_units(since, view::DUR_LIST_PRECISION, None));
-            wakeups.push(Span::raw(" ago"));
+            last_woken_line.reserve(3);
+            last_woken_line.push(bold("Last woken: "));
+            last_woken_line.push(styles.time_units(since, view::DUR_LIST_PRECISION, None));
+            last_woken_line.push(Span::raw(" ago"));
         }
 
+        waker_stats.push(Line::from(waker_stats_clones));
+        waker_stats.push(Line::from(waker_stats_drops));
         waker_stats.push(Line::from(wakeups));
+        waker_stats.push(Line::from(last_woken_line));
 
         if task.self_wakes() > 0 {
             waker_stats.push(Line::from(vec![

--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -139,19 +139,12 @@ impl TaskView {
             )
         };
 
-        let stats_constraints = if location_lines_vector.len() > 1 {
-            let location_len = task.location().len() as u16;
-            [
-                // 15 is the length of "| Location:     |"
-                layout::Constraint::Min(location_len + 15),
-                layout::Constraint::Min(32),
-            ]
-        } else {
-            [
-                layout::Constraint::Percentage(50),
-                layout::Constraint::Percentage(50),
-            ]
-        };
+        let stats_constraints = [
+            // 15 is the length of "| Location:     |"
+            layout::Constraint::Min(task.location().len() as u16 + 15),
+            layout::Constraint::Min(32),
+        ];
+
         let stats_area = Layout::default()
             .direction(layout::Direction::Horizontal)
             .constraints(stats_constraints.as_ref())

--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -34,6 +34,7 @@ impl TaskView {
     pub(crate) fn update_input(&mut self, _event: input::Event) {
         // TODO :D
     }
+
     pub(crate) fn render(
         &mut self,
         styles: &view::Styles,
@@ -67,21 +68,9 @@ impl TaskView {
             })
             .collect();
 
-        let stats_area_check = Layout::default()
-            .direction(layout::Direction::Horizontal)
-            .constraints(
-                [
-                    layout::Constraint::Percentage(50),
-                    layout::Constraint::Percentage(50),
-                ]
-                .as_ref(),
-            )
-            .split(area);
-
         let location_heading = "Location: ";
-        let location_max_width = stats_area_check[0].width as usize - 2 - location_heading.len(); // NOTE: -2 for the border
-        let max_width_stats_area = area.width - 45;
-        let mut location_lines_vector: Vec<String> = task
+        let max_width_stats_area = area.width - 45; //NOTE: 45 is min width needed, this is a calculated number according to the string: 'Last woken: 75.831727ms ago' but with some more extra pixels.
+        let location_lines_vector: Vec<String> = task
             .location()
             .to_string()
             .chars()
@@ -89,7 +78,8 @@ impl TaskView {
             .chunks(max_width_stats_area as usize)
             .map(|chunk| chunk.iter().collect())
             .collect();
-        let no_of_lines_extra_required_to_accomadate_location = location_lines_vector.len() - 1;
+        let task_stats_height = 9 + location_lines_vector.len() as u16;
+        // Id, Name, Target, Location (multiple), total, busy, scheduled, and idle times + top/bottom borders
         let (
             controls_area,
             stats_area,
@@ -97,141 +87,75 @@ impl TaskView {
             scheduled_dur_area,
             fields_area,
             warnings_area,
-        ) = if task.location().len() > location_max_width {
-            if warnings.is_empty() {
-                let chunks = Layout::default()
-                    .direction(layout::Direction::Vertical)
-                    .constraints(
-                        [
-                            // controls
-                            layout::Constraint::Length(controls.height()),
-                            // task stats
-                            layout::Constraint::Length(
-                                10 + no_of_lines_extra_required_to_accomadate_location as u16,
-                            ),
-                            // poll duration
-                            layout::Constraint::Length(9),
-                            // scheduled duration
-                            layout::Constraint::Length(9),
-                            // fields
-                            layout::Constraint::Percentage(60),
-                        ]
-                        .as_ref(),
-                    )
-                    .split(area);
-                (chunks[0], chunks[1], chunks[2], chunks[3], chunks[4], None)
-            } else {
-                let chunks = Layout::default()
-                    .direction(layout::Direction::Vertical)
-                    .constraints(
-                        [
-                            // controls
-                            layout::Constraint::Length(controls.height()),
-                            // warnings (add 2 for top and bottom borders)
-                            layout::Constraint::Length(warnings.len() as u16 + 2),
-                            // task stats
-                            layout::Constraint::Length(
-                                10 + no_of_lines_extra_required_to_accomadate_location as u16,
-                            ),
-                            // poll duration
-                            layout::Constraint::Length(9),
-                            // scheduled duration
-                            layout::Constraint::Length(9),
-                            // fields
-                            layout::Constraint::Percentage(60),
-                        ]
-                        .as_ref(),
-                    )
-                    .split(area);
-
-                (
-                    chunks[0],
-                    chunks[2],
-                    chunks[3],
-                    chunks[4],
-                    chunks[5],
-                    Some(chunks[1]),
+        ) = if warnings.is_empty() {
+            let chunks = Layout::default()
+                .direction(layout::Direction::Vertical)
+                .constraints(
+                    [
+                        // controls
+                        layout::Constraint::Length(controls.height()),
+                        // task stats
+                        layout::Constraint::Length(task_stats_height),
+                        // poll duration
+                        layout::Constraint::Length(9),
+                        // scheduled duration
+                        layout::Constraint::Length(9),
+                        // fields
+                        layout::Constraint::Percentage(60),
+                    ]
+                    .as_ref(),
                 )
-            }
+                .split(area);
+            (chunks[0], chunks[1], chunks[2], chunks[3], chunks[4], None)
         } else {
-            if warnings.is_empty() {
-                let chunks = Layout::default()
-                    .direction(layout::Direction::Vertical)
-                    .constraints(
-                        [
-                            // controls
-                            layout::Constraint::Length(controls.height()),
-                            // task stats
-                            layout::Constraint::Length(10),
-                            // poll duration
-                            layout::Constraint::Length(9),
-                            // scheduled duration
-                            layout::Constraint::Length(9),
-                            // fields
-                            layout::Constraint::Percentage(60),
-                        ]
-                        .as_ref(),
-                    )
-                    .split(area);
-                (chunks[0], chunks[1], chunks[2], chunks[3], chunks[4], None)
-            } else {
-                let chunks = Layout::default()
-                    .direction(layout::Direction::Vertical)
-                    .constraints(
-                        [
-                            // controls
-                            layout::Constraint::Length(controls.height()),
-                            // warnings (add 2 for top and bottom borders)
-                            layout::Constraint::Length(warnings.len() as u16 + 2),
-                            // task stats
-                            layout::Constraint::Length(10),
-                            // poll duration
-                            layout::Constraint::Length(9),
-                            // scheduled duration
-                            layout::Constraint::Length(9),
-                            // fields
-                            layout::Constraint::Percentage(60),
-                        ]
-                        .as_ref(),
-                    )
-                    .split(area);
-
-                (
-                    chunks[0],
-                    chunks[2],
-                    chunks[3],
-                    chunks[4],
-                    chunks[5],
-                    Some(chunks[1]),
+            let chunks = Layout::default()
+                .direction(layout::Direction::Vertical)
+                .constraints(
+                    [
+                        // controls
+                        layout::Constraint::Length(controls.height()),
+                        // warnings (add 2 for top and bottom borders)
+                        layout::Constraint::Length(warnings.len() as u16 + 2),
+                        // task stats
+                        layout::Constraint::Length(task_stats_height),
+                        // poll duration
+                        layout::Constraint::Length(9),
+                        // scheduled duration
+                        layout::Constraint::Length(9),
+                        // fields
+                        layout::Constraint::Percentage(60),
+                    ]
+                    .as_ref(),
                 )
-            }
+                .split(area);
+
+            (
+                chunks[0],
+                chunks[2],
+                chunks[3],
+                chunks[4],
+                chunks[5],
+                Some(chunks[1]),
+            )
         };
 
-        let stats_area = if location_lines_vector.len() != 1 {
+        let stats_constraints = if location_lines_vector.len() > 1 {
             let area_needed_to_render_location = task.location().len() as u16;
-            Layout::default()
-                .direction(layout::Direction::Horizontal)
-                .constraints(
-                    [
-                        layout::Constraint::Min(area_needed_to_render_location + 15), //Note: 15 is the length of "| Location:     |"
-                        layout::Constraint::Min(32),
-                    ]
-                    .as_ref(),
-                )
-                .split(stats_area)
+            [
+                // 15 is the length of "| Location:     |"
+                layout::Constraint::Min(area_needed_to_render_location + 15),
+                layout::Constraint::Min(32),
+            ]
         } else {
-            Layout::default()
-                .direction(layout::Direction::Horizontal)
-                .constraints(
-                    [
-                        layout::Constraint::Percentage(50),
-                        layout::Constraint::Percentage(50),
-                    ]
-                    .as_ref(),
-                )
-                .split(stats_area)
-            // stats_area_check
+            [
+                layout::Constraint::Percentage(50),
+                layout::Constraint::Percentage(50),
+            ]
         };
+        let stats_area = Layout::default()
+            .direction(layout::Direction::Horizontal)
+            .constraints(stats_constraints.as_ref())
+            .split(stats_area);
 
         // Just preallocate capacity for ID, name, target, total, busy, and idle.
         let mut overview = Vec::with_capacity(8);
@@ -247,12 +171,11 @@ impl TaskView {
 
         overview.push(Line::from(vec![bold("Target: "), Span::raw(task.target())]));
 
-        let first_line = location_lines_vector[0].clone();
-        location_lines_vector.remove(0);
-        let location_vector = vec![bold(location_heading), Span::raw(first_line)];
+        let location_vector = vec![bold(location_heading), Span::raw(&location_lines_vector[0])];
         overview.push(Line::from(location_vector));
-        for line in location_lines_vector {
-            overview.push(Line::from(Span::raw(format!("    {}", line))));
+        for line in &location_lines_vector[1..] {
+            overview.push(Line::from(Span::raw(format!("          {}", line))));
+            //10 spaces to be precise due to the Length of  "Location: "
         }
 
         let total = task.total(now);

--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -34,7 +34,6 @@ impl TaskView {
     pub(crate) fn update_input(&mut self, _event: input::Event) {
         // TODO :D
     }
-
     pub(crate) fn render(
         &mut self,
         styles: &view::Styles,
@@ -68,65 +67,6 @@ impl TaskView {
             })
             .collect();
 
-        let (
-            controls_area,
-            stats_area,
-            poll_dur_area,
-            scheduled_dur_area,
-            fields_area,
-            warnings_area,
-        ) = if warnings.is_empty() {
-            let chunks = Layout::default()
-                .direction(layout::Direction::Vertical)
-                .constraints(
-                    [
-                        // controls
-                        layout::Constraint::Length(controls.height()),
-                        // task stats
-                        layout::Constraint::Length(10),
-                        // poll duration
-                        layout::Constraint::Length(9),
-                        // scheduled duration
-                        layout::Constraint::Length(9),
-                        // fields
-                        layout::Constraint::Percentage(60),
-                    ]
-                    .as_ref(),
-                )
-                .split(area);
-            (chunks[0], chunks[1], chunks[2], chunks[3], chunks[4], None)
-        } else {
-            let chunks = Layout::default()
-                .direction(layout::Direction::Vertical)
-                .constraints(
-                    [
-                        // controls
-                        layout::Constraint::Length(controls.height()),
-                        // warnings (add 2 for top and bottom borders)
-                        layout::Constraint::Length(warnings.len() as u16 + 2),
-                        // task stats
-                        layout::Constraint::Length(10),
-                        // poll duration
-                        layout::Constraint::Length(9),
-                        // scheduled duration
-                        layout::Constraint::Length(9),
-                        // fields
-                        layout::Constraint::Percentage(60),
-                    ]
-                    .as_ref(),
-                )
-                .split(area);
-
-            (
-                chunks[0],
-                chunks[2],
-                chunks[3],
-                chunks[4],
-                chunks[5],
-                Some(chunks[1]),
-            )
-        };
-
         let stats_area_check = Layout::default()
             .direction(layout::Direction::Horizontal)
             .constraints(
@@ -136,51 +76,161 @@ impl TaskView {
                 ]
                 .as_ref(),
             )
-            .split(stats_area);
+            .split(area);
 
-        let mut location_lines_vector: Vec<String> = vec![];
-        let title = "Location: ";
-        let location_max_width = stats_area_check[0].width as usize - 2 - title.len(); // NOTE: -2 for the border
-        let stats_area = if task.location().len() > location_max_width {
-            let max_width_stats_area = area.width - 45;
-            if max_width_stats_area < task.location().len() as u16 {
-                location_lines_vector = task
-                    .location()
-                    .to_string()
-                    .chars()
-                    .collect::<Vec<char>>()
-                    .chunks(max_width_stats_area as usize)
-                    .map(|chunk| chunk.iter().collect())
-                    .collect();
-
-                let area_needed_to_render_location = task.location().len() as u16;
-                Layout::default()
-                    .direction(layout::Direction::Horizontal)
+        let location_heading = "Location: ";
+        let location_max_width = stats_area_check[0].width as usize - 2 - location_heading.len(); // NOTE: -2 for the border
+        let max_width_stats_area = area.width - 45;
+        let mut location_lines_vector: Vec<String> = task
+            .location()
+            .to_string()
+            .chars()
+            .collect::<Vec<char>>()
+            .chunks(max_width_stats_area as usize)
+            .map(|chunk| chunk.iter().collect())
+            .collect();
+        let no_of_lines_extra_required_to_accomadate_location = location_lines_vector.len() - 1;
+        let (
+            controls_area,
+            stats_area,
+            poll_dur_area,
+            scheduled_dur_area,
+            fields_area,
+            warnings_area,
+        ) = if task.location().len() > location_max_width {
+            if warnings.is_empty() {
+                let chunks = Layout::default()
+                    .direction(layout::Direction::Vertical)
                     .constraints(
                         [
-                            layout::Constraint::Min(area_needed_to_render_location + 15), //Note: 15 is the length of "| Location:     |"
-                            layout::Constraint::Min(32),
+                            // controls
+                            layout::Constraint::Length(controls.height()),
+                            // task stats
+                            layout::Constraint::Length(
+                                10 + no_of_lines_extra_required_to_accomadate_location as u16,
+                            ),
+                            // poll duration
+                            layout::Constraint::Length(9),
+                            // scheduled duration
+                            layout::Constraint::Length(9),
+                            // fields
+                            layout::Constraint::Percentage(60),
                         ]
                         .as_ref(),
                     )
-                    .split(stats_area)
+                    .split(area);
+                (chunks[0], chunks[1], chunks[2], chunks[3], chunks[4], None)
             } else {
-                let area_needed_to_render_location = task.location().len() as u16;
-                location_lines_vector.push(task.location().to_string());
-                Layout::default()
-                    .direction(layout::Direction::Horizontal)
+                let chunks = Layout::default()
+                    .direction(layout::Direction::Vertical)
                     .constraints(
                         [
-                            layout::Constraint::Min(area_needed_to_render_location + 15), //Note: 15 is the length of "| Location:     |"
-                            layout::Constraint::Min(32),
+                            // controls
+                            layout::Constraint::Length(controls.height()),
+                            // warnings (add 2 for top and bottom borders)
+                            layout::Constraint::Length(warnings.len() as u16 + 2),
+                            // task stats
+                            layout::Constraint::Length(
+                                10 + no_of_lines_extra_required_to_accomadate_location as u16,
+                            ),
+                            // poll duration
+                            layout::Constraint::Length(9),
+                            // scheduled duration
+                            layout::Constraint::Length(9),
+                            // fields
+                            layout::Constraint::Percentage(60),
                         ]
                         .as_ref(),
                     )
-                    .split(stats_area)
+                    .split(area);
+
+                (
+                    chunks[0],
+                    chunks[2],
+                    chunks[3],
+                    chunks[4],
+                    chunks[5],
+                    Some(chunks[1]),
+                )
             }
         } else {
-            location_lines_vector.push(task.location().to_string());
-            stats_area_check
+            if warnings.is_empty() {
+                let chunks = Layout::default()
+                    .direction(layout::Direction::Vertical)
+                    .constraints(
+                        [
+                            // controls
+                            layout::Constraint::Length(controls.height()),
+                            // task stats
+                            layout::Constraint::Length(10),
+                            // poll duration
+                            layout::Constraint::Length(9),
+                            // scheduled duration
+                            layout::Constraint::Length(9),
+                            // fields
+                            layout::Constraint::Percentage(60),
+                        ]
+                        .as_ref(),
+                    )
+                    .split(area);
+                (chunks[0], chunks[1], chunks[2], chunks[3], chunks[4], None)
+            } else {
+                let chunks = Layout::default()
+                    .direction(layout::Direction::Vertical)
+                    .constraints(
+                        [
+                            // controls
+                            layout::Constraint::Length(controls.height()),
+                            // warnings (add 2 for top and bottom borders)
+                            layout::Constraint::Length(warnings.len() as u16 + 2),
+                            // task stats
+                            layout::Constraint::Length(10),
+                            // poll duration
+                            layout::Constraint::Length(9),
+                            // scheduled duration
+                            layout::Constraint::Length(9),
+                            // fields
+                            layout::Constraint::Percentage(60),
+                        ]
+                        .as_ref(),
+                    )
+                    .split(area);
+
+                (
+                    chunks[0],
+                    chunks[2],
+                    chunks[3],
+                    chunks[4],
+                    chunks[5],
+                    Some(chunks[1]),
+                )
+            }
+        };
+
+        let stats_area = if location_lines_vector.len() != 1 {
+            let area_needed_to_render_location = task.location().len() as u16;
+            Layout::default()
+                .direction(layout::Direction::Horizontal)
+                .constraints(
+                    [
+                        layout::Constraint::Min(area_needed_to_render_location + 15), //Note: 15 is the length of "| Location:     |"
+                        layout::Constraint::Min(32),
+                    ]
+                    .as_ref(),
+                )
+                .split(stats_area)
+        } else {
+            Layout::default()
+                .direction(layout::Direction::Horizontal)
+                .constraints(
+                    [
+                        layout::Constraint::Percentage(50),
+                        layout::Constraint::Percentage(50),
+                    ]
+                    .as_ref(),
+                )
+                .split(stats_area)
+            // stats_area_check
         };
 
         // Just preallocate capacity for ID, name, target, total, busy, and idle.
@@ -199,7 +249,7 @@ impl TaskView {
 
         let first_line = location_lines_vector[0].clone();
         location_lines_vector.remove(0);
-        let location_vector = vec![bold(title), Span::raw(first_line)];
+        let location_vector = vec![bold(location_heading), Span::raw(first_line)];
         overview.push(Line::from(location_vector));
         for line in location_lines_vector {
             overview.push(Line::from(Span::raw(format!("    {}", line))));

--- a/tokio-console/src/view/task.rs
+++ b/tokio-console/src/view/task.rs
@@ -140,10 +140,10 @@ impl TaskView {
         };
 
         let stats_constraints = if location_lines_vector.len() > 1 {
-            let area_needed_to_render_location = task.location().len() as u16;
+            let location_len = task.location().len() as u16;
             [
                 // 15 is the length of "| Location:     |"
-                layout::Constraint::Min(area_needed_to_render_location + 15),
+                layout::Constraint::Min(location_len + 15),
                 layout::Constraint::Min(32),
             ]
         } else {


### PR DESCRIPTION
Changes I've made is for accommodating loong location names; ive changed the .. to the long name; it widens the task rectangle if its longer than the default (50%) and goes to the next line if its longer than what we can accommodate in a single line. This fixes issue #523  have attached screenshots of the same in the PR, before and after changes

These screenshots are what was the UI before my changes.
<img width="1440" alt="Screenshot 2025-03-16 at 4 15 10 PM" src="https://github.com/user-attachments/assets/c600b155-7b77-450e-9695-f9db9be67e8d" />


and these are the screenshots after my changes.
<img width="1440" alt="Screenshot 2025-03-16 at 4 14 25 PM" src="https://github.com/user-attachments/assets/83d1c6c6-5b06-42b8-a109-6e26d380eea2" />
<img width="1440" alt="Screenshot 2025-03-16 at 4 14 19 PM" src="https://github.com/user-attachments/assets/39d13ac2-de81-468c-b87a-2c9e52913108" />
<img width="1440" alt="Screenshot 2025-03-16 at 4 14 15 PM" src="https://github.com/user-attachments/assets/2bf01897-2d6a-4150-a245-a45bb3849543" />



