### PR TITLE
refactor: resolve clippy lints

### DIFF
--- a/console-subscriber/src/builder.rs
+++ b/console-subscriber/src/builder.rs
@@ -431,7 +431,7 @@ impl Builder {
                 Err(e) => {
                     eprintln!(
                         "failed to parse filter environment variable `{}={:?}`: {}",
-                        &self.filter_env_var, log_filter, e
+                        self.filter_env_var, log_filter, e
                     );
                     None
                 }

--- a/tokio-console/src/view/mini_histogram.rs
+++ b/tokio-console/src/view/mini_histogram.rs
@@ -136,8 +136,7 @@ impl<'a> MiniHistogram<'a> {
             .iter()
             .take(max_index)
             .map(|e| {
-                if max != 0 {
-                    let r = e * u64::from(area.height) * 8 / max;
+                if let Some(r) = (e * u64::from(area.height) * 8).checked_div(max) {
                     // This is the only difference in the bar rendering logic
                     // between MiniHistogram and Sparkline. At least render a
                     // ONE_EIGHT, if the value is greater than 0, even if it's


### PR DESCRIPTION
```console
warning: redundant reference in `eprintln!` argument
   --> console-subscriber/src/builder.rs:434:25
    |
434 |                         &self.filter_env_var, log_filter, e
    |                         ^^^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `self.filter_env_var`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
    = note: `#[warn(clippy::useless_borrows_in_formatting)]` on by default

warning: manual checked division
   --> tokio-console/src/view/mini_histogram.rs:139:20
    |
139 |                 if max != 0 {
    |                    ^^^^^^^^ check performed here
140 |                     let r = e * u64::from(area.height) * 8 / max;
    |                             ------------------------------------ division performed here
    |
    = help: consider using `checked_div`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#manual_checked_ops
    = note: `#[warn(clippy::manual_checked_ops)]` on by default
```