### PR TITLE
chore: update tokio to 1.38.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,9 +1065,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libredox"
@@ -1875,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/console-subscriber/Cargo.toml
+++ b/console-subscriber/Cargo.toml
@@ -32,7 +32,7 @@ grpc-web = ["dep:tonic-web"]
 
 [dependencies]
 crossbeam-utils = "0.8.7"
-tokio = { version = "1.34", features = ["sync", "time", "macros", "tracing"] }
+tokio = { version = "1.38.2", features = ["sync", "time", "macros", "tracing"] }
 tokio-stream = { version = "0.1.16", features = ["net"] }
 thread_local = "1.1.4"
 console-api = { version = "0.8.0", path = "../console-api", features = ["transport"] }
@@ -57,7 +57,7 @@ crossbeam-channel = "0.5"
 tonic-web = { version = "0.12", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.34", features = ["full", "rt-multi-thread"] }
+tokio = { version = "1.38.2", features = ["full", "rt-multi-thread"] }
 tower = { version = "0.4.12", default-features = false, features = ["util"] }
 futures = "0.3"
 http = "1.1"

--- a/console-subscriber/README.md
+++ b/console-subscriber/README.md
@@ -62,7 +62,7 @@ runtime][Tokio] is considered *experimental*. In order to use
   ```toml
   [dependencies]
   # ...
-  tokio = { version = "1.15", features = ["full", "tracing"] }
+  tokio = { version = "1.38.2", features = ["full", "tracing"] }
   ```
 
 * The `tokio_unstable` cfg flag, which enables experimental APIs in Tokio, must
@@ -130,7 +130,7 @@ Other instrumentation is added in later Tokio releases:
 
 * [Tokio v1.21.0] or later is required to use newest `task::Builder::spawn*` APIs.
 
-* [Tokio v1.41.0] (as yet unreleased) or later is required for task future sizes and the related
+* [Tokio v1.41.0] or later is required for task future sizes and the related
   tokio-console lints `auto-boxed-future` and `large-future`.
 
 [Tokio v1.0.0]: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.0.0

--- a/tokio-console/Cargo.toml
+++ b/tokio-console/Cargo.toml
@@ -36,7 +36,7 @@ eula = false
 console-api = { version = "0.8.1", path = "../console-api", features = ["transport"] }
 clap = { version = "~4.5.4", features = ["wrap_help", "cargo", "derive", "env"] }
 clap_complete = "~4.5.2"
-tokio = { version = "1.34", features = ["full", "rt-multi-thread"] }
+tokio = { version = "1.38.2", features = ["full", "rt-multi-thread"] }
 tonic = { version = "0.13.0", features = ["transport"] }
 futures = "0.3"
 ratatui = { version = "0.26.2", default-features = false, features = ["crossterm"] }


### PR DESCRIPTION
There was a soundness defect in Tokio's broadcast channel. This change
updates to the oldest version of Tokio with the soundness defect fixed
(1.38.2 - 1.38 is the current oldest LTS version). This is preferable to
updating to the latest version of Tokio, as that would force users of
`console-subscriber` to use that version or later too.

Tokio 1.38.2: https://github.com/tokio-rs/tokio/releases/tag/tokio-1.38.2