### PR TITLE
Resolve clippy lints

### DIFF
--- a/console-subscriber/tests/support/subscriber.rs
+++ b/console-subscriber/tests/support/subscriber.rs
@@ -305,6 +305,7 @@ async fn record_actual_tasks(
 /// expected task is validated against the actual task.
 ///
 /// Any validation errors result in failure. If no matches
+#[allow(clippy::result_large_err)]
 fn validate_expected_tasks(
     expected_tasks: Vec<ExpectedTask>,
     actual_tasks: Vec<ActualTask>,

--- a/tokio-console/src/state/async_ops.rs
+++ b/tokio-console/src/state/async_ops.rs
@@ -25,9 +25,10 @@ pub(crate) struct AsyncOpsState {
     dropped_events: u64,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 #[repr(usize)]
 pub(crate) enum SortBy {
+    #[default]
     Aid = 0,
     Task = 1,
     Source = 2,
@@ -63,12 +64,6 @@ struct AsyncOpStats {
     task_id: Option<Id<Task>>,
     task_id_str: InternedStr,
     formatted_attributes: Vec<Vec<Span<'static>>>,
-}
-
-impl Default for SortBy {
-    fn default() -> Self {
-        Self::Aid
-    }
 }
 
 impl SortBy {

--- a/tokio-console/src/state/mod.rs
+++ b/tokio-console/src/state/mod.rs
@@ -71,18 +71,13 @@ pub(crate) enum FieldValue {
     Debug(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) enum Temporality {
     Unpausing,
+    #[default]
     Live,
     Pausing,
     Paused,
-}
-
-impl Default for Temporality {
-    fn default() -> Self {
-        Self::Live
-    }
 }
 
 impl From<proto::instrument::Temporality> for Temporality {

--- a/tokio-console/src/state/resources.rs
+++ b/tokio-console/src/state/resources.rs
@@ -26,9 +26,10 @@ pub(crate) enum TypeVisibility {
     Internal,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 #[repr(usize)]
 pub(crate) enum SortBy {
+    #[default]
     Id = 0,
     ParentId = 1,
     Kind = 2,
@@ -71,12 +72,6 @@ struct ResourceStats {
     dropped_at: Option<SystemTime>,
     total: Option<Duration>,
     formatted_attributes: Vec<Vec<Span<'static>>>,
-}
-
-impl Default for SortBy {
-    fn default() -> Self {
-        Self::Id
-    }
 }
 
 impl SortBy {

--- a/tokio-console/src/state/tasks.rs
+++ b/tokio-console/src/state/tasks.rs
@@ -36,13 +36,14 @@ pub(crate) struct Details {
     pub(crate) scheduled_times_histogram: Option<DurationHistogram>,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 #[repr(usize)]
 pub(crate) enum SortBy {
     Warns = 0,
     Tid = 1,
     State = 2,
     Name = 3,
+    #[default]
     Total = 4,
     Busy = 5,
     Scheduled = 6,
@@ -578,12 +579,6 @@ impl From<proto::tasks::Stats> for TaskStats {
             waker_drops: pb.waker_drops,
             self_wakes: pb.self_wakes,
         }
-    }
-}
-
-impl Default for SortBy {
-    fn default() -> Self {
-        Self::Total
     }
 }
 

--- a/tokio-console/src/view/styles.rs
+++ b/tokio-console/src/view/styles.rs
@@ -13,10 +13,11 @@ pub struct Styles {
     pub(crate) utf8: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Default, Deserialize, Serialize)]
 #[repr(u8)]
 pub enum Palette {
     #[serde(rename = "off")]
+    #[default]
     NoColors,
     /// Use ANSI 8 color palette only.
     #[serde(rename = "8")]
@@ -359,11 +360,5 @@ impl FromStr for Palette {
             s if s.eq_ignore_ascii_case("off") => Ok(Palette::NoColors),
             _ => Err("invalid color palette"),
         }
-    }
-}
-
-impl Default for Palette {
-    fn default() -> Self {
-        Self::NoColors
     }
 }


### PR DESCRIPTION
```console
warning: the `Err`-variant returned from this closure is very large
   --> console-subscriber/tests/support/subscriber.rs:314:14
    |
314 |         .map(|expected| validate_expected_task(expected, &actual_tasks))
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 160 bytes
    |
    = help: try reducing the size of `support::task::TaskValidationFailure`, for example by boxing large elements or replacing it with `Box<support::task::TaskValidationFailure>`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#result_large_err
    = note: `#[warn(clippy::result_large_err)]` on by default

warning: this `impl` can be derived
  --> tokio-console/src/state/async_ops.rs:68:1
   |
68 | / impl Default for SortBy {
69 | |     fn default() -> Self {
70 | |         Self::Aid
71 | |     }
72 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#derivable_impls
   = note: `#[warn(clippy::derivable_impls)]` on by default
help: replace the manual implementation with a derive attribute and mark the default variant
   |
30 + #[derive(Default)]
31 | pub(crate) enum SortBy {
32 ~     #[default]
33 ~     Aid = 0,
   |

warning: this `impl` can be derived
  --> tokio-console/src/state/resources.rs:76:1
   |
76 | / impl Default for SortBy {
77 | |     fn default() -> Self {
78 | |         Self::Id
79 | |     }
80 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#derivable_impls
help: replace the manual implementation with a derive attribute and mark the default variant
   |
31 + #[derive(Default)]
32 | pub(crate) enum SortBy {
33 ~     #[default]
34 ~     Id = 0,
   |

warning: this `impl` can be derived
   --> tokio-console/src/state/tasks.rs:584:1
    |
584 | / impl Default for SortBy {
585 | |     fn default() -> Self {
586 | |         Self::Total
587 | |     }
588 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#derivable_impls
help: replace the manual implementation with a derive attribute and mark the default variant
    |
 41 + #[derive(Default)]
 42 | pub(crate) enum SortBy {
 43 |     Warns = 0,
...
 46 |     Name = 3,
 47 ~     #[default]
 48 ~     Total = 4,
    |

warning: this `impl` can be derived
  --> tokio-console/src/state/mod.rs:82:1
   |
82 | / impl Default for Temporality {
83 | |     fn default() -> Self {
84 | |         Self::Live
85 | |     }
86 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#derivable_impls
help: replace the manual implementation with a derive attribute and mark the default variant
   |
75 + #[derive(Default)]
76 | pub(crate) enum Temporality {
77 |     Unpausing,
78 ~     #[default]
79 ~     Live,
   |

warning: this `impl` can be derived
   --> tokio-console/src/view/styles.rs:365:1
    |
365 | / impl Default for Palette {
366 | |     fn default() -> Self {
367 | |         Self::NoColors
368 | |     }
369 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#derivable_impls
help: replace the manual implementation with a derive attribute and mark the default variant
    |
 18 + #[derive(Default)]
 19 | pub enum Palette {
 20 |     #[serde(rename = "off")]
 21 ~     #[default]
 22 ~     NoColors,
    |
```